### PR TITLE
Use ordinal sgptDataTables instead of local gpDataTables

### DIFF
--- a/source/D2Common/src/D2Inventory.cpp
+++ b/source/D2Common/src/D2Inventory.cpp
@@ -3345,7 +3345,7 @@ BOOL __fastcall sub_6FD91E80(D2UnitStrc* pUnit, D2UnitStrc* pItem1, D2UnitStrc* 
 				if (pUnit->dwUnitType == UNIT_MONSTER)
 				{
 					nUnitId = pUnit->dwClassId;
-					if (nUnitId < 0 || nUnitId >= gpDataTables.nMonStatsTxtRecordCount)
+					if (nUnitId < 0 || nUnitId >= sgptDataTables->nMonStatsTxtRecordCount)
 					{
 						nUnitId = -1;
 					}

--- a/source/D2Common/src/D2Skills.cpp
+++ b/source/D2Common/src/D2Skills.cpp
@@ -259,7 +259,7 @@ int __stdcall SKILLS_GetSpecialParamValue(D2UnitStrc* pUnit, BYTE nParamId, int 
 					nMissileId = pSkillDescTxtRecord->wDescMissile[nParamId - 35];
 					if (DATATBLS_GetMissilesTxtRecord(nMissileId))
 					{
-						return gpDataTables.pMissilesTxt[nMissileId].wRange + nSkillLevel * gpDataTables.pMissilesTxt[nMissileId].wLevRange;
+						return sgptDataTables->pMissilesTxt[nMissileId].wRange + nSkillLevel * sgptDataTables->pMissilesTxt[nMissileId].wLevRange;
 					}
 				}
 			}
@@ -472,13 +472,13 @@ int __stdcall SKILLS_EvaluateSkillFormula(D2UnitStrc* pUnit, unsigned int nCalc,
 {
 	D2SkillCalcStrc pSkillCalc = {};
 
-	if (gpDataTables.pSkillsCode && nCalc < gpDataTables.nSkillsCodeSize)
+	if (sgptDataTables->pSkillsCode && nCalc < sgptDataTables->nSkillsCodeSize)
 	{
 		pSkillCalc.pUnit = pUnit;
 		pSkillCalc.nSkillId = nSkillId;
 		pSkillCalc.nSkillLevel = nSkillLevel;
 
-		return FOG_10253(&gpDataTables.pSkillsCode[nCalc], gpDataTables.nSkillsCodeSize - nCalc, sub_6FDAF6A0, off_6FDE5804, dword_6FDE583C, &pSkillCalc);
+		return FOG_10253(&sgptDataTables->pSkillsCode[nCalc], sgptDataTables->nSkillsCodeSize - nCalc, sub_6FDAF6A0, off_6FDE5804, dword_6FDE583C, &pSkillCalc);
 	}
 
 	return 0;
@@ -489,13 +489,13 @@ int __stdcall SKILLS_EvaluateSkillDescFormula(D2UnitStrc* pUnit, unsigned int nC
 {
 	D2SkillCalcStrc pSkillCalc = {};
 
-	if (gpDataTables.pSkillDescCode && nCalc < gpDataTables.nSkillDescCodeSize)
+	if (sgptDataTables->pSkillDescCode && nCalc < sgptDataTables->nSkillDescCodeSize)
 	{
 		pSkillCalc.pUnit = pUnit;
 		pSkillCalc.nSkillId = nSkillId;
 		pSkillCalc.nSkillLevel = nSkillLevel;
 
-		return FOG_10253(&gpDataTables.pSkillDescCode[nCalc], gpDataTables.nSkillDescCodeSize - nCalc, sub_6FDAF6A0, off_6FDE5804, dword_6FDE583C, &pSkillCalc);
+		return FOG_10253(&sgptDataTables->pSkillDescCode[nCalc], sgptDataTables->nSkillDescCodeSize - nCalc, sub_6FDAF6A0, off_6FDE5804, dword_6FDE583C, &pSkillCalc);
 	}
 
 	return 0;
@@ -517,7 +517,7 @@ void __stdcall SKILLS_RefreshSkill(D2UnitStrc* pUnit, int nSkillId)
 		if (pSkillsTxtRecord)
 		{
 			nPassiveState = pSkillsTxtRecord->nPassiveState;
-			if (nPassiveState > 0 && nPassiveState < gpDataTables.nStatesTxtRecordCount)
+			if (nPassiveState > 0 && nPassiveState < sgptDataTables->nStatesTxtRecordCount)
 			{
 				pSkill = SKILLS_GetHighestLevelSkillFromSkillId(pUnit, nSkillId);
 				if (!pSkill || pSkillsTxtRecord->nAuraState > 0 && STATES_CheckState(pUnit, pSkillsTxtRecord->nAuraState))
@@ -558,7 +558,7 @@ void __stdcall SKILLS_RefreshSkill(D2UnitStrc* pUnit, int nSkillId)
 					{
 						for (int i = 0; i < ARRAY_SIZE(pSkillsTxtRecord->nPassiveStat); ++i)
 						{
-							if (pSkillsTxtRecord->nPassiveStat[i] < 0 || pSkillsTxtRecord->nPassiveStat[i] >= gpDataTables.nItemStatCostTxtRecordCount)
+							if (pSkillsTxtRecord->nPassiveStat[i] < 0 || pSkillsTxtRecord->nPassiveStat[i] >= sgptDataTables->nItemStatCostTxtRecordCount)
 							{
 								break;
 							}
@@ -600,9 +600,9 @@ void __stdcall SKILLS_RefreshPassiveSkills(D2UnitStrc* pUnit)
 	int nSkillId = 0;
 	short nPassiveState = 0;
 
-	for (int i = 0; i < gpDataTables.nPassiveSkills; ++i)
+	for (int i = 0; i < sgptDataTables->nPassiveSkills; ++i)
 	{
-		nSkillId = gpDataTables.pPassiveSkills[i];
+		nSkillId = sgptDataTables->pPassiveSkills[i];
 
 		pSkillsTxtRecord = DATATBLS_GetSkillsTxtRecord(nSkillId);
 		if (pSkillsTxtRecord)
@@ -690,12 +690,12 @@ void __stdcall SKILLS_InitSkillList(D2UnitStrc* pUnit)
 	if (!SKILLS_GetSkill(pUnit, 0, -1))
 	{
 		nClass = pUnit->dwClassId;
-		if (nClass < 0 || nClass >= gpDataTables.nCharStatsTxtRecordCount)
+		if (nClass < 0 || nClass >= sgptDataTables->nCharStatsTxtRecordCount)
 		{
 			return;
 		}
 
-		pCharStatsTxtRecord = &gpDataTables.pCharStatsTxt[nClass];
+		pCharStatsTxtRecord = &sgptDataTables->pCharStatsTxt[nClass];
 		if (!pCharStatsTxtRecord)
 		{
 			return;
@@ -1948,7 +1948,7 @@ int __fastcall SKILLS_GetBonusSkillLevel(D2UnitStrc* pUnit, D2SkillStrc* pSkill)
 		{
 			nSkillLevel += STATLIST_GetUnitStat(pUnit, STAT_ITEM_ADDCLASSSKILLS, pUnit->dwClassId);
 
-			pSkillsTxtRecord = &gpDataTables.pSkillsTxt[pSkill->pSkillsTxt->nSkillId];
+			pSkillsTxtRecord = &sgptDataTables->pSkillsTxt[pSkill->pSkillsTxt->nSkillId];
 			if (pSkillsTxtRecord)
 			{
 				pSkillDescTxtRecord = DATATBLS_GetSkillDescTxtRecord(pSkillsTxtRecord->wSkillDesc);
@@ -2892,17 +2892,17 @@ void __stdcall D2COMMON_11013_ConvertMode(D2UnitStrc* pUnit, int* pType, int* pC
 	int nState = 0;
 	int nMode = 0;
 
-	if (!pUnit || !(pUnit->dwFlagEx & UNITFLAGEX_ISSHAPESHIFTED) || gpDataTables.nTransformStates <= 0)
+	if (!pUnit || !(pUnit->dwFlagEx & UNITFLAGEX_ISSHAPESHIFTED) || sgptDataTables->nTransformStates <= 0)
 	{
 		return;
 	}
 
 	while (1)
 	{
-		nState = gpDataTables.pTransformStates[nCounter];
-		if (STATES_CheckState(pUnit, nState) && nState >= 0 && nState < gpDataTables.nStatesTxtRecordCount)
+		nState = sgptDataTables->pTransformStates[nCounter];
+		if (STATES_CheckState(pUnit, nState) && nState >= 0 && nState < sgptDataTables->nStatesTxtRecordCount)
 		{
-			pStatesTxtRecord = &gpDataTables.pStatesTxt[nState];
+			pStatesTxtRecord = &sgptDataTables->pStatesTxt[nState];
 			if (pStatesTxtRecord)
 			{
 				if (pStatesTxtRecord->nGfxType == 1)
@@ -2932,7 +2932,7 @@ void __stdcall D2COMMON_11013_ConvertMode(D2UnitStrc* pUnit, int* pType, int* pC
 		}
 
 		++nCounter;
-		if (nCounter >= gpDataTables.nTransformStates)
+		if (nCounter >= sgptDataTables->nTransformStates)
 		{
 			return;
 		}
@@ -3056,7 +3056,7 @@ BOOL __stdcall D2COMMON_11017_CheckUnitIfConsumeable(D2UnitStrc* pUnit, int a2)
 		pMonStats2TxtRecord = UNITS_GetMonStats2TxtRecordFromMonsterId(pUnit->dwClassId);
 		if (pMonStats2TxtRecord && pMonStats2TxtRecord->dwFlags & gdwBitMasks[MONSTATS2FLAGINDEX_CORPSESEL])
 		{
-			return gpDataTables.pMonStatsTxt[pUnit->dwClassId].nVelocity != 0;
+			return sgptDataTables->pMonStatsTxt[pUnit->dwClassId].nVelocity != 0;
 		}
 	}
 
@@ -3527,18 +3527,18 @@ BOOL __stdcall SKILLS_RemoveTransformStatesFromShapeshiftedUnit(D2UnitStrc* pUni
 
 	if (STATES_IsUnitShapeShifted(pUnit))
 	{
-		for (int i = 0; i < gpDataTables.nTransformStates; ++i)
+		for (int i = 0; i < sgptDataTables->nTransformStates; ++i)
 		{
-			if (STATES_CheckState(pUnit, gpDataTables.pTransformStates[i]))
+			if (STATES_CheckState(pUnit, sgptDataTables->pTransformStates[i]))
 			{
-				pStatList = STATLIST_GetStatListFromUnitAndState(pUnit, gpDataTables.pTransformStates[i]);
+				pStatList = STATLIST_GetStatListFromUnitAndState(pUnit, sgptDataTables->pTransformStates[i]);
 				if (pStatList)
 				{
 					D2Common_10474(pUnit, (D2StatListExStrc*)pStatList);
 					STATLIST_FreeStatList(pStatList);
 				}
 
-				STATES_ToggleState(pUnit, gpDataTables.pTransformStates[i], FALSE);
+				STATES_ToggleState(pUnit, sgptDataTables->pTransformStates[i], FALSE);
 			}
 		}
 
@@ -3551,9 +3551,9 @@ BOOL __stdcall SKILLS_RemoveTransformStatesFromShapeshiftedUnit(D2UnitStrc* pUni
 //D2Common.0x6FDB4100 (#11041)
 int __stdcall SKILLS_GetClassSkillId(int nClassId, int nPosition)
 {
-	if (nClassId >= 0 && nClassId < 7 && nPosition >= 0 && nPosition < gpDataTables.nClassSkillCount[nClassId])
+	if (nClassId >= 0 && nClassId < 7 && nPosition >= 0 && nPosition < sgptDataTables->nClassSkillCount[nClassId])
 	{
-		return gpDataTables.nClassSkillList[nPosition + nClassId * gpDataTables.nHighestClassSkillCount];
+		return sgptDataTables->nClassSkillList[nPosition + nClassId * sgptDataTables->nHighestClassSkillCount];
 	}
 
 	return -1;
@@ -3564,7 +3564,7 @@ int __stdcall SKILLS_GetPlayerSkillCount(int nClassId)
 {
 	if (nClassId >= 0 && nClassId < 7)
 	{
-		return gpDataTables.nClassSkillCount[nClassId];
+		return sgptDataTables->nClassSkillCount[nClassId];
 	}
 
 	return 0;

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -668,9 +668,9 @@ int __fastcall sub_6FDB64A0(D2StatListExStrc* pStatListEx, int nLayer_StatId, D2
 						nOpBase = pItemStatCostTxtRecord->pOpStatData[nCounter].nOpBase;
 						if (nOpBase != -1)
 						{
-							if (pStatListEx->pUnit->pStatListEx && nOpBase < gpDataTables.nItemStatCostTxtRecordCount)
+							if (pStatListEx->pUnit->pStatListEx && nOpBase < sgptDataTables->nItemStatCostTxtRecordCount)
 							{
-								if (&gpDataTables.pItemStatCostTxt[nOpBase] && sub_6FDB63E0(pStatListEx->pUnit->pStatListEx, nOpBase << 16, &gpDataTables.pItemStatCostTxt[nOpBase]) > 0)
+								if (&sgptDataTables->pItemStatCostTxt[nOpBase] && sub_6FDB63E0(pStatListEx->pUnit->pStatListEx, nOpBase << 16, &sgptDataTables->pItemStatCostTxt[nOpBase]) > 0)
 								{
 									bUpdate = FALSE;
 								}
@@ -1303,8 +1303,8 @@ void __stdcall STATLIST_AllocStatListEx(D2UnitStrc* pUnit, char nFlags, void* pC
 	pStatListEx->pGame = pGame;
 	pStatListEx->dwFlags = nFlags & 1 | 0x80000000;
 
-	pStatListEx->StatFlags = (DWORD*)FOG_AllocServerMemory(pUnit->pMemoryPool, 2 * sizeof(DWORD) * (gpDataTables.nStatesTxtRecordCount + 31) / 32, __FILE__, __LINE__, 0);
-	memset(pStatListEx->StatFlags, 0x00, 2 * sizeof(DWORD) * (gpDataTables.nStatesTxtRecordCount + 31) / 32);
+	pStatListEx->StatFlags = (DWORD*)FOG_AllocServerMemory(pUnit->pMemoryPool, 2 * sizeof(DWORD) * (sgptDataTables->nStatesTxtRecordCount + 31) / 32, __FILE__, __LINE__, 0);
+	memset(pStatListEx->StatFlags, 0x00, 2 * sizeof(DWORD) * (sgptDataTables->nStatesTxtRecordCount + 31) / 32);
 
 	pUnit->pStatListEx = pStatListEx;
 }
@@ -2733,11 +2733,11 @@ void __stdcall D2Common_STATES_ToggleState_6FDB8900(D2UnitStrc* pUnit, int nStat
 			}
 		}
 
-		pUnit->pStatListEx->StatFlags[(nState >> 5) + (gpDataTables.nStatesTxtRecordCount + 31) / 32] |= gdwBitMasks[nState & 31];
+		pUnit->pStatListEx->StatFlags[(nState >> 5) + (sgptDataTables->nStatesTxtRecordCount + 31) / 32] |= gdwBitMasks[nState & 31];
 
-		if (nState >= 0 && nState < gpDataTables.nStatesTxtRecordCount)
+		if (nState >= 0 && nState < sgptDataTables->nStatesTxtRecordCount)
 		{
-			pStatesTxtRecord = &gpDataTables.pStatesTxt[nState];
+			pStatesTxtRecord = &sgptDataTables->pStatesTxt[nState];
 			if (pStatesTxtRecord)
 			{
 				if (bSet)
@@ -2775,7 +2775,7 @@ DWORD* __stdcall D2COMMON_STATES_GetListGfxFlags_6FDB8AC0(D2UnitStrc* pUnit)
 {
 	if (pUnit && pUnit->pStatListEx && (pUnit->pStatListEx->dwFlags & 0x80000000) != 0)
 	{
-		return &pUnit->pStatListEx->StatFlags[(gpDataTables.nStatesTxtRecordCount + 31) / 32];
+		return &pUnit->pStatListEx->StatFlags[(sgptDataTables->nStatesTxtRecordCount + 31) / 32];
 	}
 
 	return NULL;

--- a/source/D2Common/src/D2States.cpp
+++ b/source/D2Common/src/D2States.cpp
@@ -8,9 +8,9 @@
 //Used in some of the following functions
 __forceinline BOOL __fastcall STATES_CheckStateMaskByStateId(int nState, int nStateMask)
 {
-	if (nState >= 0 && nState < gpDataTables.nStatesTxtRecordCount)
+	if (nState >= 0 && nState < sgptDataTables->nStatesTxtRecordCount)
 	{
-		return gpDataTables.fStateMasks[nStateMask][nState >> 5] & gdwBitMasks[nState & 31];
+		return sgptDataTables->fStateMasks[nStateMask][nState >> 5] & gdwBitMasks[nState & 31];
 	}
 
 	return FALSE;
@@ -20,7 +20,7 @@ __forceinline BOOL __fastcall STATES_CheckStateMaskByStateId(int nState, int nSt
 //D2Common.0x6FDB4560 (#10486)
 void __stdcall STATES_ToggleState(D2UnitStrc* pUnit, int nState, BOOL bSet)
 {
-	if (nState >= 0 && nState < gpDataTables.nStatesTxtRecordCount)
+	if (nState >= 0 && nState < sgptDataTables->nStatesTxtRecordCount)
 	{
 		D2Common_STATES_ToggleState_6FDB8900(pUnit, nState, bSet);
 		UNITROOM_RefreshUnit(pUnit);
@@ -30,7 +30,7 @@ void __stdcall STATES_ToggleState(D2UnitStrc* pUnit, int nState, BOOL bSet)
 //D2Common.0x6FDB45A0 (#10487)
 BOOL __stdcall STATES_CheckState(D2UnitStrc* pUnit, int nState)
 {
-	if (pUnit && (pUnit->dwUnitType == UNIT_PLAYER || pUnit->dwUnitType == UNIT_MONSTER || pUnit->dwUnitType == UNIT_MISSILE) && nState >= 0 && nState < gpDataTables.nStatesTxtRecordCount)
+	if (pUnit && (pUnit->dwUnitType == UNIT_PLAYER || pUnit->dwUnitType == UNIT_MONSTER || pUnit->dwUnitType == UNIT_MISSILE) && nState >= 0 && nState < sgptDataTables->nStatesTxtRecordCount)
 	{
 		if (pUnit->pStatListEx && (pUnit->pStatListEx->dwFlags & 0x80000000) != 0)
 		{
@@ -46,7 +46,7 @@ void __stdcall STATES_ToggleGfxStateFlag(D2UnitStrc* pUnit, int nState, BOOL bSe
 {
 	DWORD* pGfxFlags = D2COMMON_STATES_GetListGfxFlags_6FDB8AC0(pUnit);
 
-	if (pGfxFlags && nState >= 0 && nState < gpDataTables.nStatesTxtRecordCount)
+	if (pGfxFlags && nState >= 0 && nState < sgptDataTables->nStatesTxtRecordCount)
 	{
 		if (bSet)
 		{
@@ -66,7 +66,7 @@ BOOL __stdcall STATES_CheckGfxStateFlag(D2UnitStrc* pUnit, int nState)
 {
 	DWORD* pGfxFlags = NULL;
 
-	if (nState >= 0 && nState < gpDataTables.nStatesTxtRecordCount)
+	if (nState >= 0 && nState < sgptDataTables->nStatesTxtRecordCount)
 	{
 		pGfxFlags = D2COMMON_STATES_GetListGfxFlags_6FDB8AC0(pUnit);
 		if (pGfxFlags)
@@ -85,7 +85,7 @@ void __stdcall STATES_ClearGfxStateFlags(D2UnitStrc* pUnit)
 
 	if (pGfxFlags)
 	{
-		memset(pGfxFlags, 0x00, sizeof(DWORD) * (gpDataTables.nStatesTxtRecordCount + 31) / 32);
+		memset(pGfxFlags, 0x00, sizeof(DWORD) * (sgptDataTables->nStatesTxtRecordCount + 31) / 32);
 	}
 }
 
@@ -96,12 +96,12 @@ BOOL __stdcall STATES_IsAnyGfxStateFlagSet(D2UnitStrc* pUnit)
 	int nCounter = 0;
 
 	pGfxFlags = D2COMMON_STATES_GetListGfxFlags_6FDB8AC0(pUnit);
-	if (pGfxFlags && (gpDataTables.nStatesTxtRecordCount + 31) / 32 > 0)
+	if (pGfxFlags && (sgptDataTables->nStatesTxtRecordCount + 31) / 32 > 0)
 	{
 		while (!pGfxFlags[nCounter])
 		{
 			++nCounter;
-			if (nCounter >= (gpDataTables.nStatesTxtRecordCount + 31) / 32)
+			if (nCounter >= (sgptDataTables->nStatesTxtRecordCount + 31) / 32)
 			{
 				return FALSE;
 			}
@@ -134,26 +134,26 @@ void __stdcall STATES_UpdateStayDeathFlags(D2UnitStrc* pUnit, BOOL bIsBoss)
 	{
 		if (bIsBoss)
 		{
-			for (int i = 0; i < (gpDataTables.nStatesTxtRecordCount + 31) / 32; ++i)
+			for (int i = 0; i < (sgptDataTables->nStatesTxtRecordCount + 31) / 32; ++i)
 			{
-				pGfxFlags[i] |= pStatFlags[i] & ~gpDataTables.fStateMasks[STATEMASK_BOSSSTAYDEATH][i];
-				pStatFlags[i] &= gpDataTables.fStateMasks[STATEMASK_BOSSSTAYDEATH][i];
+				pGfxFlags[i] |= pStatFlags[i] & ~sgptDataTables->fStateMasks[STATEMASK_BOSSSTAYDEATH][i];
+				pStatFlags[i] &= sgptDataTables->fStateMasks[STATEMASK_BOSSSTAYDEATH][i];
 			}
 		}
 		else if (!pUnit || pUnit->dwUnitType != UNIT_PLAYER)
 		{
-			for (int i = 0; i < (gpDataTables.nStatesTxtRecordCount + 31) / 32; ++i)
+			for (int i = 0; i < (sgptDataTables->nStatesTxtRecordCount + 31) / 32; ++i)
 			{
-				pGfxFlags[i] |= pStatFlags[i] & ~gpDataTables.fStateMasks[STATEMASK_MONSTAYDEATH][i];
-				pStatFlags[i] &= gpDataTables.fStateMasks[STATEMASK_MONSTAYDEATH][i];
+				pGfxFlags[i] |= pStatFlags[i] & ~sgptDataTables->fStateMasks[STATEMASK_MONSTAYDEATH][i];
+				pStatFlags[i] &= sgptDataTables->fStateMasks[STATEMASK_MONSTAYDEATH][i];
 			}
 		}
 		else
 		{
-			for (int i = 0; i < (gpDataTables.nStatesTxtRecordCount + 31) / 32; ++i)
+			for (int i = 0; i < (sgptDataTables->nStatesTxtRecordCount + 31) / 32; ++i)
 			{
-				pGfxFlags[i] |= pStatFlags[i] & ~gpDataTables.fStateMasks[STATEMASK_PLRSTAYDEATH][i];
-				pStatFlags[i] &= gpDataTables.fStateMasks[STATEMASK_PLRSTAYDEATH][i];
+				pGfxFlags[i] |= pStatFlags[i] & ~sgptDataTables->fStateMasks[STATEMASK_PLRSTAYDEATH][i];
+				pStatFlags[i] &= sgptDataTables->fStateMasks[STATEMASK_PLRSTAYDEATH][i];
 			}
 		}
 
@@ -170,7 +170,7 @@ DWORD* __stdcall D2COMMON_10494_STATES_GetStatFlags(D2UnitStrc* pUnit)
 //D2Common.0x6FDB4900 (#10495)
 int __fastcall STATES_GetNumberOfStateFlags()
 {
-	return (gpDataTables.nStatesTxtRecordCount + 31) / 32;
+	return (sgptDataTables->nStatesTxtRecordCount + 31) / 32;
 }
 
 //D2Common.0x6FDB4920 (#10496)
@@ -208,10 +208,10 @@ void __stdcall STATES_UpdatePgsvFlags(D2UnitStrc* pUnit)
 
 	if (pGfxFlags && pStatFlags)
 	{
-		for (int i = 0; i < (gpDataTables.nStatesTxtRecordCount + 31) / 32; ++i)
+		for (int i = 0; i < (sgptDataTables->nStatesTxtRecordCount + 31) / 32; ++i)
 		{
-			pGfxFlags[i] |= pStatFlags[i] & gpDataTables.fStateMasks[STATEMASK_PGSV][i];
-			pStatFlags[i] &= ~gpDataTables.fStateMasks[STATEMASK_PGSV][i];
+			pGfxFlags[i] |= pStatFlags[i] & sgptDataTables->fStateMasks[STATEMASK_PGSV][i];
+			pStatFlags[i] &= ~sgptDataTables->fStateMasks[STATEMASK_PGSV][i];
 		}
 
 		UNITROOM_RefreshUnit(pUnit);
@@ -280,9 +280,9 @@ BOOL __stdcall STATES_IsUnitShapeShifted(D2UnitStrc* pUnit)
 //D2Common.0x6FDB4E80 (#10497)
 BOOL __stdcall STATES_CheckStateMaskCurseByStateId(int nState)
 {
-	if (nState >= 0 && nState < gpDataTables.nStatesTxtRecordCount)
+	if (nState >= 0 && nState < sgptDataTables->nStatesTxtRecordCount)
 	{
-		return gpDataTables.fStateMasks[11][nState >> 5] & gdwBitMasks[nState & 31];
+		return sgptDataTables->fStateMasks[11][nState >> 5] & gdwBitMasks[nState & 31];
 	}
 
 	return STATES_CheckStateMaskByStateId(nState, STATEMASK_CURSE);
@@ -297,15 +297,15 @@ BOOL __stdcall STATES_CheckStateMaskCurableByStateId(int nState)
 //D2Common.0x6FDB4F00 (#10554)
 BOOL __stdcall STATES_CheckStateMaskStayDeathOnUnitByStateId(D2UnitStrc* pUnit, int nState)
 {
-	if (nState >= 0 && nState < gpDataTables.nStatesTxtRecordCount)
+	if (nState >= 0 && nState < sgptDataTables->nStatesTxtRecordCount)
 	{
 		if (pUnit && pUnit->dwUnitType == UNIT_MONSTER)
 		{
-			return gpDataTables.fStateMasks[STATEMASK_MONSTAYDEATH][nState >> 5] & gdwBitMasks[nState & 31];
+			return sgptDataTables->fStateMasks[STATEMASK_MONSTAYDEATH][nState >> 5] & gdwBitMasks[nState & 31];
 		}
 		else
 		{
-			return gpDataTables.fStateMasks[STATEMASK_PLRSTAYDEATH][nState >> 5] & gdwBitMasks[nState & 31];
+			return sgptDataTables->fStateMasks[STATEMASK_PLRSTAYDEATH][nState >> 5] & gdwBitMasks[nState & 31];
 		}
 	}
 
@@ -438,9 +438,9 @@ BOOL __stdcall STATES_CheckStateMaskOnUnit(D2UnitStrc* pUnit, int nStateMask)
 
 		if (pStatFlags)
 		{
-			for (int i = 0; i < (gpDataTables.nStatesTxtRecordCount + 31) / 32; ++i)
+			for (int i = 0; i < (sgptDataTables->nStatesTxtRecordCount + 31) / 32; ++i)
 			{
-				if (pStatFlags[i] & gpDataTables.fStateMasks[nStateMask][i])
+				if (pStatFlags[i] & sgptDataTables->fStateMasks[nStateMask][i])
 				{
 					return TRUE;
 				}

--- a/source/D2Common/src/D2Waypoints.cpp
+++ b/source/D2Common/src/D2Waypoints.cpp
@@ -11,7 +11,7 @@ BOOL __stdcall WAYPOINTS_GetLevelIdFromWaypointNo(short nWaypointNo, int* pLevel
 
 	if (nWaypointNo < 255)
 	{
-		for (int i = 1; i < gpDataTables.nLevelsTxtRecordCount; ++i)
+		for (int i = 1; i < sgptDataTables->nLevelsTxtRecordCount; ++i)
 		{
 			if (DATATBLS_GetLevelsTxtRecord(i)->nWaypoint == nWaypointNo)
 			{

--- a/source/D2Common/src/DataTbls/ArenaTbls.cpp
+++ b/source/D2Common/src/DataTbls/ArenaTbls.cpp
@@ -44,7 +44,7 @@ void __fastcall DATATBLS_LoadCharTemplateTxt(void* pMemPool)
 	D2BinFieldStrc pTbl[] =
 	{
 		{ "Name", TXTFIELD_ASCII, 29, 0, NULL },
-		{ "class", TXTFIELD_CODETOBYTE, 0, 30, &gpDataTables.pPlayerClassLinker },
+		{ "class", TXTFIELD_CODETOBYTE, 0, 30, &sgptDataTables->pPlayerClassLinker },
 		{ "act", TXTFIELD_BYTE, 0, 32, NULL },
 		{ "level", TXTFIELD_BYTE, 0, 31, NULL },
 		{ "str", TXTFIELD_BYTE, 0, 33, NULL },

--- a/source/D2Common/src/DataTbls/DataTbls.cpp
+++ b/source/D2Common/src/DataTbls/DataTbls.cpp
@@ -161,25 +161,25 @@ void __fastcall DATATBLS_InitUnicodeClassNamesInCharStatsTxt()
 	wchar_t wszName[512] = {};
 	size_t nConvertedChars = 0;
 
-	for (int i = 0; i < gpDataTables.nCharStatsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nCharStatsTxtRecordCount; ++i)
 	{
-		memset(gpDataTables.pCharStatsTxt[i].wszClassName, 0x00, ARRAY_SIZE(gpDataTables.pCharStatsTxt[i].wszClassName));
+		memset(sgptDataTables->pCharStatsTxt[i].wszClassName, 0x00, ARRAY_SIZE(sgptDataTables->pCharStatsTxt[i].wszClassName));
 
-		wszClassName = D2LANG_GetStringByReferenceString(gpDataTables.pCharStatsTxt[i].szClassName);
+		wszClassName = D2LANG_GetStringByReferenceString(sgptDataTables->pCharStatsTxt[i].szClassName);
 
 		if (wszClassName)
 		{
-			wcsncpy_s(gpDataTables.pCharStatsTxt[i].wszClassName, wszClassName, ARRAY_SIZE(gpDataTables.pCharStatsTxt[i].wszClassName));
+			wcsncpy_s(sgptDataTables->pCharStatsTxt[i].wszClassName, wszClassName, ARRAY_SIZE(sgptDataTables->pCharStatsTxt[i].wszClassName));
 		}
 		else
 		{
-			mbstowcs_s(&nConvertedChars, wszName, gpDataTables.pCharStatsTxt[i].szClassName, ARRAY_SIZE(gpDataTables.pCharStatsTxt[i].szClassName) - 1);
+			mbstowcs_s(&nConvertedChars, wszName, sgptDataTables->pCharStatsTxt[i].szClassName, ARRAY_SIZE(sgptDataTables->pCharStatsTxt[i].szClassName) - 1);
 
 			wcscpy_s(wszClass, L"<");
 			wcscat_s(wszClass, wszName);
 			wcscat_s(wszClass, L">");
 
-			wcsncpy_s(gpDataTables.pCharStatsTxt[i].wszClassName, wszClass, ARRAY_SIZE(gpDataTables.pCharStatsTxt[i].wszClassName));
+			wcsncpy_s(sgptDataTables->pCharStatsTxt[i].wszClassName, wszClass, ARRAY_SIZE(sgptDataTables->pCharStatsTxt[i].wszClassName));
 		}
 	}
 }
@@ -187,9 +187,9 @@ void __fastcall DATATBLS_InitUnicodeClassNamesInCharStatsTxt()
 //D2Common.0x6FD49660 (#11255)
 DWORD __stdcall DATATBLS_GetCodeFromCompCodeTxt(int nCompCode)
 {
-	if (nCompCode < gpDataTables.nCompCodeTxtRecordCount)
+	if (nCompCode < sgptDataTables->nCompCodeTxtRecordCount)
 	{
-		return gpDataTables.pCompCodeTxt[nCompCode].dwCode;
+		return sgptDataTables->pCompCodeTxt[nCompCode].dwCode;
 	}
 
 	return 0;
@@ -198,18 +198,18 @@ DWORD __stdcall DATATBLS_GetCodeFromCompCodeTxt(int nCompCode)
 //D2Common.0x6FD49680 (#11249)
 DWORD __stdcall DATATBLS_GetExpRatio(int nLevel)
 {
-	if (gpDataTables.pExperienceTxt)
+	if (sgptDataTables->pExperienceTxt)
 	{
 		if (nLevel > 0)
 		{
-			if (nLevel <= (int)gpDataTables.pExperienceTxt->dwClass[0])
+			if (nLevel <= (int)sgptDataTables->pExperienceTxt->dwClass[0])
 			{
-				return gpDataTables.pExperienceTxt[nLevel + 1].dwExpRatio;
+				return sgptDataTables->pExperienceTxt[nLevel + 1].dwExpRatio;
 			}
 		}
 		else
 		{
-			return gpDataTables.pExperienceTxt->dwExpRatio;
+			return sgptDataTables->pExperienceTxt->dwExpRatio;
 		}
 	}
 
@@ -224,7 +224,7 @@ DWORD __stdcall DATATBLS_GetLevelThreshold(int nClass, DWORD dwLevel)
 		nClass = 0;
 	}
 
-	return gpDataTables.pExperienceTxt[dwLevel + 1].dwClass[nClass];
+	return sgptDataTables->pExperienceTxt[dwLevel + 1].dwClass[nClass];
 }
 
 //D2Common.0x6FD496E0 (#10629)
@@ -232,10 +232,10 @@ int __stdcall DATATBLS_GetMaxLevel(int nClass)
 {
 	if (nClass >= 0 && nClass < 7)
 	{
-		return gpDataTables.pExperienceTxt->dwClass[nClass];
+		return sgptDataTables->pExperienceTxt->dwClass[nClass];
 	}
 
-	return gpDataTables.pExperienceTxt->dwClass[0];
+	return sgptDataTables->pExperienceTxt->dwClass[0];
 }
 
 //D2Common.0x6FD49710 (#10630)
@@ -248,7 +248,7 @@ DWORD __stdcall DATATBLS_GetCurrentLevelFromExp(int nClass, DWORD dwExperience)
 		nClass = 0;
 	}
 
-	while (dwExperience >= gpDataTables.pExperienceTxt[nLevel].dwClass[nClass])
+	while (dwExperience >= sgptDataTables->pExperienceTxt[nLevel].dwClass[nClass])
 	{
 		++nLevel;
 	}
@@ -265,7 +265,7 @@ void __fastcall DATATBLS_GetBinFileHandle(void* pMemPool, char* szFile, void** p
 
 	wsprintfA(szFilePath, "%s\\%s.bin", "DATA\\GLOBAL\\EXCEL", szFile);
 
-	if (gpDataTables.bCompileTxt && *ppFileHandle)
+	if (sgptDataTables->bCompileTxt && *ppFileHandle)
 	{
 		fopen_s(&pFile, szFilePath, "wb");
 		if (pFile)
@@ -327,13 +327,13 @@ int __fastcall DATATBLS_AppendMemoryBuffer(char** ppCodes, int* pSize, int* pSiz
 //D2Common.0x6FD4E4B0 (#10593)
 D2CharStatsTxt* __fastcall DATATBLS_GetCharstatsTxtTable()
 {
-	return gpDataTables.pCharStatsTxt;
+	return sgptDataTables->pCharStatsTxt;
 }
 
 //D2Common.0x6FD4E4C0
 D2AnimDataStrc* __fastcall DATATBLS_GetAnimData()
 {
-	return gpDataTables.pAnimData;
+	return sgptDataTables->pAnimData;
 }
 
 //D2Common.0x6FD4E4D0 (#10655)
@@ -344,12 +344,12 @@ D2DifficultyLevelsTxt* __stdcall DATATBLS_GetDifficultyLevelsTxtRecord(int nDiff
 		nDifficulty = 0;
 	}
 
-	if (nDifficulty > gpDataTables.nDifficultyLevelsTxtRecordCount - 1)
+	if (nDifficulty > sgptDataTables->nDifficultyLevelsTxtRecordCount - 1)
 	{
-		nDifficulty = gpDataTables.nDifficultyLevelsTxtRecordCount - 1;
+		nDifficulty = sgptDataTables->nDifficultyLevelsTxtRecordCount - 1;
 	}
 
-	return &gpDataTables.pDifficultyLevelsTxt[nDifficulty];
+	return &sgptDataTables->pDifficultyLevelsTxt[nDifficulty];
 }
 
 //D2Common.0x6FD4E500
@@ -359,7 +359,7 @@ void __fastcall DATATBLS_LoadStatesTxt(void* pMemPool)
 
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "state", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pStatesLinker },
+		{ "state", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pStatesLinker },
 		{ "group", TXTFIELD_WORD, 0, 30, NULL },
 		{ "nosend", TXTFIELD_BIT, 0, 16, NULL },
 		{ "hide", TXTFIELD_BIT, 2, 16, NULL },
@@ -401,111 +401,111 @@ void __fastcall DATATBLS_LoadStatesTxt(void* pMemPool)
 		{ "nooverlays", TXTFIELD_BIT, 35, 16, NULL },
 		{ "notondead", TXTFIELD_BIT, 39, 16, NULL },
 		{ "noclear", TXTFIELD_BIT, 36, 16, NULL },
-		{ "overlay1", TXTFIELD_NAMETOWORD, 0, 2, &gpDataTables.pOverlayLinker },
-		{ "overlay2", TXTFIELD_NAMETOWORD, 0, 4, &gpDataTables.pOverlayLinker },
-		{ "overlay3", TXTFIELD_NAMETOWORD, 0, 6, &gpDataTables.pOverlayLinker },
-		{ "overlay4", TXTFIELD_NAMETOWORD, 0, 8, &gpDataTables.pOverlayLinker },
-		{ "pgsvoverlay", TXTFIELD_NAMETOWORD, 0, 14, &gpDataTables.pOverlayLinker },
-		{ "castoverlay", TXTFIELD_NAMETOWORD, 0, 10, &gpDataTables.pOverlayLinker },
-		{ "removerlay", TXTFIELD_NAMETOWORD, 0, 12, &gpDataTables.pOverlayLinker },
-		{ "stat", TXTFIELD_NAMETOWORD, 0, 24, &gpDataTables.pItemStatCostLinker },
+		{ "overlay1", TXTFIELD_NAMETOWORD, 0, 2, &sgptDataTables->pOverlayLinker },
+		{ "overlay2", TXTFIELD_NAMETOWORD, 0, 4, &sgptDataTables->pOverlayLinker },
+		{ "overlay3", TXTFIELD_NAMETOWORD, 0, 6, &sgptDataTables->pOverlayLinker },
+		{ "overlay4", TXTFIELD_NAMETOWORD, 0, 8, &sgptDataTables->pOverlayLinker },
+		{ "pgsvoverlay", TXTFIELD_NAMETOWORD, 0, 14, &sgptDataTables->pOverlayLinker },
+		{ "castoverlay", TXTFIELD_NAMETOWORD, 0, 10, &sgptDataTables->pOverlayLinker },
+		{ "removerlay", TXTFIELD_NAMETOWORD, 0, 12, &sgptDataTables->pOverlayLinker },
+		{ "stat", TXTFIELD_NAMETOWORD, 0, 24, &sgptDataTables->pItemStatCostLinker },
 		{ "setfunc", TXTFIELD_WORD, 0, 26, NULL },
 		{ "remfunc", TXTFIELD_WORD, 0, 28, NULL },
-		{ "missile", TXTFIELD_NAMETOWORD, 0, 58, &gpDataTables.pMissilesLinker },
-		{ "skill", TXTFIELD_NAMETOWORD, 0, 56, &gpDataTables.iSkillCode },
+		{ "missile", TXTFIELD_NAMETOWORD, 0, 58, &sgptDataTables->pMissilesLinker },
+		{ "skill", TXTFIELD_NAMETOWORD, 0, 56, &sgptDataTables->iSkillCode },
 		{ "colorpri", TXTFIELD_BYTE, 0, 32, NULL },
 		{ "colorshift", TXTFIELD_BYTE, 0, 33, NULL },
 		{ "light-r", TXTFIELD_BYTE, 0, 34, NULL },
 		{ "light-g", TXTFIELD_BYTE, 0, 35, NULL },
 		{ "light-b", TXTFIELD_BYTE, 0, 36, NULL },
-		{ "onsound", TXTFIELD_NAMETOWORD, 0, 38, &gpDataTables.pSoundsLinker },
-		{ "offsound", TXTFIELD_NAMETOWORD, 0, 40, &gpDataTables.pSoundsLinker },
-		{ "itemtype", TXTFIELD_CODETOWORD, 0, 42, &gpDataTables.pItemTypesLinker },
-		{ "itemtrans", TXTFIELD_CODETOBYTE, 0, 44, &gpDataTables.pColorsLinker },
+		{ "onsound", TXTFIELD_NAMETOWORD, 0, 38, &sgptDataTables->pSoundsLinker },
+		{ "offsound", TXTFIELD_NAMETOWORD, 0, 40, &sgptDataTables->pSoundsLinker },
+		{ "itemtype", TXTFIELD_CODETOWORD, 0, 42, &sgptDataTables->pItemTypesLinker },
+		{ "itemtrans", TXTFIELD_CODETOBYTE, 0, 44, &sgptDataTables->pColorsLinker },
 		{ "gfxtype", TXTFIELD_BYTE, 0, 45, NULL },
 		{ "gfxclass", TXTFIELD_WORD, 0, 46, NULL },
-		{ "cltevent", TXTFIELD_NAMETOWORD, 0, 48, &gpDataTables.pEventsLinker },
+		{ "cltevent", TXTFIELD_NAMETOWORD, 0, 48, &sgptDataTables->pEventsLinker },
 		{ "clteventfunc", TXTFIELD_WORD, 0, 50, NULL },
 		{ "cltactivefunc", TXTFIELD_WORD, 0, 52, NULL },
 		{ "srvactivefunc", TXTFIELD_WORD, 0, 54, NULL },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pStatesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pStatesTxt = (D2StatesTxt*)DATATBLS_CompileTxt(pMemPool, "states", pTbl, &gpDataTables.nStatesTxtRecordCount, sizeof(D2StatesTxt));
+	sgptDataTables->pStatesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pStatesTxt = (D2StatesTxt*)DATATBLS_CompileTxt(pMemPool, "states", pTbl, &sgptDataTables->nStatesTxtRecordCount, sizeof(D2StatesTxt));
 
-	if (gpDataTables.nStatesTxtRecordCount >= 256)
+	if (sgptDataTables->nStatesTxtRecordCount >= 256)
 	{
 		FOG_10025("Exceeded maximum allowable number of states", __FILE__, __LINE__);
 	}
 
-	gpDataTables.pStateMasks = (DWORD*)FOG_AllocServerMemory(NULL, ARRAY_SIZE(gpDataTables.fStateMasks) * sizeof(DWORD) * (gpDataTables.nStatesTxtRecordCount + 31) / 32, __FILE__, __LINE__, 0);
-	memset(gpDataTables.pStateMasks, 0x00, ARRAY_SIZE(gpDataTables.fStateMasks) * sizeof(DWORD) * (gpDataTables.nStatesTxtRecordCount + 31) / 32);
+	sgptDataTables->pStateMasks = (DWORD*)FOG_AllocServerMemory(NULL, ARRAY_SIZE(sgptDataTables->fStateMasks) * sizeof(DWORD) * (sgptDataTables->nStatesTxtRecordCount + 31) / 32, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->pStateMasks, 0x00, ARRAY_SIZE(sgptDataTables->fStateMasks) * sizeof(DWORD) * (sgptDataTables->nStatesTxtRecordCount + 31) / 32);
 
-	for (int i = 0; i < ARRAY_SIZE(gpDataTables.fStateMasks); ++i)
+	for (int i = 0; i < ARRAY_SIZE(sgptDataTables->fStateMasks); ++i)
 	{
-		pStateMasks = &gpDataTables.pStateMasks[(gpDataTables.nStatesTxtRecordCount + 31) / 32 * i];
-		gpDataTables.fStateMasks[i] = pStateMasks;
+		pStateMasks = &sgptDataTables->pStateMasks[(sgptDataTables->nStatesTxtRecordCount + 31) / 32 * i];
+		sgptDataTables->fStateMasks[i] = pStateMasks;
 
-		for (int j = 0; j < gpDataTables.nStatesTxtRecordCount; ++j)
+		for (int j = 0; j < sgptDataTables->nStatesTxtRecordCount; ++j)
 		{
-			if (gpDataTables.pStatesTxt[j].nStateFlags[i >> 3] & gdwBitMasks[i & 7])
+			if (sgptDataTables->pStatesTxt[j].nStateFlags[i >> 3] & gdwBitMasks[i & 7])
 			{
 				pStateMasks[j >> 5] |= gdwBitMasks[j & 31];
 			}
 		}
 	}
 
-	gpDataTables.pProgressiveStates = (short*)FOG_AllocServerMemory(NULL, sizeof(short) * gpDataTables.nStatesTxtRecordCount, __FILE__, __LINE__, 0);
-	memset(gpDataTables.pProgressiveStates, 0x00, sizeof(short) * gpDataTables.nStatesTxtRecordCount);
-	gpDataTables.nProgressiveStates = 0;
+	sgptDataTables->pProgressiveStates = (short*)FOG_AllocServerMemory(NULL, sizeof(short) * sgptDataTables->nStatesTxtRecordCount, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->pProgressiveStates, 0x00, sizeof(short) * sgptDataTables->nStatesTxtRecordCount);
+	sgptDataTables->nProgressiveStates = 0;
 
-	gpDataTables.pCurseStates = (short*)FOG_AllocServerMemory(NULL, sizeof(short) * gpDataTables.nStatesTxtRecordCount, __FILE__, __LINE__, 0);
-	memset(gpDataTables.pCurseStates, 0x00, sizeof(short) * gpDataTables.nStatesTxtRecordCount);
-	gpDataTables.nCurseStates = 0;
+	sgptDataTables->pCurseStates = (short*)FOG_AllocServerMemory(NULL, sizeof(short) * sgptDataTables->nStatesTxtRecordCount, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->pCurseStates, 0x00, sizeof(short) * sgptDataTables->nStatesTxtRecordCount);
+	sgptDataTables->nCurseStates = 0;
 
-	gpDataTables.pTransformStates = (short*)FOG_AllocServerMemory(NULL, sizeof(short) * gpDataTables.nStatesTxtRecordCount, __FILE__, __LINE__, 0);
-	memset(gpDataTables.pTransformStates, 0x00, sizeof(short) * gpDataTables.nStatesTxtRecordCount);
-	gpDataTables.nTransformStates = 0;
+	sgptDataTables->pTransformStates = (short*)FOG_AllocServerMemory(NULL, sizeof(short) * sgptDataTables->nStatesTxtRecordCount, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->pTransformStates, 0x00, sizeof(short) * sgptDataTables->nStatesTxtRecordCount);
+	sgptDataTables->nTransformStates = 0;
 
-	gpDataTables.pActionStates = (short*)FOG_AllocServerMemory(NULL, sizeof(short) * gpDataTables.nStatesTxtRecordCount, __FILE__, __LINE__, 0);
-	memset(gpDataTables.pActionStates, 0x00, sizeof(short) * gpDataTables.nStatesTxtRecordCount);
-	gpDataTables.nActionStates = 0;
+	sgptDataTables->pActionStates = (short*)FOG_AllocServerMemory(NULL, sizeof(short) * sgptDataTables->nStatesTxtRecordCount, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->pActionStates, 0x00, sizeof(short) * sgptDataTables->nStatesTxtRecordCount);
+	sgptDataTables->nActionStates = 0;
 
-	gpDataTables.pColourStates = (short*)FOG_AllocServerMemory(NULL, sizeof(short) * gpDataTables.nStatesTxtRecordCount, __FILE__, __LINE__, 0);
-	memset(gpDataTables.pColourStates, 0x00, sizeof(short) * gpDataTables.nStatesTxtRecordCount);
-	gpDataTables.nColourStates = 0;
+	sgptDataTables->pColourStates = (short*)FOG_AllocServerMemory(NULL, sizeof(short) * sgptDataTables->nStatesTxtRecordCount, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->pColourStates, 0x00, sizeof(short) * sgptDataTables->nStatesTxtRecordCount);
+	sgptDataTables->nColourStates = 0;
 	
-	for (int i = 0; i < gpDataTables.nStatesTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nStatesTxtRecordCount; ++i)
 	{
-		if (gpDataTables.pStatesTxt[i].dwStateFlags & gdwBitMasks[STATEMASK_PGSV])
+		if (sgptDataTables->pStatesTxt[i].dwStateFlags & gdwBitMasks[STATEMASK_PGSV])
 		{
-			gpDataTables.pProgressiveStates[gpDataTables.nProgressiveStates] = i;
-			++gpDataTables.nProgressiveStates;
+			sgptDataTables->pProgressiveStates[sgptDataTables->nProgressiveStates] = i;
+			++sgptDataTables->nProgressiveStates;
 		}
 
-		if (gpDataTables.pStatesTxt[i].dwStateFlags & gdwBitMasks[STATEMASK_CURSE])
+		if (sgptDataTables->pStatesTxt[i].dwStateFlags & gdwBitMasks[STATEMASK_CURSE])
 		{
-			gpDataTables.pCurseStates[gpDataTables.nCurseStates] = i;
-			++gpDataTables.nCurseStates;
+			sgptDataTables->pCurseStates[sgptDataTables->nCurseStates] = i;
+			++sgptDataTables->nCurseStates;
 		}
 
-		if (gpDataTables.pStatesTxt[i].dwStateFlags & gdwBitMasks[STATEMASK_DISGUISE])
+		if (sgptDataTables->pStatesTxt[i].dwStateFlags & gdwBitMasks[STATEMASK_DISGUISE])
 		{
-			gpDataTables.pTransformStates[gpDataTables.nTransformStates] = i;
-			++gpDataTables.nTransformStates;
+			sgptDataTables->pTransformStates[sgptDataTables->nTransformStates] = i;
+			++sgptDataTables->nTransformStates;
 		}
 
-		if (gpDataTables.pStatesTxt[i].dwStateFlags & gdwBitMasks[STATEMASK_ACTIVE])
+		if (sgptDataTables->pStatesTxt[i].dwStateFlags & gdwBitMasks[STATEMASK_ACTIVE])
 		{
-			gpDataTables.pActionStates[gpDataTables.nActionStates] = i;
-			++gpDataTables.nActionStates;
+			sgptDataTables->pActionStates[sgptDataTables->nActionStates] = i;
+			++sgptDataTables->nActionStates;
 		}
 
-		if (gpDataTables.pStatesTxt[i].wItemType > 0)
+		if (sgptDataTables->pStatesTxt[i].wItemType > 0)
 		{
-			gpDataTables.pColourStates[gpDataTables.nColourStates] = i;
-			++gpDataTables.nColourStates;
+			sgptDataTables->pColourStates[sgptDataTables->nColourStates] = i;
+			++sgptDataTables->nColourStates;
 		}
 	}
 }
@@ -513,42 +513,42 @@ void __fastcall DATATBLS_LoadStatesTxt(void* pMemPool)
 //D2Common.0x6FD4F4A0
 void __fastcall DATATBLS_UnloadStatesTxt()
 {
-	if (gpDataTables.pStateMasks)
+	if (sgptDataTables->pStateMasks)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pStateMasks, __FILE__, __LINE__, 0);
-		gpDataTables.pStateMasks = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pStateMasks, __FILE__, __LINE__, 0);
+		sgptDataTables->pStateMasks = NULL;
 	}
 
-	if (gpDataTables.pProgressiveStates)
+	if (sgptDataTables->pProgressiveStates)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pProgressiveStates, __FILE__, __LINE__, 0);
-		gpDataTables.pProgressiveStates = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pProgressiveStates, __FILE__, __LINE__, 0);
+		sgptDataTables->pProgressiveStates = NULL;
 	}
 
-	if (gpDataTables.pCurseStates)
+	if (sgptDataTables->pCurseStates)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pCurseStates, __FILE__, __LINE__, 0);
-		gpDataTables.pCurseStates = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pCurseStates, __FILE__, __LINE__, 0);
+		sgptDataTables->pCurseStates = NULL;
 	}
 
-	if (gpDataTables.pTransformStates)
+	if (sgptDataTables->pTransformStates)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pTransformStates, __FILE__, __LINE__, 0);
-		gpDataTables.pTransformStates = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pTransformStates, __FILE__, __LINE__, 0);
+		sgptDataTables->pTransformStates = NULL;
 	}
 
-	if (gpDataTables.pActionStates)
+	if (sgptDataTables->pActionStates)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pActionStates, __FILE__, __LINE__, 0);
-		gpDataTables.pActionStates = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pActionStates, __FILE__, __LINE__, 0);
+		sgptDataTables->pActionStates = NULL;
 	}
 
-	memset(gpDataTables.fStateMasks, 0x00, sizeof(gpDataTables.fStateMasks));
+	memset(sgptDataTables->fStateMasks, 0x00, sizeof(sgptDataTables->fStateMasks));
 
-	DATATBLS_UnloadBin(gpDataTables.pStatesTxt);
-	gpDataTables.pStatesTxt = NULL;
-	FOG_FreeLinker(gpDataTables.pStatesLinker);
-	gpDataTables.pStatesLinker = NULL;
+	DATATBLS_UnloadBin(sgptDataTables->pStatesTxt);
+	sgptDataTables->pStatesTxt = NULL;
+	FOG_FreeLinker(sgptDataTables->pStatesLinker);
+	sgptDataTables->pStatesLinker = NULL;
 }
 
 //D2Common.0x6FD4F5A0
@@ -556,7 +556,7 @@ void __fastcall DATATBLS_LoadPetTypeTxt(void* pMemPool)
 {
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "pet type", TXTFIELD_NAMETOINDEX2, 0, 0, &gpDataTables.pPetTypeLinker },
+		{ "pet type", TXTFIELD_NAMETOINDEX2, 0, 0, &sgptDataTables->pPetTypeLinker },
 		{ "group", TXTFIELD_WORD, 0, 8, NULL },
 		{ "basemax", TXTFIELD_WORD, 0, 10, NULL },
 		{ "warp", TXTFIELD_BIT, 0, 4, NULL },
@@ -579,20 +579,20 @@ void __fastcall DATATBLS_LoadPetTypeTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pPetTypeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pPetTypeTxt = (D2PetTypeTxt*)DATATBLS_CompileTxt(pMemPool, "pettype", pTbl, &gpDataTables.nPetTypeTxtRecordCount, sizeof(D2PetTypeTxt));
+	sgptDataTables->pPetTypeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pPetTypeTxt = (D2PetTypeTxt*)DATATBLS_CompileTxt(pMemPool, "pettype", pTbl, &sgptDataTables->nPetTypeTxtRecordCount, sizeof(D2PetTypeTxt));
 
-	if (gpDataTables.nPetTypeTxtRecordCount > 0)
+	if (sgptDataTables->nPetTypeTxtRecordCount > 0)
 	{
-		if (gpDataTables.nPetTypeTxtRecordCount >= 256)
+		if (sgptDataTables->nPetTypeTxtRecordCount >= 256)
 		{
 			FOG_10025("Pet types table exceeded maximum number of entries.", __FILE__, __LINE__);
-			gpDataTables.nPetTypeTxtRecordCount = 256;
+			sgptDataTables->nPetTypeTxtRecordCount = 256;
 		}
 	}
 	else
 	{
-		gpDataTables.nPetTypeTxtRecordCount = 0;
+		sgptDataTables->nPetTypeTxtRecordCount = 0;
 	}
 }
 
@@ -626,9 +626,9 @@ char* __stdcall DATATBLS_GetUnitNameFromUnitTypeAndClassId(int nUnitType, int nC
 	switch (nUnitType)
 	{
 	case UNIT_PLAYER:
-		if (nClassId >= 0 && nClassId < gpDataTables.nCharStatsTxtRecordCount)
+		if (nClassId >= 0 && nClassId < sgptDataTables->nCharStatsTxtRecordCount)
 		{
-			pCharStatsTxtRecord = &gpDataTables.pCharStatsTxt[nClassId];
+			pCharStatsTxtRecord = &sgptDataTables->pCharStatsTxt[nClassId];
 			if (pCharStatsTxtRecord && pCharStatsTxtRecord->szClassName[0])
 			{
 				strcpy_s(szName, 64, pCharStatsTxtRecord->szClassName);
@@ -721,7 +721,7 @@ void* __stdcall DATATBLS_CompileTxt(void* pMemPool, char* szName, D2BinFieldStrc
 	char szFilePath[MAX_PATH] = {};
 
 	nDataSize = 0;
-	if (gpDataTables.bCompileTxt)
+	if (sgptDataTables->bCompileTxt)
 	{
 		if (_strcmpi(szName, "leveldefs"))
 		{
@@ -800,7 +800,7 @@ void* __stdcall DATATBLS_CompileTxt(void* pMemPool, char* szName, D2BinFieldStrc
 //D2Common.0x6FD500F0 (#11242)
 void __stdcall DATATBLS_ToggleCompileTxtFlag(BOOL bSilent)
 {
-	gpDataTables.bCompileTxt = !bSilent;
+	sgptDataTables->bCompileTxt = !bSilent;
 }
 
 //D2Common.0x6FD50110 (#10579)
@@ -822,52 +822,52 @@ void __stdcall DATATBLS_UnloadBin(void* pBinFile)
 //D2Common.0x6FD50150 (#10575)
 void __stdcall DATATBLS_UnloadAllBins()
 {
-	DATATBLS_UnloadBin(gpDataTables.pCompCodeTxt);
-	FOG_FreeLinker(gpDataTables.pCompCodeLinker);
+	DATATBLS_UnloadBin(sgptDataTables->pCompCodeTxt);
+	FOG_FreeLinker(sgptDataTables->pCompCodeLinker);
 
-	if (gpDataTables.bCompileTxt)
+	if (sgptDataTables->bCompileTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pPlayerClassTxt);
-		FOG_FreeLinker(gpDataTables.pPlayerClassLinker);
-		DATATBLS_UnloadBin(gpDataTables.pBodyLocsTxt);
-		FOG_FreeLinker(gpDataTables.pBodyLocsLinker);
-		DATATBLS_UnloadBin(gpDataTables.pStorePageTxt);
-		FOG_FreeLinker(gpDataTables.pStorePageLinker);
-		DATATBLS_UnloadBin(gpDataTables.pElemTypesTxt);
-		FOG_FreeLinker(gpDataTables.pElemTypesLinker);
-		DATATBLS_UnloadBin(gpDataTables.pHitClassTxt);
-		FOG_FreeLinker(gpDataTables.pHitClassLinker);
-		DATATBLS_UnloadBin(gpDataTables.pColorsTxt);
-		FOG_FreeLinker(gpDataTables.pColorsLinker);
-		DATATBLS_UnloadBin(gpDataTables.pHireDescTxt);
-		FOG_FreeLinker(gpDataTables.pHireDescLinker);
-		DATATBLS_UnloadBin(gpDataTables.pMonModeTxtStub);
-		FOG_FreeLinker(gpDataTables.pMonModeLinker);
-		DATATBLS_UnloadBin(gpDataTables.pPlrModeTxtStub);
-		FOG_FreeLinker(gpDataTables.pPlrModeLinker);
-		DATATBLS_UnloadBin(gpDataTables.pMonAiTxt);
-		FOG_FreeLinker(gpDataTables.pMonAiLinker);
-		DATATBLS_UnloadBin(gpDataTables.pMonPlaceTxt);
-		FOG_FreeLinker(gpDataTables.pMonPlaceLinker);
-		DATATBLS_UnloadBin(gpDataTables.pSkillCalcTxt);
-		FOG_FreeLinker(gpDataTables.pSkillCalcLinker);
-		DATATBLS_UnloadBin(gpDataTables.pMissileCalcTxt);
-		FOG_FreeLinker(gpDataTables.pMissileCalcLinker);
-		DATATBLS_UnloadBin((void*)gpDataTables.pSkillCode);
-		FOG_FreeLinker(gpDataTables.iSkillCode);
-		DATATBLS_UnloadBin(gpDataTables.pEventsTxt);
-		FOG_FreeLinker(gpDataTables.pEventsLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pPlayerClassTxt);
+		FOG_FreeLinker(sgptDataTables->pPlayerClassLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pBodyLocsTxt);
+		FOG_FreeLinker(sgptDataTables->pBodyLocsLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pStorePageTxt);
+		FOG_FreeLinker(sgptDataTables->pStorePageLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pElemTypesTxt);
+		FOG_FreeLinker(sgptDataTables->pElemTypesLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pHitClassTxt);
+		FOG_FreeLinker(sgptDataTables->pHitClassLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pColorsTxt);
+		FOG_FreeLinker(sgptDataTables->pColorsLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pHireDescTxt);
+		FOG_FreeLinker(sgptDataTables->pHireDescLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pMonModeTxtStub);
+		FOG_FreeLinker(sgptDataTables->pMonModeLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pPlrModeTxtStub);
+		FOG_FreeLinker(sgptDataTables->pPlrModeLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pMonAiTxt);
+		FOG_FreeLinker(sgptDataTables->pMonAiLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pMonPlaceTxt);
+		FOG_FreeLinker(sgptDataTables->pMonPlaceLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pSkillCalcTxt);
+		FOG_FreeLinker(sgptDataTables->pSkillCalcLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pMissileCalcTxt);
+		FOG_FreeLinker(sgptDataTables->pMissileCalcLinker);
+		DATATBLS_UnloadBin((void*)sgptDataTables->pSkillCode);
+		FOG_FreeLinker(sgptDataTables->iSkillCode);
+		DATATBLS_UnloadBin(sgptDataTables->pEventsTxt);
+		FOG_FreeLinker(sgptDataTables->pEventsLinker);
 	}
 
-	DATATBLS_UnloadBin(gpDataTables.pCharStatsTxt);
+	DATATBLS_UnloadBin(sgptDataTables->pCharStatsTxt);
 	DATATBLS_UnloadMissilesTxt();
 	DATATBLS_UnloadOverlayTxt();
 	DATATBLS_UnloadSkills_SkillDescTxt();
 	DATATBLS_UnloadItemStatCostTxt();
 	DATATBLS_UnloadStatesTxt();
 
-	DATATBLS_UnloadBin(gpDataTables.pPetTypeTxt);
-	FOG_FreeLinker(gpDataTables.pPetTypeLinker);
+	DATATBLS_UnloadBin(sgptDataTables->pPetTypeTxt);
+	FOG_FreeLinker(sgptDataTables->pPetTypeLinker);
 
 	DATATBLS_UnloadItemsTxt();
 	DATATBLS_UnloadPropertiesTxt();
@@ -884,8 +884,8 @@ void __stdcall DATATBLS_UnloadAllBins()
 	DATATBLS_UnloadItemTypesTxt();
 	DATATBLS_UnloadMonTypeTxt();
 	DATATBLS_UnloadPlrMode_Type_MonMode_ObjMode_Type_Composit_ArmtypeTxt();
-	DATATBLS_UnloadBin(gpDataTables.pExperienceTxt);
-	DATATBLS_UnloadAnimDataD2(gpDataTables.pAnimData);
+	DATATBLS_UnloadBin(sgptDataTables->pExperienceTxt);
+	DATATBLS_UnloadAnimDataD2(sgptDataTables->pAnimData);
 	DATATBLS_UnloadSomeMonsterTxts();
 	DATATBLS_UnloadLevelsTxt();
 	DATATBLS_UnloadLevelDefsBin();
@@ -908,7 +908,7 @@ void __stdcall DATATBLS_UnloadAllBins()
 	DATATBLS_UnloadCubeMainTxt();
 	DATATBLS_UnloadCharTemplateTxt();
 	//D2COMMON_10916_Return();
-	DATATBLS_UnloadBin(gpDataTables.pDifficultyLevelsTxt);
+	DATATBLS_UnloadBin(sgptDataTables->pDifficultyLevelsTxt);
 }
 
 //D2Common.0x6FD504B0 (#10576)
@@ -959,9 +959,9 @@ void __stdcall DATATBLS_LoadAllTxts(void* pMemPool, int a2, int a3)
 	DATATBLS_LoadCompositTxt(pMemPool);
 	DATATBLS_LoadArmTypeTxt(pMemPool);
 
-	gpDataTables.pExperienceTxt = (D2ExperienceTxt*)DATATBLS_CompileTxt(pMemPool, "experience", pTbl, NULL, sizeof(D2ExperienceTxt));
+	sgptDataTables->pExperienceTxt = (D2ExperienceTxt*)DATATBLS_CompileTxt(pMemPool, "experience", pTbl, NULL, sizeof(D2ExperienceTxt));
 
-	gpDataTables.pAnimData = DATATBLS_LoadAnimDataD2(pMemPool);
+	sgptDataTables->pAnimData = DATATBLS_LoadAnimDataD2(pMemPool);
 	DATATBLS_LoadSomeMonsterTxts(pMemPool);
 	DATATBLS_LoadLevelsTxt(pMemPool);
 	DATATBLS_LoadLevelDefsBin(pMemPool);
@@ -995,134 +995,134 @@ void __fastcall DATATBLS_LoadSomeTxts(void* pMemPool)
 
 	D2BinFieldStrc pHireDescTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pHireDescLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pHireDescLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pMonModeTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pMonModeLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pMonModeLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pPlayerClassTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pPlayerClassLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pPlayerClassLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pPlrModeTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pPlrModeLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pPlrModeLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pStorePageTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pStorePageLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pStorePageLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pMonAiTbl[] =
 	{
-		{ "AI", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pMonAiLinker },
+		{ "AI", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pMonAiLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pHitClassTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pHitClassLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pHitClassLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pMonPlaceTbl[] =
 	{
-		{ "code", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pMonPlaceLinker },
+		{ "code", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pMonPlaceLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pCompCodeTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pCompCodeLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pCompCodeLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pSkillCalcTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pSkillCalcLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pSkillCalcLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pElemTypesTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pElemTypesLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pElemTypesLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pMissCalcTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pMissileCalcLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pMissileCalcLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pBodyLocsTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pBodyLocsLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pBodyLocsLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pSkillCodeTbl[] =
 	{
-		{ "skill", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.iSkillCode },
+		{ "skill", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->iSkillCode },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pColorsTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pColorsLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pColorsLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 	D2BinFieldStrc pEventsTbl[] =
 	{
-		{ "event", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pEventsLinker },
+		{ "event", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pEventsLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pCompCodeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pCompCodeTxt = (D2CompCodeTxt*)DATATBLS_CompileTxt(pMemPool, "compcode", pCompCodeTbl, &gpDataTables.nCompCodeTxtRecordCount, sizeof(D2CompCodeTxt));
+	sgptDataTables->pCompCodeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pCompCodeTxt = (D2CompCodeTxt*)DATATBLS_CompileTxt(pMemPool, "compcode", pCompCodeTbl, &sgptDataTables->nCompCodeTxtRecordCount, sizeof(D2CompCodeTxt));
 
-	if (gpDataTables.bCompileTxt)
+	if (sgptDataTables->bCompileTxt)
 	{
-		gpDataTables.pPlayerClassLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pPlayerClassTxt = (D2PlayerClassTxt*)DATATBLS_CompileTxt(pMemPool, "playerclass", pPlayerClassTbl, &nRecordCount, sizeof(D2PlayerClassTxt));
+		sgptDataTables->pPlayerClassLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pPlayerClassTxt = (D2PlayerClassTxt*)DATATBLS_CompileTxt(pMemPool, "playerclass", pPlayerClassTbl, &nRecordCount, sizeof(D2PlayerClassTxt));
 
-		gpDataTables.pBodyLocsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pBodyLocsTxt = (D2BodyLocsTxt*)DATATBLS_CompileTxt(pMemPool, "bodylocs", pBodyLocsTbl, &nRecordCount, sizeof(D2BodyLocsTxt));
+		sgptDataTables->pBodyLocsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pBodyLocsTxt = (D2BodyLocsTxt*)DATATBLS_CompileTxt(pMemPool, "bodylocs", pBodyLocsTbl, &nRecordCount, sizeof(D2BodyLocsTxt));
 
-		gpDataTables.pStorePageLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pStorePageTxt = (D2StorePageTxt*)DATATBLS_CompileTxt(pMemPool, "storepage", pStorePageTbl, &nRecordCount, sizeof(D2StorePageTxt));
+		sgptDataTables->pStorePageLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pStorePageTxt = (D2StorePageTxt*)DATATBLS_CompileTxt(pMemPool, "storepage", pStorePageTbl, &nRecordCount, sizeof(D2StorePageTxt));
 
-		gpDataTables.pElemTypesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pElemTypesTxt = (D2ElemTypesTxt*)DATATBLS_CompileTxt(pMemPool, "elemtypes", pElemTypesTbl, &nRecordCount, sizeof(D2ElemTypesTxt));
+		sgptDataTables->pElemTypesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pElemTypesTxt = (D2ElemTypesTxt*)DATATBLS_CompileTxt(pMemPool, "elemtypes", pElemTypesTbl, &nRecordCount, sizeof(D2ElemTypesTxt));
 
-		gpDataTables.pHitClassLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pHitClassTxt = (D2HitClassTxt*)DATATBLS_CompileTxt(pMemPool, "hitclass", pHitClassTbl, &nRecordCount, sizeof(D2HitClassTxt));
+		sgptDataTables->pHitClassLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pHitClassTxt = (D2HitClassTxt*)DATATBLS_CompileTxt(pMemPool, "hitclass", pHitClassTbl, &nRecordCount, sizeof(D2HitClassTxt));
 
-		gpDataTables.pColorsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pColorsTxt = (D2ColorsTxt*)DATATBLS_CompileTxt(pMemPool, "colors", pColorsTbl, &nRecordCount, sizeof(D2ColorsTxt));
+		sgptDataTables->pColorsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pColorsTxt = (D2ColorsTxt*)DATATBLS_CompileTxt(pMemPool, "colors", pColorsTbl, &nRecordCount, sizeof(D2ColorsTxt));
 
-		gpDataTables.pHireDescLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pHireDescTxt = (D2HireDescTxt*)DATATBLS_CompileTxt(pMemPool, "hiredesc", pHireDescTbl, &nRecordCount, sizeof(D2HireDescTxt));
+		sgptDataTables->pHireDescLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pHireDescTxt = (D2HireDescTxt*)DATATBLS_CompileTxt(pMemPool, "hiredesc", pHireDescTbl, &nRecordCount, sizeof(D2HireDescTxt));
 
-		gpDataTables.pMonModeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pMonModeTxtStub = (D2MonModeTxtStub*)DATATBLS_CompileTxt(pMemPool, "monmode", pMonModeTbl, &nRecordCount, sizeof(D2MonModeTxtStub));
+		sgptDataTables->pMonModeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pMonModeTxtStub = (D2MonModeTxtStub*)DATATBLS_CompileTxt(pMemPool, "monmode", pMonModeTbl, &nRecordCount, sizeof(D2MonModeTxtStub));
 
-		gpDataTables.pPlrModeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pPlrModeTxtStub = (D2PlrModeTxtStub*)DATATBLS_CompileTxt(pMemPool, "plrmode", pPlrModeTbl, &nRecordCount, sizeof(D2PlrModeTxtStub));
+		sgptDataTables->pPlrModeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pPlrModeTxtStub = (D2PlrModeTxtStub*)DATATBLS_CompileTxt(pMemPool, "plrmode", pPlrModeTbl, &nRecordCount, sizeof(D2PlrModeTxtStub));
 
-		gpDataTables.pMonAiLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pMonAiTxt = (D2MonAiTxt*)DATATBLS_CompileTxt(pMemPool, "monai", pMonAiTbl, &gpDataTables.nMonAiTxtRecordCount, sizeof(D2MonAiTxt));
+		sgptDataTables->pMonAiLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pMonAiTxt = (D2MonAiTxt*)DATATBLS_CompileTxt(pMemPool, "monai", pMonAiTbl, &sgptDataTables->nMonAiTxtRecordCount, sizeof(D2MonAiTxt));
 
-		gpDataTables.pMonPlaceLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pMonPlaceTxt = (D2MonPlaceTxt*)DATATBLS_CompileTxt(pMemPool, "monplace", pMonPlaceTbl, &gpDataTables.nMonPlaceTxtRecordCount, sizeof(D2MonPlaceTxt));
+		sgptDataTables->pMonPlaceLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pMonPlaceTxt = (D2MonPlaceTxt*)DATATBLS_CompileTxt(pMemPool, "monplace", pMonPlaceTbl, &sgptDataTables->nMonPlaceTxtRecordCount, sizeof(D2MonPlaceTxt));
 
-		gpDataTables.pSkillCalcLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pSkillCalcTxt = (D2SkillCalcTxt*)DATATBLS_CompileTxt(pMemPool, "skillcalc", pSkillCalcTbl, &nRecordCount, sizeof(D2SkillCalcTxt));
+		sgptDataTables->pSkillCalcLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pSkillCalcTxt = (D2SkillCalcTxt*)DATATBLS_CompileTxt(pMemPool, "skillcalc", pSkillCalcTbl, &nRecordCount, sizeof(D2SkillCalcTxt));
 
-		gpDataTables.pMissileCalcLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pMissileCalcTxt = (D2MissCalcTxt*)DATATBLS_CompileTxt(pMemPool, "misscalc", pMissCalcTbl, &nRecordCount, sizeof(D2MissCalcTxt));
+		sgptDataTables->pMissileCalcLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pMissileCalcTxt = (D2MissCalcTxt*)DATATBLS_CompileTxt(pMemPool, "misscalc", pMissCalcTbl, &nRecordCount, sizeof(D2MissCalcTxt));
 
-		gpDataTables.iSkillCode = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pSkillCode = (const char*)DATATBLS_CompileTxt(pMemPool, "skills", pSkillCodeTbl, &nRecordCount, 2);
+		sgptDataTables->iSkillCode = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pSkillCode = (const char*)DATATBLS_CompileTxt(pMemPool, "skills", pSkillCodeTbl, &nRecordCount, 2);
 
-		gpDataTables.pEventsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pEventsTxt = (D2EventsTxt*)DATATBLS_CompileTxt(pMemPool, "events", pEventsTbl, &nRecordCount, sizeof(D2EventsTxt));
+		sgptDataTables->pEventsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pEventsTxt = (D2EventsTxt*)DATATBLS_CompileTxt(pMemPool, "events", pEventsTbl, &nRecordCount, sizeof(D2EventsTxt));
 	}
 }
 
@@ -1160,28 +1160,28 @@ void __fastcall DATATBLS_LoadCharStatsTxt(void* pMemPool)
 		{ "StrSkillTab2", TXTFIELD_KEYTOWORD, 0, 86, DATATBLS_GetStringIdFromReferenceString },
 		{ "StrSkillTab3", TXTFIELD_KEYTOWORD, 0, 88, DATATBLS_GetStringIdFromReferenceString },
 		{ "StrClassOnly", TXTFIELD_KEYTOWORD, 0, 90, DATATBLS_GetStringIdFromReferenceString },
-		{ "StartSkill", TXTFIELD_NAMETOWORD, 0, 172, &gpDataTables.pSkillsLinker },
-		{ "Skill 1", TXTFIELD_NAMETOWORD, 0, 174, &gpDataTables.pSkillsLinker },
-		{ "Skill 2", TXTFIELD_NAMETOWORD, 0, 176, &gpDataTables.pSkillsLinker },
-		{ "Skill 3", TXTFIELD_NAMETOWORD, 0, 178, &gpDataTables.pSkillsLinker },
-		{ "Skill 4", TXTFIELD_NAMETOWORD, 0, 180, &gpDataTables.pSkillsLinker },
-		{ "Skill 5", TXTFIELD_NAMETOWORD, 0, 182, &gpDataTables.pSkillsLinker },
-		{ "Skill 6", TXTFIELD_NAMETOWORD, 0, 184, &gpDataTables.pSkillsLinker },
-		{ "Skill 7", TXTFIELD_NAMETOWORD, 0, 186, &gpDataTables.pSkillsLinker },
-		{ "Skill 8", TXTFIELD_NAMETOWORD, 0, 188, &gpDataTables.pSkillsLinker },
-		{ "Skill 9", TXTFIELD_NAMETOWORD, 0, 190, &gpDataTables.pSkillsLinker },
-		{ "Skill 10", TXTFIELD_NAMETOWORD, 0, 192, &gpDataTables.pSkillsLinker },
+		{ "StartSkill", TXTFIELD_NAMETOWORD, 0, 172, &sgptDataTables->pSkillsLinker },
+		{ "Skill 1", TXTFIELD_NAMETOWORD, 0, 174, &sgptDataTables->pSkillsLinker },
+		{ "Skill 2", TXTFIELD_NAMETOWORD, 0, 176, &sgptDataTables->pSkillsLinker },
+		{ "Skill 3", TXTFIELD_NAMETOWORD, 0, 178, &sgptDataTables->pSkillsLinker },
+		{ "Skill 4", TXTFIELD_NAMETOWORD, 0, 180, &sgptDataTables->pSkillsLinker },
+		{ "Skill 5", TXTFIELD_NAMETOWORD, 0, 182, &sgptDataTables->pSkillsLinker },
+		{ "Skill 6", TXTFIELD_NAMETOWORD, 0, 184, &sgptDataTables->pSkillsLinker },
+		{ "Skill 7", TXTFIELD_NAMETOWORD, 0, 186, &sgptDataTables->pSkillsLinker },
+		{ "Skill 8", TXTFIELD_NAMETOWORD, 0, 188, &sgptDataTables->pSkillsLinker },
+		{ "Skill 9", TXTFIELD_NAMETOWORD, 0, 190, &sgptDataTables->pSkillsLinker },
+		{ "Skill 10", TXTFIELD_NAMETOWORD, 0, 192, &sgptDataTables->pSkillsLinker },
 		{ "StatPerLevel", TXTFIELD_BYTE, 0, 80, NULL },
-		{ "item1loc", TXTFIELD_CODETOBYTE, 0, 96, &gpDataTables.pBodyLocsLinker },
-		{ "item2loc", TXTFIELD_CODETOBYTE, 0, 104, &gpDataTables.pBodyLocsLinker },
-		{ "item3loc", TXTFIELD_CODETOBYTE, 0, 112, &gpDataTables.pBodyLocsLinker },
-		{ "item4loc", TXTFIELD_CODETOBYTE, 0, 120, &gpDataTables.pBodyLocsLinker },
-		{ "item5loc", TXTFIELD_CODETOBYTE, 0, 128, &gpDataTables.pBodyLocsLinker },
-		{ "item6loc", TXTFIELD_CODETOBYTE, 0, 136, &gpDataTables.pBodyLocsLinker },
-		{ "item7loc", TXTFIELD_CODETOBYTE, 0, 144, &gpDataTables.pBodyLocsLinker },
-		{ "item8loc", TXTFIELD_CODETOBYTE, 0, 152, &gpDataTables.pBodyLocsLinker },
-		{ "item9loc", TXTFIELD_CODETOBYTE, 0, 160, &gpDataTables.pBodyLocsLinker },
-		{ "item10loc", TXTFIELD_CODETOBYTE, 0, 168, &gpDataTables.pBodyLocsLinker },
+		{ "item1loc", TXTFIELD_CODETOBYTE, 0, 96, &sgptDataTables->pBodyLocsLinker },
+		{ "item2loc", TXTFIELD_CODETOBYTE, 0, 104, &sgptDataTables->pBodyLocsLinker },
+		{ "item3loc", TXTFIELD_CODETOBYTE, 0, 112, &sgptDataTables->pBodyLocsLinker },
+		{ "item4loc", TXTFIELD_CODETOBYTE, 0, 120, &sgptDataTables->pBodyLocsLinker },
+		{ "item5loc", TXTFIELD_CODETOBYTE, 0, 128, &sgptDataTables->pBodyLocsLinker },
+		{ "item6loc", TXTFIELD_CODETOBYTE, 0, 136, &sgptDataTables->pBodyLocsLinker },
+		{ "item7loc", TXTFIELD_CODETOBYTE, 0, 144, &sgptDataTables->pBodyLocsLinker },
+		{ "item8loc", TXTFIELD_CODETOBYTE, 0, 152, &sgptDataTables->pBodyLocsLinker },
+		{ "item9loc", TXTFIELD_CODETOBYTE, 0, 160, &sgptDataTables->pBodyLocsLinker },
+		{ "item10loc", TXTFIELD_CODETOBYTE, 0, 168, &sgptDataTables->pBodyLocsLinker },
 		{ "item1", TXTFIELD_RAW, 0, 92, NULL },
 		{ "item1count", TXTFIELD_BYTE, 0, 97, NULL },
 		{ "item2", TXTFIELD_RAW, 0, 100, NULL },
@@ -1205,7 +1205,7 @@ void __fastcall DATATBLS_LoadCharStatsTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pCharStatsTxt = (D2CharStatsTxt*)DATATBLS_CompileTxt(pMemPool, "charstats", pTbl, &gpDataTables.nCharStatsTxtRecordCount, sizeof(D2CharStatsTxt));
+	sgptDataTables->pCharStatsTxt = (D2CharStatsTxt*)DATATBLS_CompileTxt(pMemPool, "charstats", pTbl, &sgptDataTables->nCharStatsTxtRecordCount, sizeof(D2CharStatsTxt));
 
 	DATATBLS_InitUnicodeClassNamesInCharStatsTxt();
 }
@@ -1240,9 +1240,9 @@ void __fastcall DATATBLS_LoadDifficultyLevelsTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pDifficultyLevelsTxt = (D2DifficultyLevelsTxt*)DATATBLS_CompileTxt(pMemPool, "difficultylevels", pTbl, &gpDataTables.nDifficultyLevelsTxtRecordCount, sizeof(D2DifficultyLevelsTxt));
+	sgptDataTables->pDifficultyLevelsTxt = (D2DifficultyLevelsTxt*)DATATBLS_CompileTxt(pMemPool, "difficultylevels", pTbl, &sgptDataTables->nDifficultyLevelsTxtRecordCount, sizeof(D2DifficultyLevelsTxt));
 #define NUM_DIFFICULTY_LEVELS 3
-	D2_ASSERT(gpDataTables.nDifficultyLevelsTxtRecordCount == NUM_DIFFICULTY_LEVELS);
+	D2_ASSERT(sgptDataTables->nDifficultyLevelsTxtRecordCount == NUM_DIFFICULTY_LEVELS);
 }
 
 // FIELD

--- a/source/D2Common/src/DataTbls/FieldTbls.cpp
+++ b/source/D2Common/src/DataTbls/FieldTbls.cpp
@@ -28,19 +28,19 @@ BOOL __stdcall DATATBLS_InitializeCollisionFieldTable(char* pExpField, int nSize
 	DWORD v2 = *(DWORD*)(pExpField + 2);
 	DWORD v3 = *(DWORD*)(pExpField + 6);
 
-	gpDataTables.pFieldData = (char*)FOG_AllocServerMemory(NULL, v2 * v3, __FILE__, __LINE__, 0);
-	D2_ASSERT(gpDataTables.pFieldData);
-	memcpy(gpDataTables.pFieldData, pExpField + 10, v2 * v3);
+	sgptDataTables->pFieldData = (char*)FOG_AllocServerMemory(NULL, v2 * v3, __FILE__, __LINE__, 0);
+	D2_ASSERT(sgptDataTables->pFieldData);
+	memcpy(sgptDataTables->pFieldData, pExpField + 10, v2 * v3);
 
-	gpDataTables.pCollisionField.nWidth = v3;
-	gpDataTables.pCollisionField.nHeight = v2;
-	gpDataTables.pCollisionField.nArea = v2 * v3;
-	gpDataTables.pCollisionField.nCenterX = v3 >> 1;
-	gpDataTables.pCollisionField.nCenterY = v2 >> 1;
+	sgptDataTables->pCollisionField.nWidth = v3;
+	sgptDataTables->pCollisionField.nHeight = v2;
+	sgptDataTables->pCollisionField.nArea = v2 * v3;
+	sgptDataTables->pCollisionField.nCenterX = v3 >> 1;
+	sgptDataTables->pCollisionField.nCenterY = v2 >> 1;
 
 	for (int i = 0; i < ARRAY_SIZE(gnFieldXOffsets); ++i)
 	{
-		gpDataTables.ExpFieldI[i] = gnFieldXOffsets[i] + v3 * gnFieldYOffsets[i];
+		sgptDataTables->ExpFieldI[i] = gnFieldXOffsets[i] + v3 * gnFieldYOffsets[i];
 	}
 
 	FOG_FreeClientMemory(pExpField, __FILE__, __LINE__, 0);
@@ -51,17 +51,17 @@ BOOL __stdcall DATATBLS_InitializeCollisionFieldTable(char* pExpField, int nSize
 //D2Common.0x6FD520F0 (#11090)
 BOOL __stdcall DATATBLS_FreeCollisionFieldTable()
 {
-	if (gpDataTables.pFieldData)
+	if (sgptDataTables->pFieldData)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pFieldData, __FILE__, __LINE__, 0);
+		FOG_FreeServerMemory(NULL, sgptDataTables->pFieldData, __FILE__, __LINE__, 0);
 	}
 
-	gpDataTables.pFieldData = NULL;
-	gpDataTables.pCollisionField.nWidth = 0;
-	gpDataTables.pCollisionField.nHeight = 0;
-	gpDataTables.pCollisionField.nArea = 0;
-	gpDataTables.pCollisionField.nCenterX = 0;
-	gpDataTables.pCollisionField.nCenterY = 0;
+	sgptDataTables->pFieldData = NULL;
+	sgptDataTables->pCollisionField.nWidth = 0;
+	sgptDataTables->pCollisionField.nHeight = 0;
+	sgptDataTables->pCollisionField.nArea = 0;
+	sgptDataTables->pCollisionField.nCenterX = 0;
+	sgptDataTables->pCollisionField.nCenterY = 0;
 
 	return TRUE;
 }
@@ -69,20 +69,20 @@ BOOL __stdcall DATATBLS_FreeCollisionFieldTable()
 //D2Common.0x6FD52140 (#11091)
 void __stdcall DATATBLS_GetCollisionFieldCenter(int* pCenterX, int* pCenterY)
 {
-	*pCenterX = gpDataTables.pCollisionField.nCenterX;
-	*pCenterY = gpDataTables.pCollisionField.nCenterY;
+	*pCenterX = sgptDataTables->pCollisionField.nCenterX;
+	*pCenterY = sgptDataTables->pCollisionField.nCenterY;
 }
 
 //D2Common.0x6FD52160 (#11092)
 int __stdcall DATATBLS_GetCollisionFieldWidth()
 {
-	return gpDataTables.pCollisionField.nWidth;
+	return sgptDataTables->pCollisionField.nWidth;
 }
 
 //D2Common.0x6FD52170 (#11093)
 int __stdcall DATATBLS_GetCollisionFieldHeight()
 {
-	return gpDataTables.pCollisionField.nHeight;
+	return sgptDataTables->pCollisionField.nHeight;
 }
 
 //D2Common.0x6FD52180 (#11094)
@@ -119,7 +119,7 @@ int __stdcall D2Common_11097(D2FieldStrc* pField, int nX, int nY)
 {
 	D2_ASSERT(pField);
 
-	return *(&gpDataTables.pFieldData[((nY - pField->nY) << 8) - pField->nX] + nX);
+	return *(&sgptDataTables->pFieldData[((nY - pField->nY) << 8) - pField->nX] + nX);
 }
 
 //D2Common.0x6FD522A0 (#11098)
@@ -129,12 +129,12 @@ int __stdcall D2Common_11098(D2FieldStrc* pField, int* pX, int* pY)
 	
 	D2_ASSERT(pField);
 
-	nIndex = *(&gpDataTables.pFieldData[((gpDataTables.pCollisionField.nCenterY + *pY - pField->nY) << 8) - pField->nX] + *pX + gpDataTables.pCollisionField.nCenterX);
+	nIndex = *(&sgptDataTables->pFieldData[((sgptDataTables->pCollisionField.nCenterY + *pY - pField->nY) << 8) - pField->nX] + *pX + sgptDataTables->pCollisionField.nCenterX);
 
 	*pX += gnFieldXOffsets[nIndex];
 	*pY += gnFieldYOffsets[nIndex];
 
-	return *(&gpDataTables.pFieldData[((gpDataTables.pCollisionField.nCenterY + *pY - pField->nY) << 8) - pField->nX] + *pX + gpDataTables.pCollisionField.nCenterX) != 8;
+	return *(&sgptDataTables->pFieldData[((sgptDataTables->pCollisionField.nCenterY + *pY - pField->nY) << 8) - pField->nX] + *pX + sgptDataTables->pCollisionField.nCenterX) != 8;
 }
 
 //D2Common.0x6FD52360 (#11099)

--- a/source/D2Common/src/DataTbls/HoradricCube.cpp
+++ b/source/D2Common/src/DataTbls/HoradricCube.cpp
@@ -73,7 +73,7 @@ BOOL __fastcall DATATBLS_CubeMainInputParser(D2CubeInputItem* pCubeInput, char* 
 
 			if (strlen(szInput) <= 4)
 			{
-				nLinkId = FOG_GetLinkIndex(gpDataTables.pItemTypesLinker, DATATBLS_StringToCode(szInput), 0);
+				nLinkId = FOG_GetLinkIndex(sgptDataTables->pItemTypesLinker, DATATBLS_StringToCode(szInput), 0);
 			}
 
 			if (nLinkId >= 0)
@@ -90,14 +90,14 @@ BOOL __fastcall DATATBLS_CubeMainInputParser(D2CubeInputItem* pCubeInput, char* 
 			{
 				nLinkId = -1;
 
-				if (gpDataTables.pUniqueItemsLinker)
+				if (sgptDataTables->pUniqueItemsLinker)
 				{
-					nLinkId = FOG_GetRowFromTxt(gpDataTables.pUniqueItemsLinker, szInput, 0);
+					nLinkId = FOG_GetRowFromTxt(sgptDataTables->pUniqueItemsLinker, szInput, 0);
 				}
 
 				if (nLinkId >= 0)
 				{
-					DATATBLS_GetItemRecordFromItemCode(gpDataTables.pUniqueItemsTxt[nLinkId].dwBaseItemCode, &nBaseItemId);
+					DATATBLS_GetItemRecordFromItemCode(sgptDataTables->pUniqueItemsTxt[nLinkId].dwBaseItemCode, &nBaseItemId);
 					pCubeInput->wInputFlags |= CUBEFLAG_IN_SPECIAL | CUBEFLAG_IN_USEANY;
 					pCubeInput->nQuality = ITEMQUAL_UNIQUE;
 					pCubeInput->wItemID = nLinkId + 1;
@@ -107,14 +107,14 @@ BOOL __fastcall DATATBLS_CubeMainInputParser(D2CubeInputItem* pCubeInput, char* 
 				{
 					nLinkId = -1;
 
-					if (gpDataTables.pSetItemsLinker)
+					if (sgptDataTables->pSetItemsLinker)
 					{
-						nLinkId = FOG_GetRowFromTxt(gpDataTables.pSetItemsLinker, szInput, 0);
+						nLinkId = FOG_GetRowFromTxt(sgptDataTables->pSetItemsLinker, szInput, 0);
 					}
 
 					if (nLinkId >= 0)
 					{
-						DATATBLS_GetItemRecordFromItemCode(gpDataTables.pSetItemsTxt[nLinkId].szItemCode, &nBaseItemId);
+						DATATBLS_GetItemRecordFromItemCode(sgptDataTables->pSetItemsTxt[nLinkId].szItemCode, &nBaseItemId);
 						pCubeInput->wInputFlags |= CUBEFLAG_IN_SPECIAL | CUBEFLAG_IN_USEANY;
 						pCubeInput->nQuality = ITEMQUAL_SET;
 						pCubeInput->wItemID = nLinkId + 1;
@@ -322,7 +322,7 @@ BOOL __fastcall DATATBLS_CubeMainOutputParser(D2CubeOutputItem* pCubeOutputParam
 
 		if (strlen(szOutput) <= 4)
 		{
-			nLinkId = FOG_GetLinkIndex(gpDataTables.pItemTypesLinker, DATATBLS_StringToCode(szOutput), 0);
+			nLinkId = FOG_GetLinkIndex(sgptDataTables->pItemTypesLinker, DATATBLS_StringToCode(szOutput), 0);
 		}
 
 		if (nLinkId >= 0)
@@ -334,39 +334,39 @@ BOOL __fastcall DATATBLS_CubeMainOutputParser(D2CubeOutputItem* pCubeOutputParam
 		{
 			nLinkId = -1;
 
-			if (gpDataTables.pUniqueItemsLinker)
+			if (sgptDataTables->pUniqueItemsLinker)
 			{
-				nLinkId = FOG_GetRowFromTxt(gpDataTables.pUniqueItemsLinker, szOutput, 0);
+				nLinkId = FOG_GetRowFromTxt(sgptDataTables->pUniqueItemsLinker, szOutput, 0);
 			}
 
 			if (nLinkId >= 0)
 			{
-				DATATBLS_GetItemRecordFromItemCode(gpDataTables.pUniqueItemsTxt[nLinkId].dwBaseItemCode, &nBaseItemId);
+				DATATBLS_GetItemRecordFromItemCode(sgptDataTables->pUniqueItemsTxt[nLinkId].dwBaseItemCode, &nBaseItemId);
 				pCubeOutputParam->wItemFlags |= CUBEFLAG_OUT_SPECIAL;
 				pCubeOutputParam->nType = CUBEOP_ITEMCODE;
 				pCubeOutputParam->nQuality = ITEMQUAL_UNIQUE;
 				pCubeOutputParam->wItemID = nLinkId + 1;
 				pCubeOutputParam->wBaseItemId = nBaseItemId;
-				pCubeOutputParam->nILvl = (BYTE)gpDataTables.pUniqueItemsTxt[nLinkId].wLvl;
+				pCubeOutputParam->nILvl = (BYTE)sgptDataTables->pUniqueItemsTxt[nLinkId].wLvl;
 			}
 			else
 			{
 				nLinkId = -1;
 
-				if (gpDataTables.pSetItemsLinker)
+				if (sgptDataTables->pSetItemsLinker)
 				{
-					nLinkId = FOG_GetRowFromTxt(gpDataTables.pSetItemsLinker, szOutput, 0);
+					nLinkId = FOG_GetRowFromTxt(sgptDataTables->pSetItemsLinker, szOutput, 0);
 				}
 
 				if (nLinkId >= 0)
 				{
-					DATATBLS_GetItemRecordFromItemCode(gpDataTables.pSetItemsTxt[nLinkId].szItemCode, &nBaseItemId);
+					DATATBLS_GetItemRecordFromItemCode(sgptDataTables->pSetItemsTxt[nLinkId].szItemCode, &nBaseItemId);
 					pCubeOutputParam->wItemFlags |= CUBEFLAG_OUT_SPECIAL;
 					pCubeOutputParam->nType = CUBEOP_ITEMCODE;
 					pCubeOutputParam->nQuality = ITEMQUAL_SET;
 					pCubeOutputParam->wItemID = nLinkId + 1;
 					pCubeOutputParam->wBaseItemId = nBaseItemId;
-					pCubeOutputParam->nILvl = (BYTE)gpDataTables.pSetItemsTxt[nLinkId].wLvl;
+					pCubeOutputParam->nILvl = (BYTE)sgptDataTables->pSetItemsTxt[nLinkId].wLvl;
 				}
 				else
 				{
@@ -565,9 +565,9 @@ void __fastcall DATATBLS_CubeMainParamLinker(char* pSrc, void* pRecord, int nOff
 		}
 		else
 		{
-			if (gpDataTables.pItemStatCostLinker)
+			if (sgptDataTables->pItemStatCostLinker)
 			{
-				nValue = FOG_GetRowFromTxt(gpDataTables.pItemStatCostLinker, pSrc, 0);
+				nValue = FOG_GetRowFromTxt(sgptDataTables->pItemStatCostLinker, pSrc, 0);
 				if (nValue >= 0)
 				{
 					*(int*)pRecord = nValue;
@@ -595,7 +595,7 @@ void __fastcall DATATBLS_LoadCubeMainTxt(void* pMemPool)
 		{ "op", TXTFIELD_BYTE, 0, 4, NULL },
 		{ "param", TXTFIELD_DWORD, 0, 8, DATATBLS_CubeMainParamLinker },
 		{ "value", TXTFIELD_DWORD, 0, 12, NULL },
-		{ "class", TXTFIELD_CODETOBYTE, 0, 3, &gpDataTables.pPlayerClassLinker },
+		{ "class", TXTFIELD_CODETOBYTE, 0, 3, &sgptDataTables->pPlayerClassLinker },
 		{ "numinputs", TXTFIELD_BYTE, 0, 16, NULL },
 		{ "version", TXTFIELD_WORD, 0, 18, NULL },
 		{ "input 1", TXTFIELD_CUSTOMLINK, 0, 0, DATATBLS_CubeMainInputLinker },
@@ -609,27 +609,27 @@ void __fastcall DATATBLS_LoadCubeMainTxt(void* pMemPool)
 		{ "lvl", TXTFIELD_BYTE, 0, 85, NULL },
 		{ "plvl", TXTFIELD_BYTE, 0, 86, NULL },
 		{ "ilvl", TXTFIELD_BYTE, 0, 87, NULL },
-		{ "mod 1", TXTFIELD_NAMETODWORD, 0, 100, &gpDataTables.pPropertiesLinker },
+		{ "mod 1", TXTFIELD_NAMETODWORD, 0, 100, &sgptDataTables->pPropertiesLinker },
 		{ "mod 1 chance", TXTFIELD_BYTE, 0, 110, NULL },
 		{ "mod 1 param", TXTFIELD_WORD, 0, 104, NULL },
 		{ "mod 1 min", TXTFIELD_WORD, 0, 106, NULL },
 		{ "mod 1 max", TXTFIELD_WORD, 0, 108, NULL },
-		{ "mod 2", TXTFIELD_NAMETODWORD, 0, 112, &gpDataTables.pPropertiesLinker },
+		{ "mod 2", TXTFIELD_NAMETODWORD, 0, 112, &sgptDataTables->pPropertiesLinker },
 		{ "mod 2 chance", TXTFIELD_BYTE, 0, 122, NULL },
 		{ "mod 2 param", TXTFIELD_WORD, 0, 116, NULL },
 		{ "mod 2 min", TXTFIELD_WORD, 0, 118, NULL },
 		{ "mod 2 max", TXTFIELD_WORD, 0, 120, NULL },
-		{ "mod 3", TXTFIELD_NAMETODWORD, 0, 124, &gpDataTables.pPropertiesLinker },
+		{ "mod 3", TXTFIELD_NAMETODWORD, 0, 124, &sgptDataTables->pPropertiesLinker },
 		{ "mod 3 chance", TXTFIELD_BYTE, 0, 134, NULL },
 		{ "mod 3 param", TXTFIELD_WORD, 0, 128, NULL },
 		{ "mod 3 min", TXTFIELD_WORD, 0, 130, NULL },
 		{ "mod 3 max", TXTFIELD_WORD, 0, 132, NULL },
-		{ "mod 4", TXTFIELD_NAMETODWORD, 0, 136, &gpDataTables.pPropertiesLinker },
+		{ "mod 4", TXTFIELD_NAMETODWORD, 0, 136, &sgptDataTables->pPropertiesLinker },
 		{ "mod 4 chance", TXTFIELD_BYTE, 0, 146, NULL },
 		{ "mod 4 param", TXTFIELD_WORD, 0, 140, NULL },
 		{ "mod 4 min", TXTFIELD_WORD, 0, 142, NULL },
 		{ "mod 4 max", TXTFIELD_WORD, 0, 144, NULL },
-		{ "mod 5", TXTFIELD_NAMETODWORD, 0, 148, &gpDataTables.pPropertiesLinker },
+		{ "mod 5", TXTFIELD_NAMETODWORD, 0, 148, &sgptDataTables->pPropertiesLinker },
 		{ "mod 5 chance", TXTFIELD_BYTE, 0, 158, NULL },
 		{ "mod 5 param", TXTFIELD_WORD, 0, 152, NULL },
 		{ "mod 5 min", TXTFIELD_WORD, 0, 154, NULL },
@@ -638,27 +638,27 @@ void __fastcall DATATBLS_LoadCubeMainTxt(void* pMemPool)
 		{ "b lvl", TXTFIELD_BYTE, 0, 169, NULL },
 		{ "b plvl", TXTFIELD_BYTE, 0, 170, NULL },
 		{ "b ilvl", TXTFIELD_BYTE, 0, 171, NULL },
-		{ "b mod 1", TXTFIELD_NAMETODWORD, 0, 184, &gpDataTables.pPropertiesLinker },
+		{ "b mod 1", TXTFIELD_NAMETODWORD, 0, 184, &sgptDataTables->pPropertiesLinker },
 		{ "b mod 1 chance", TXTFIELD_BYTE, 0, 194, NULL },
 		{ "b mod 1 param", TXTFIELD_WORD, 0, 188, NULL },
 		{ "b mod 1 min", TXTFIELD_WORD, 0, 190, NULL },
 		{ "b mod 1 max", TXTFIELD_WORD, 0, 192, NULL },
-		{ "b mod 2", TXTFIELD_NAMETODWORD, 0, 196, &gpDataTables.pPropertiesLinker },
+		{ "b mod 2", TXTFIELD_NAMETODWORD, 0, 196, &sgptDataTables->pPropertiesLinker },
 		{ "b mod 2 chance", TXTFIELD_BYTE, 0, 206, NULL },
 		{ "b mod 2 param", TXTFIELD_WORD, 0, 200, NULL },
 		{ "b mod 2 min", TXTFIELD_WORD, 0, 202, NULL },
 		{ "b mod 2 max", TXTFIELD_WORD, 0, 204, NULL },
-		{ "b mod 3", TXTFIELD_NAMETODWORD, 0, 208, &gpDataTables.pPropertiesLinker },
+		{ "b mod 3", TXTFIELD_NAMETODWORD, 0, 208, &sgptDataTables->pPropertiesLinker },
 		{ "b mod 3 chance", TXTFIELD_BYTE, 0, 218, NULL },
 		{ "b mod 3 param", TXTFIELD_WORD, 0, 212, NULL },
 		{ "b mod 3 min", TXTFIELD_WORD, 0, 214, NULL },
 		{ "b mod 3 max", TXTFIELD_WORD, 0, 216, NULL },
-		{ "b mod 4", TXTFIELD_NAMETODWORD, 0, 220, &gpDataTables.pPropertiesLinker },
+		{ "b mod 4", TXTFIELD_NAMETODWORD, 0, 220, &sgptDataTables->pPropertiesLinker },
 		{ "b mod 4 chance", TXTFIELD_BYTE, 0, 230, NULL },
 		{ "b mod 4 param", TXTFIELD_WORD, 0, 224, NULL },
 		{ "b mod 4 min", TXTFIELD_WORD, 0, 226, NULL },
 		{ "b mod 4 max", TXTFIELD_WORD, 0, 228, NULL },
-		{ "b mod 5", TXTFIELD_NAMETODWORD, 0, 232, &gpDataTables.pPropertiesLinker },
+		{ "b mod 5", TXTFIELD_NAMETODWORD, 0, 232, &sgptDataTables->pPropertiesLinker },
 		{ "b mod 5 chance", TXTFIELD_BYTE, 0, 242, NULL },
 		{ "b mod 5 param", TXTFIELD_WORD, 0, 236, NULL },
 		{ "b mod 5 min", TXTFIELD_WORD, 0, 238, NULL },
@@ -667,27 +667,27 @@ void __fastcall DATATBLS_LoadCubeMainTxt(void* pMemPool)
 		{ "c lvl", TXTFIELD_BYTE, 0, 253, NULL },
 		{ "c plvl", TXTFIELD_BYTE, 0, 254, NULL },
 		{ "c ilvl", TXTFIELD_BYTE, 0, 255, NULL },
-		{ "c mod 1", TXTFIELD_NAMETODWORD, 0, 268, &gpDataTables.pPropertiesLinker },
+		{ "c mod 1", TXTFIELD_NAMETODWORD, 0, 268, &sgptDataTables->pPropertiesLinker },
 		{ "c mod 1 chance", TXTFIELD_BYTE, 0, 278, NULL },
 		{ "c mod 1 param", TXTFIELD_WORD, 0, 272, NULL },
 		{ "c mod 1 min", TXTFIELD_WORD, 0, 274, NULL },
 		{ "c mod 1 max", TXTFIELD_WORD, 0, 276, NULL },
-		{ "c mod 2", TXTFIELD_NAMETODWORD, 0, 280, &gpDataTables.pPropertiesLinker },
+		{ "c mod 2", TXTFIELD_NAMETODWORD, 0, 280, &sgptDataTables->pPropertiesLinker },
 		{ "c mod 2 chance", TXTFIELD_BYTE, 0, 290, NULL },
 		{ "c mod 2 param", TXTFIELD_WORD, 0, 284, NULL },
 		{ "c mod 2 min", TXTFIELD_WORD, 0, 286, NULL },
 		{ "c mod 2 max", TXTFIELD_WORD, 0, 288, NULL },
-		{ "c mod 3", TXTFIELD_NAMETODWORD, 0, 292, &gpDataTables.pPropertiesLinker },
+		{ "c mod 3", TXTFIELD_NAMETODWORD, 0, 292, &sgptDataTables->pPropertiesLinker },
 		{ "c mod 3 chance", TXTFIELD_BYTE, 0, 302, NULL },
 		{ "c mod 3 param", TXTFIELD_WORD, 0, 296, NULL },
 		{ "c mod 3 min", TXTFIELD_WORD, 0, 298, NULL },
 		{ "c mod 3 max", TXTFIELD_WORD, 0, 300, NULL },
-		{ "c mod 4", TXTFIELD_NAMETODWORD, 0, 304, &gpDataTables.pPropertiesLinker },
+		{ "c mod 4", TXTFIELD_NAMETODWORD, 0, 304, &sgptDataTables->pPropertiesLinker },
 		{ "c mod 4 chance", TXTFIELD_BYTE, 0, 314, NULL },
 		{ "c mod 4 param", TXTFIELD_WORD, 0, 308, NULL },
 		{ "c mod 4 min", TXTFIELD_WORD, 0, 310, NULL },
 		{ "c mod 4 max", TXTFIELD_WORD, 0, 312, NULL },
-		{ "c mod 5", TXTFIELD_NAMETODWORD, 0, 316, &gpDataTables.pPropertiesLinker },
+		{ "c mod 5", TXTFIELD_NAMETODWORD, 0, 316, &sgptDataTables->pPropertiesLinker },
 		{ "c mod 5 chance", TXTFIELD_BYTE, 0, 326, NULL },
 		{ "c mod 5 param", TXTFIELD_WORD, 0, 320, NULL },
 		{ "c mod 5 min", TXTFIELD_WORD, 0, 322, NULL },
@@ -707,27 +707,27 @@ void __fastcall DATATBLS_LoadCubeMainTxt(void* pMemPool)
 		FOG_10025("Found cubeserver.txt in data path.  This file should only be on the server\n", __FILE__, __LINE__);
 	}
 
-	gpDataTables.pCubeMainTxt = (D2CubeMainTxt*)DATATBLS_CompileTxt(pMemPool, "cubemain", pTbl, &gpDataTables.nCubeMainTxtRecordCount, sizeof(D2CubeMainTxt));
+	sgptDataTables->pCubeMainTxt = (D2CubeMainTxt*)DATATBLS_CompileTxt(pMemPool, "cubemain", pTbl, &sgptDataTables->nCubeMainTxtRecordCount, sizeof(D2CubeMainTxt));
 }
 
 //D2Common.0x6FD54250
 void __fastcall DATATBLS_UnloadCubeMainTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pCubeMainTxt);
-	gpDataTables.pCubeMainTxt = NULL;
+	DATATBLS_UnloadBin(sgptDataTables->pCubeMainTxt);
+	sgptDataTables->pCubeMainTxt = NULL;
 }
 
 //D2Common.0x6FD54260 (#11232)
 D2CubeMainTxt* __stdcall DATATBLS_GetCubemainTxtRecord(int nIndex)
 {
-	D2_ASSERT(gpDataTables.pCubeMainTxt);
-	D2_ASSERT(nIndex < gpDataTables.nCubeMainTxtRecordCount);
+	D2_ASSERT(sgptDataTables->pCubeMainTxt);
+	D2_ASSERT(nIndex < sgptDataTables->nCubeMainTxtRecordCount);
 
-	return &gpDataTables.pCubeMainTxt[nIndex];
+	return &sgptDataTables->pCubeMainTxt[nIndex];
 }
 
 //D2Common.0x6FD542C0 (#11233)
 int __fastcall DATATBLS_GetCubemainTxtRecordCount()
 {
-	return gpDataTables.nCubeMainTxtRecordCount;
+	return sgptDataTables->nCubeMainTxtRecordCount;
 }

--- a/source/D2Common/src/DataTbls/ItemsTbls.cpp
+++ b/source/D2Common/src/DataTbls/ItemsTbls.cpp
@@ -83,26 +83,26 @@ void __fastcall DATATBLS_LoadInventoryTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pInventoryTxt = (D2InventoryTxt*)DATATBLS_CompileTxt(pMemPool, "inventory", pTbl, &gpDataTables.nInventoryTxtRecordCount, sizeof(D2InventoryTxt));
+	sgptDataTables->pInventoryTxt = (D2InventoryTxt*)DATATBLS_CompileTxt(pMemPool, "inventory", pTbl, &sgptDataTables->nInventoryTxtRecordCount, sizeof(D2InventoryTxt));
 #define NUM_INVENTORY_PAGE_STATS 16
-	D2_ASSERT(gpDataTables.nInventoryTxtRecordCount == NUM_INVENTORY_PAGE_STATS * NUM_GAME_RESOLUTIONS);
+	D2_ASSERT(sgptDataTables->nInventoryTxtRecordCount == NUM_INVENTORY_PAGE_STATS * NUM_GAME_RESOLUTIONS);
 }
 
 //D2Common.0x6FD54F10
 void __fastcall DATATBLS_UnloadInventoryTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pInventoryTxt);
+	DATATBLS_UnloadBin(sgptDataTables->pInventoryTxt);
 }
 
 //D2Common.0x6FD54F20 (#10635)
 void __stdcall DATATBLS_GetInventoryRect(int nInventoryTxtId, int bHigherRes, D2InvRectStrc* pInvRect)
 {
 
-	D2_ASSERT(gpDataTables.pInventoryTxt);
+	D2_ASSERT(sgptDataTables->pInventoryTxt);
 
 	const int nIndex = nInventoryTxtId + 16 * bHigherRes;
-	D2_ASSERT(nIndex < gpDataTables.nInventoryTxtRecordCount);
-	const D2InventoryTxt* pInventoryTxtRecord = &gpDataTables.pInventoryTxt[nIndex];
+	D2_ASSERT(nIndex < sgptDataTables->nInventoryTxtRecordCount);
+	const D2InventoryTxt* pInventoryTxtRecord = &sgptDataTables->pInventoryTxt[nIndex];
 	D2_ASSERT(pInventoryTxtRecord);
 
 	pInvRect->nLeft = pInventoryTxtRecord->pRect.nLeft;
@@ -117,9 +117,9 @@ void __stdcall DATATBLS_GetInventoryGridInfo(int nInventoryTxtId, int bHigherRes
 	D2InventoryTxt* pInventoryTxtRecord = NULL;
 	int nIndex = nInventoryTxtId + 16 * bHigherRes;
 
-	D2_ASSERT(gpDataTables.pInventoryTxt);
-	D2_ASSERT(nIndex < gpDataTables.nInventoryTxtRecordCount);
-	pInventoryTxtRecord = &gpDataTables.pInventoryTxt[nIndex];
+	D2_ASSERT(sgptDataTables->pInventoryTxt);
+	D2_ASSERT(nIndex < sgptDataTables->nInventoryTxtRecordCount);
+	pInventoryTxtRecord = &sgptDataTables->pInventoryTxt[nIndex];
 	D2_ASSERT(pInventoryTxtRecord);
 
 	memcpy(pInventoryGridInfo, &pInventoryTxtRecord->pGridInfo, sizeof(D2InventoryGridInfoStrc));
@@ -130,10 +130,10 @@ void __stdcall DATATBLS_GetInventoryComponentGrid(int nInventoryTxtId, int bHigh
 {
 	int nIndex = nInventoryTxtId + 16 * bHigherRes;
 
-	D2_ASSERT(gpDataTables.pInventoryTxt);
-	D2_ASSERT(nIndex < gpDataTables.nInventoryTxtRecordCount);
+	D2_ASSERT(sgptDataTables->pInventoryTxt);
+	D2_ASSERT(nIndex < sgptDataTables->nInventoryTxtRecordCount);
 
-	const D2InventoryTxt* pInventoryTxtRecord = &gpDataTables.pInventoryTxt[nIndex];
+	const D2InventoryTxt* pInventoryTxtRecord = &sgptDataTables->pInventoryTxt[nIndex];
 	D2_ASSERT(pInventoryTxtRecord);
 
 	const D2InvCompGridStrc* ptBodyStats = &pInventoryTxtRecord->pComponents[nComponent];
@@ -181,9 +181,9 @@ int __fastcall sub_6FD55150(char* szText, int* a2, int a3, int nKeywordNumber)
 
 	if (a3 == 1 && nKeywordNumber == 3)
 	{
-		if (gpDataTables.pItemStatCostLinker)
+		if (sgptDataTables->pItemStatCostLinker)
 		{
-			nRow = FOG_GetRowFromTxt(gpDataTables.pItemStatCostLinker, szText, 0);
+			nRow = FOG_GetRowFromTxt(sgptDataTables->pItemStatCostLinker, szText, 0);
 			if (nRow >= 0)
 			{
 				*a2 = 1;
@@ -223,7 +223,7 @@ void __fastcall DATATBLS_ItemCalcLinker(char* pSrc, void* pRecord, int nOffset, 
 			nBufferSize = FOG_10254(pSrc, pBuffer, sizeof(pBuffer), DATATBLS_MapItemsTxtKeywordToNumber, DATATBLS_Return2, sub_6FD55150);
 			if (nBufferSize > 0)
 			{
-				*(DWORD*)((char*)pRecord + nOffset) = DATATBLS_AppendMemoryBuffer(&gpDataTables.pItemsCode, (int*)&gpDataTables.nItemsCodeSize, &gpDataTables.nItemsCodeSizeEx, pBuffer, nBufferSize);
+				*(DWORD*)((char*)pRecord + nOffset) = DATATBLS_AppendMemoryBuffer(&sgptDataTables->pItemsCode, (int*)&sgptDataTables->nItemsCodeSize, &sgptDataTables->nItemsCodeSizeEx, pBuffer, nBufferSize);
 			}
 			else
 			{
@@ -248,13 +248,13 @@ void __fastcall DATATBLS_LoadItemsTxt(void* pMemPool)
 
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 128, &gpDataTables.pItemsLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 128, &sgptDataTables->pItemsLinker },
 		{ "namestr", TXTFIELD_KEYTOWORD, 0, 244, DATATBLS_GetStringIdFromReferenceString },
 		{ "version", TXTFIELD_WORD, 0, 246, NULL },
 		{ "compactsave", TXTFIELD_UNKNOWN2, 0, 323, NULL },
-		{ "type", TXTFIELD_CODETOWORD, 0, 286, &gpDataTables.pItemTypesLinker },
-		{ "type2", TXTFIELD_CODETOWORD, 0, 288, &gpDataTables.pItemTypesLinker },
-		{ "hit class", TXTFIELD_CODETOBYTE, 0, 316, &gpDataTables.pHitClassLinker },
+		{ "type", TXTFIELD_CODETOWORD, 0, 286, &sgptDataTables->pItemTypesLinker },
+		{ "type2", TXTFIELD_CODETOWORD, 0, 288, &sgptDataTables->pItemTypesLinker },
+		{ "hit class", TXTFIELD_CODETOBYTE, 0, 316, &sgptDataTables->pHitClassLinker },
 		{ "gemapplytype", TXTFIELD_BYTE, 0, 318, NULL },
 		{ "levelreq", TXTFIELD_BYTE, 0, 319, NULL },
 		{ "magic lvl", TXTFIELD_BYTE, 0, 320, NULL },
@@ -311,9 +311,9 @@ void __fastcall DATATBLS_LoadItemsTxt(void* pMemPool)
 		{ "2handed", TXTFIELD_UNKNOWN2, 0, 284, NULL },
 		{ "useable", TXTFIELD_BYTE, 0, 285, NULL },
 		{ "subtype", TXTFIELD_UNKNOWN2, 0, 290, NULL },
-		{ "dropsound", TXTFIELD_NAMETOWORD, 0, 292, &gpDataTables.pSoundsLinker },
+		{ "dropsound", TXTFIELD_NAMETOWORD, 0, 292, &sgptDataTables->pSoundsLinker },
 		{ "dropsfxframe", TXTFIELD_BYTE, 0, 296, NULL },
-		{ "usesound", TXTFIELD_NAMETOWORD, 0, 294, &gpDataTables.pSoundsLinker },
+		{ "usesound", TXTFIELD_NAMETOWORD, 0, 294, &sgptDataTables->pSoundsLinker },
 		{ "unique", TXTFIELD_BYTE, 0, 297, NULL },
 		{ "quest", TXTFIELD_BYTE, 0, 298, NULL },
 		{ "questdiffcheck", TXTFIELD_BYTE, 0, 299, NULL },
@@ -330,15 +330,15 @@ void __fastcall DATATBLS_LoadItemsTxt(void* pMemPool)
 		{ "gemsockets", TXTFIELD_UNKNOWN2, 0, 312, NULL },
 		{ "gemoffset", TXTFIELD_DWORD, 0, 240, NULL },
 		{ "pSpell", TXTFIELD_DWORD, 0, 148, NULL },
-		{ "state", TXTFIELD_NAMETOWORD, 0, 152, &gpDataTables.pStatesLinker },
-		{ "cstate1", TXTFIELD_NAMETOWORD, 0, 154, &gpDataTables.pStatesLinker },
-		{ "cstate2", TXTFIELD_NAMETOWORD, 0, 156, &gpDataTables.pStatesLinker },
+		{ "state", TXTFIELD_NAMETOWORD, 0, 152, &sgptDataTables->pStatesLinker },
+		{ "cstate1", TXTFIELD_NAMETOWORD, 0, 154, &sgptDataTables->pStatesLinker },
+		{ "cstate2", TXTFIELD_NAMETOWORD, 0, 156, &sgptDataTables->pStatesLinker },
 		{ "len", TXTFIELD_CALCTODWORD, 0, 176, DATATBLS_ItemCalcLinker },
-		{ "stat1", TXTFIELD_NAMETOWORD, 0, 158, &gpDataTables.pItemStatCostLinker },
+		{ "stat1", TXTFIELD_NAMETOWORD, 0, 158, &sgptDataTables->pItemStatCostLinker },
 		{ "calc1", TXTFIELD_CALCTODWORD, 0, 164, DATATBLS_ItemCalcLinker },
-		{ "stat2", TXTFIELD_NAMETOWORD, 0, 160, &gpDataTables.pItemStatCostLinker },
+		{ "stat2", TXTFIELD_NAMETOWORD, 0, 160, &sgptDataTables->pItemStatCostLinker },
 		{ "calc2", TXTFIELD_CALCTODWORD, 0, 168, DATATBLS_ItemCalcLinker },
-		{ "stat3", TXTFIELD_NAMETOWORD, 0, 162, &gpDataTables.pItemStatCostLinker },
+		{ "stat3", TXTFIELD_NAMETOWORD, 0, 162, &sgptDataTables->pItemStatCostLinker },
 		{ "calc3", TXTFIELD_CALCTODWORD, 0, 172, DATATBLS_ItemCalcLinker },
 		{ "spelldesc", TXTFIELD_BYTE, 0, 180, NULL },
 		{ "spelldescstr", TXTFIELD_KEYTOWORD, 0, 182, DATATBLS_GetStringIdFromReferenceString },
@@ -445,47 +445,47 @@ void __fastcall DATATBLS_LoadItemsTxt(void* pMemPool)
 	};
 
 
-	gpDataTables.pItemsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	pWeapons = (D2ItemsTxt*)DATATBLS_CompileTxt(pMemPool, "weapons", pTbl, &gpDataTables.pItemDataTables.nWeaponsTxtRecordCount, sizeof(D2ItemsTxt));
-	pArmor = (D2ItemsTxt*)DATATBLS_CompileTxt(pMemPool, "armor", pTbl, &gpDataTables.pItemDataTables.nArmorTxtRecordCount, sizeof(D2ItemsTxt));
-	pMisc = (D2ItemsTxt*)DATATBLS_CompileTxt(pMemPool, "misc", pTbl, &gpDataTables.pItemDataTables.nMiscTxtRecordCount, sizeof(D2ItemsTxt));
+	sgptDataTables->pItemsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	pWeapons = (D2ItemsTxt*)DATATBLS_CompileTxt(pMemPool, "weapons", pTbl, &sgptDataTables->pItemDataTables.nWeaponsTxtRecordCount, sizeof(D2ItemsTxt));
+	pArmor = (D2ItemsTxt*)DATATBLS_CompileTxt(pMemPool, "armor", pTbl, &sgptDataTables->pItemDataTables.nArmorTxtRecordCount, sizeof(D2ItemsTxt));
+	pMisc = (D2ItemsTxt*)DATATBLS_CompileTxt(pMemPool, "misc", pTbl, &sgptDataTables->pItemDataTables.nMiscTxtRecordCount, sizeof(D2ItemsTxt));
 
-	gpDataTables.pItemDataTables.nItemsTxtRecordCount = gpDataTables.pItemDataTables.nWeaponsTxtRecordCount + gpDataTables.pItemDataTables.nMiscTxtRecordCount + gpDataTables.pItemDataTables.nArmorTxtRecordCount;
-	pItems = (D2ItemsTxt*)FOG_AllocServerMemory(NULL, sizeof(D2ItemsTxt) * gpDataTables.pItemDataTables.nItemsTxtRecordCount, __FILE__, __LINE__, 0);
+	sgptDataTables->pItemDataTables.nItemsTxtRecordCount = sgptDataTables->pItemDataTables.nWeaponsTxtRecordCount + sgptDataTables->pItemDataTables.nMiscTxtRecordCount + sgptDataTables->pItemDataTables.nArmorTxtRecordCount;
+	pItems = (D2ItemsTxt*)FOG_AllocServerMemory(NULL, sizeof(D2ItemsTxt) * sgptDataTables->pItemDataTables.nItemsTxtRecordCount, __FILE__, __LINE__, 0);
 
-	gpDataTables.pItemDataTables.pItemsTxt = pItems;
+	sgptDataTables->pItemDataTables.pItemsTxt = pItems;
 
-	gpDataTables.pItemDataTables.pWeapons = pItems;
-	gpDataTables.pItemDataTables.pArmor = &gpDataTables.pItemDataTables.pWeapons[gpDataTables.pItemDataTables.nWeaponsTxtRecordCount];
-	gpDataTables.pItemDataTables.pMisc = &gpDataTables.pItemDataTables.pArmor[gpDataTables.pItemDataTables.nArmorTxtRecordCount];
+	sgptDataTables->pItemDataTables.pWeapons = pItems;
+	sgptDataTables->pItemDataTables.pArmor = &sgptDataTables->pItemDataTables.pWeapons[sgptDataTables->pItemDataTables.nWeaponsTxtRecordCount];
+	sgptDataTables->pItemDataTables.pMisc = &sgptDataTables->pItemDataTables.pArmor[sgptDataTables->pItemDataTables.nArmorTxtRecordCount];
 
-	memcpy(gpDataTables.pItemDataTables.pWeapons, pWeapons, sizeof(D2ItemsTxt) * gpDataTables.pItemDataTables.nWeaponsTxtRecordCount);
-	memcpy(gpDataTables.pItemDataTables.pArmor, pArmor, sizeof(D2ItemsTxt) * gpDataTables.pItemDataTables.nArmorTxtRecordCount);
-	memcpy(gpDataTables.pItemDataTables.pMisc, pMisc, sizeof(D2ItemsTxt) * gpDataTables.pItemDataTables.nMiscTxtRecordCount);
+	memcpy(sgptDataTables->pItemDataTables.pWeapons, pWeapons, sizeof(D2ItemsTxt) * sgptDataTables->pItemDataTables.nWeaponsTxtRecordCount);
+	memcpy(sgptDataTables->pItemDataTables.pArmor, pArmor, sizeof(D2ItemsTxt) * sgptDataTables->pItemDataTables.nArmorTxtRecordCount);
+	memcpy(sgptDataTables->pItemDataTables.pMisc, pMisc, sizeof(D2ItemsTxt) * sgptDataTables->pItemDataTables.nMiscTxtRecordCount);
 
 	DATATBLS_UnloadBin(pWeapons);
 	DATATBLS_UnloadBin(pArmor);
 	DATATBLS_UnloadBin(pMisc);
 
-	DATATBLS_GetBinFileHandle(pMemPool, "itemscode", (void**)&gpDataTables.pItemsCode, (int*)&gpDataTables.nItemsCodeSize, &gpDataTables.nItemsCodeSizeEx);
+	DATATBLS_GetBinFileHandle(pMemPool, "itemscode", (void**)&sgptDataTables->pItemsCode, (int*)&sgptDataTables->nItemsCodeSize, &sgptDataTables->nItemsCodeSizeEx);
 
-	if (!gpDataTables.bCompileTxt)
+	if (!sgptDataTables->bCompileTxt)
 	{
-		for (int i = 0; i < gpDataTables.pItemDataTables.nItemsTxtRecordCount; ++i)
+		for (int i = 0; i < sgptDataTables->pItemDataTables.nItemsTxtRecordCount; ++i)
 		{
-			FOG_10215(gpDataTables.pItemsLinker, gpDataTables.pItemDataTables.pItemsTxt[i].dwCode);
+			FOG_10215(sgptDataTables->pItemsLinker, sgptDataTables->pItemDataTables.pItemsTxt[i].dwCode);
 		}
 	}
 
-	gpDataTables.pIndexOldToCurrent = (WORD*)FOG_AllocServerMemory(NULL, sizeof(WORD) * gpDataTables.pItemDataTables.nItemsTxtRecordCount, __FILE__, __LINE__, 0);
-	memset(gpDataTables.pIndexOldToCurrent, 0x00, sizeof(WORD) * gpDataTables.pItemDataTables.nItemsTxtRecordCount);
+	sgptDataTables->pIndexOldToCurrent = (WORD*)FOG_AllocServerMemory(NULL, sizeof(WORD) * sgptDataTables->pItemDataTables.nItemsTxtRecordCount, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->pIndexOldToCurrent, 0x00, sizeof(WORD) * sgptDataTables->pItemDataTables.nItemsTxtRecordCount);
 
 	nOldCounter = 0;
-	for (int i = 0; i < gpDataTables.pItemDataTables.nItemsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->pItemDataTables.nItemsTxtRecordCount; ++i)
 	{
-		if (!gpDataTables.pItemDataTables.pItemsTxt[i].wVersion)
+		if (!sgptDataTables->pItemDataTables.pItemsTxt[i].wVersion)
 		{
-			gpDataTables.pIndexOldToCurrent[nOldCounter] = i;
+			sgptDataTables->pIndexOldToCurrent[nOldCounter] = i;
 			++nOldCounter;
 		}
 	}
@@ -494,36 +494,36 @@ void __fastcall DATATBLS_LoadItemsTxt(void* pMemPool)
 //D2Common.0x6FD575D0
 void __fastcall DATATBLS_UnloadItemsTxt()
 {
-	FOG_FreeLinker(gpDataTables.pItemsLinker);
+	FOG_FreeLinker(sgptDataTables->pItemsLinker);
 
-	if (gpDataTables.pItemDataTables.pItemsTxt)
+	if (sgptDataTables->pItemDataTables.pItemsTxt)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pItemDataTables.pItemsTxt, __FILE__, __LINE__, 0);
+		FOG_FreeServerMemory(NULL, sgptDataTables->pItemDataTables.pItemsTxt, __FILE__, __LINE__, 0);
 	}
 
-	if (gpDataTables.pIndexOldToCurrent)
+	if (sgptDataTables->pIndexOldToCurrent)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pIndexOldToCurrent, __FILE__, __LINE__, 0);
+		FOG_FreeServerMemory(NULL, sgptDataTables->pIndexOldToCurrent, __FILE__, __LINE__, 0);
 	}
 
-	gpDataTables.pItemDataTables.pItemsTxt = NULL;
+	sgptDataTables->pItemDataTables.pItemsTxt = NULL;
 }
 
 //D2Common.0x6FD57620 (#10599)
 D2ItemDataTbl* __stdcall DATATBLS_GetItemDataTables()
 {
-	return &gpDataTables.pItemDataTables;
+	return &sgptDataTables->pItemDataTables;
 }
 
 //D2Common.0x6FD57630 (#10597)
 int __stdcall DATATBLS_MapOldItemIndexToCurrent(int nItemId)
 {
-	if (nItemId < gpDataTables.pItemDataTables.nItemsTxtRecordCount)
+	if (nItemId < sgptDataTables->pItemDataTables.nItemsTxtRecordCount)
 	{
 		if (nItemId >= 0)
 		{
-			D2_ASSERT(gpDataTables.pIndexOldToCurrent);
-			return gpDataTables.pIndexOldToCurrent[nItemId];
+			D2_ASSERT(sgptDataTables->pIndexOldToCurrent);
+			return sgptDataTables->pIndexOldToCurrent[nItemId];
 		}
 	}
 
@@ -533,10 +533,10 @@ int __stdcall DATATBLS_MapOldItemIndexToCurrent(int nItemId)
 //D2Common.0x6FD57680 (#10600)
 D2ItemsTxt* __stdcall DATATBLS_GetItemsTxtRecord(int nItemId)
 {
-	if (nItemId < gpDataTables.pItemDataTables.nItemsTxtRecordCount)
+	if (nItemId < sgptDataTables->pItemDataTables.nItemsTxtRecordCount)
 	{
-		D2_ASSERT(gpDataTables.pItemDataTables.pItemsTxt);
-		return &gpDataTables.pItemDataTables.pItemsTxt[nItemId];
+		D2_ASSERT(sgptDataTables->pItemDataTables.pItemsTxt);
+		return &sgptDataTables->pItemDataTables.pItemsTxt[nItemId];
 	}
 
 	return NULL;
@@ -545,10 +545,10 @@ D2ItemsTxt* __stdcall DATATBLS_GetItemsTxtRecord(int nItemId)
 //D2Common.0x6FD576D0 (#10601)
 D2ItemsTxt* __stdcall DATATBLS_GetItemRecordFromItemCode(DWORD dwCode, int* pItemId)
 {
-	*pItemId = FOG_GetLinkIndex(gpDataTables.pItemsLinker, dwCode, 0);
+	*pItemId = FOG_GetLinkIndex(sgptDataTables->pItemsLinker, dwCode, 0);
 	if (*pItemId >= 0)
 	{
-		return &gpDataTables.pItemDataTables.pItemsTxt[*pItemId];
+		return &sgptDataTables->pItemDataTables.pItemsTxt[*pItemId];
 	}
 	
 	*pItemId = 0;
@@ -558,7 +558,7 @@ D2ItemsTxt* __stdcall DATATBLS_GetItemRecordFromItemCode(DWORD dwCode, int* pIte
 //D2Common.0x6FD57720 (#10602)
 int __stdcall DATATBLS_GetItemIdFromItemCode(DWORD dwCode)
 {
-	return FOG_GetLinkIndex(gpDataTables.pItemsLinker, dwCode, 0);
+	return FOG_GetLinkIndex(sgptDataTables->pItemsLinker, dwCode, 0);
 }
 
 //D2Common.0x6FD57740
@@ -576,9 +576,9 @@ void __fastcall DATATBLS_ItemParamLinker(char* pSrc, void* pRecord, int nOffset,
 			}
 			else
 			{
-				if (gpDataTables.pSkillsLinker)
+				if (sgptDataTables->pSkillsLinker)
 				{
-					nRow = FOG_GetRowFromTxt(gpDataTables.pSkillsLinker, pSrc, 0);
+					nRow = FOG_GetRowFromTxt(sgptDataTables->pSkillsLinker, pSrc, 0);
 					if (nRow >= 0)
 					{
 						*(DWORD*)((char*)pRecord + nOffset) = nRow;
@@ -586,9 +586,9 @@ void __fastcall DATATBLS_ItemParamLinker(char* pSrc, void* pRecord, int nOffset,
 					}
 				}
 
-				if (gpDataTables.pMonTypeLinker)
+				if (sgptDataTables->pMonTypeLinker)
 				{
-					nRow = FOG_GetRowFromTxt(gpDataTables.pMonTypeLinker, pSrc, 0);
+					nRow = FOG_GetRowFromTxt(sgptDataTables->pMonTypeLinker, pSrc, 0);
 					if (nRow >= 0)
 					{
 						*(DWORD*)((char*)pRecord + nOffset) = nRow;
@@ -596,9 +596,9 @@ void __fastcall DATATBLS_ItemParamLinker(char* pSrc, void* pRecord, int nOffset,
 					}
 				}
 
-				if (gpDataTables.pStatesLinker)
+				if (sgptDataTables->pStatesLinker)
 				{
-					nRow = FOG_GetRowFromTxt(gpDataTables.pStatesLinker, pSrc, 0);
+					nRow = FOG_GetRowFromTxt(sgptDataTables->pStatesLinker, pSrc, 0);
 					if (nRow >= 0)
 					{
 						*(DWORD*)((char*)pRecord + nOffset) = nRow;
@@ -643,32 +643,32 @@ void __fastcall DATATBLS_LoadMagicSuffix_Prefix_AutomagicTxt(void* pMemPool)
 		{ "rare", TXTFIELD_BYTE, 0, 100, NULL },
 		{ "maxlevel", TXTFIELD_DWORD, 0, 96, NULL },
 		{ "levelreq", TXTFIELD_BYTE, 0, 101, NULL },
-		{ "classspecific", TXTFIELD_CODETOBYTE, 0, 102, &gpDataTables.pPlayerClassLinker },
-		{ "class", TXTFIELD_CODETOBYTE, 0, 103, &gpDataTables.pPlayerClassLinker },
+		{ "classspecific", TXTFIELD_CODETOBYTE, 0, 102, &sgptDataTables->pPlayerClassLinker },
+		{ "class", TXTFIELD_CODETOBYTE, 0, 103, &sgptDataTables->pPlayerClassLinker },
 		{ "classlevelreq", TXTFIELD_BYTE, 0, 104, NULL },
-		{ "itype1", TXTFIELD_CODETOWORD, 0, 106, &gpDataTables.pItemTypesLinker },
-		{ "itype2", TXTFIELD_CODETOWORD, 0, 108, &gpDataTables.pItemTypesLinker },
-		{ "itype3", TXTFIELD_CODETOWORD, 0, 110, &gpDataTables.pItemTypesLinker },
-		{ "itype4", TXTFIELD_CODETOWORD, 0, 112, &gpDataTables.pItemTypesLinker },
-		{ "itype5", TXTFIELD_CODETOWORD, 0, 114, &gpDataTables.pItemTypesLinker },
-		{ "itype6", TXTFIELD_CODETOWORD, 0, 116, &gpDataTables.pItemTypesLinker },
-		{ "itype7", TXTFIELD_CODETOWORD, 0, 118, &gpDataTables.pItemTypesLinker },
-		{ "etype1", TXTFIELD_CODETOWORD, 0, 120, &gpDataTables.pItemTypesLinker },
-		{ "etype2", TXTFIELD_CODETOWORD, 0, 122, &gpDataTables.pItemTypesLinker },
-		{ "etype3", TXTFIELD_CODETOWORD, 0, 124, &gpDataTables.pItemTypesLinker },
-		{ "etype4", TXTFIELD_CODETOWORD, 0, 126, &gpDataTables.pItemTypesLinker },
-		{ "etype5", TXTFIELD_CODETOWORD, 0, 128, &gpDataTables.pItemTypesLinker },
-		{ "transformcolor", TXTFIELD_CODETOBYTE, 0, 86, &gpDataTables.pColorsLinker },
+		{ "itype1", TXTFIELD_CODETOWORD, 0, 106, &sgptDataTables->pItemTypesLinker },
+		{ "itype2", TXTFIELD_CODETOWORD, 0, 108, &sgptDataTables->pItemTypesLinker },
+		{ "itype3", TXTFIELD_CODETOWORD, 0, 110, &sgptDataTables->pItemTypesLinker },
+		{ "itype4", TXTFIELD_CODETOWORD, 0, 112, &sgptDataTables->pItemTypesLinker },
+		{ "itype5", TXTFIELD_CODETOWORD, 0, 114, &sgptDataTables->pItemTypesLinker },
+		{ "itype6", TXTFIELD_CODETOWORD, 0, 116, &sgptDataTables->pItemTypesLinker },
+		{ "itype7", TXTFIELD_CODETOWORD, 0, 118, &sgptDataTables->pItemTypesLinker },
+		{ "etype1", TXTFIELD_CODETOWORD, 0, 120, &sgptDataTables->pItemTypesLinker },
+		{ "etype2", TXTFIELD_CODETOWORD, 0, 122, &sgptDataTables->pItemTypesLinker },
+		{ "etype3", TXTFIELD_CODETOWORD, 0, 124, &sgptDataTables->pItemTypesLinker },
+		{ "etype4", TXTFIELD_CODETOWORD, 0, 126, &sgptDataTables->pItemTypesLinker },
+		{ "etype5", TXTFIELD_CODETOWORD, 0, 128, &sgptDataTables->pItemTypesLinker },
+		{ "transformcolor", TXTFIELD_CODETOBYTE, 0, 86, &sgptDataTables->pColorsLinker },
 		{ "frequency", TXTFIELD_BYTE, 0, 130, NULL },
-		{ "mod1code", TXTFIELD_NAMETODWORD, 0, 36, &gpDataTables.pPropertiesLinker },
+		{ "mod1code", TXTFIELD_NAMETODWORD, 0, 36, &sgptDataTables->pPropertiesLinker },
 		{ "mod1param", TXTFIELD_CALCTODWORD, 0, 40, DATATBLS_ItemParamLinker },
 		{ "mod1min", TXTFIELD_DWORD, 0, 44, NULL },
 		{ "mod1max", TXTFIELD_DWORD, 0, 48, NULL },
-		{ "mod2code", TXTFIELD_NAMETODWORD, 0, 52, &gpDataTables.pPropertiesLinker },
+		{ "mod2code", TXTFIELD_NAMETODWORD, 0, 52, &sgptDataTables->pPropertiesLinker },
 		{ "mod2param", TXTFIELD_CALCTODWORD, 0, 56, DATATBLS_ItemParamLinker },
 		{ "mod2min", TXTFIELD_DWORD, 0, 60, NULL },
 		{ "mod2max", TXTFIELD_DWORD, 0, 64, NULL },
-		{ "mod3code", TXTFIELD_NAMETODWORD, 0, 68, &gpDataTables.pPropertiesLinker },
+		{ "mod3code", TXTFIELD_NAMETODWORD, 0, 68, &sgptDataTables->pPropertiesLinker },
 		{ "mod3param", TXTFIELD_CALCTODWORD, 0, 72, DATATBLS_ItemParamLinker },
 		{ "mod3min", TXTFIELD_DWORD, 0, 76, NULL },
 		{ "mod3max", TXTFIELD_DWORD, 0, 80, NULL },
@@ -679,52 +679,52 @@ void __fastcall DATATBLS_LoadMagicSuffix_Prefix_AutomagicTxt(void* pMemPool)
 	pMagicPrefix = (D2MagicAffixTxt*)DATATBLS_CompileTxt(pMemPool, "magicprefix", pTbl, &nPrefixRecords, sizeof(D2MagicAffixTxt));
 	pAutoMagic = (D2MagicAffixTxt*)DATATBLS_CompileTxt(pMemPool, "automagic", pTbl, &nAutoMagicRecords, sizeof(D2MagicAffixTxt));
 
-	gpDataTables.pMagicAffixDataTables.nMagicAffixTxtRecordCount = nSuffixRecords + nAutoMagicRecords + nPrefixRecords;
-	gpDataTables.pMagicAffixDataTables.pMagicAffixTxt = (D2MagicAffixTxt *)FOG_AllocServerMemory(NULL, sizeof(D2MagicAffixTxt) * gpDataTables.pMagicAffixDataTables.nMagicAffixTxtRecordCount, __FILE__, __LINE__, 0);
-	gpDataTables.pMagicAffixDataTables.pMagicSuffix = gpDataTables.pMagicAffixDataTables.pMagicAffixTxt;
-	memcpy(gpDataTables.pMagicAffixDataTables.pMagicAffixTxt, pMagicSuffix, sizeof(D2MagicAffixTxt) * nSuffixRecords);
-	gpDataTables.pMagicAffixDataTables.pMagicPrefix = &gpDataTables.pMagicAffixDataTables.pMagicSuffix[nSuffixRecords];
-	memcpy(&gpDataTables.pMagicAffixDataTables.pMagicSuffix[nSuffixRecords], pMagicPrefix, sizeof(D2MagicAffixTxt) * nPrefixRecords);
-	gpDataTables.pMagicAffixDataTables.pAutoMagic = &gpDataTables.pMagicAffixDataTables.pMagicPrefix[nPrefixRecords];
-	memcpy(&gpDataTables.pMagicAffixDataTables.pMagicPrefix[nPrefixRecords], pAutoMagic, sizeof(D2MagicAffixTxt) * nAutoMagicRecords);
+	sgptDataTables->pMagicAffixDataTables.nMagicAffixTxtRecordCount = nSuffixRecords + nAutoMagicRecords + nPrefixRecords;
+	sgptDataTables->pMagicAffixDataTables.pMagicAffixTxt = (D2MagicAffixTxt *)FOG_AllocServerMemory(NULL, sizeof(D2MagicAffixTxt) * sgptDataTables->pMagicAffixDataTables.nMagicAffixTxtRecordCount, __FILE__, __LINE__, 0);
+	sgptDataTables->pMagicAffixDataTables.pMagicSuffix = sgptDataTables->pMagicAffixDataTables.pMagicAffixTxt;
+	memcpy(sgptDataTables->pMagicAffixDataTables.pMagicAffixTxt, pMagicSuffix, sizeof(D2MagicAffixTxt) * nSuffixRecords);
+	sgptDataTables->pMagicAffixDataTables.pMagicPrefix = &sgptDataTables->pMagicAffixDataTables.pMagicSuffix[nSuffixRecords];
+	memcpy(&sgptDataTables->pMagicAffixDataTables.pMagicSuffix[nSuffixRecords], pMagicPrefix, sizeof(D2MagicAffixTxt) * nPrefixRecords);
+	sgptDataTables->pMagicAffixDataTables.pAutoMagic = &sgptDataTables->pMagicAffixDataTables.pMagicPrefix[nPrefixRecords];
+	memcpy(&sgptDataTables->pMagicAffixDataTables.pMagicPrefix[nPrefixRecords], pAutoMagic, sizeof(D2MagicAffixTxt) * nAutoMagicRecords);
 
 	DATATBLS_UnloadBin(pMagicSuffix);
 	DATATBLS_UnloadBin(pMagicPrefix);
 	DATATBLS_UnloadBin(pAutoMagic);
 
-	for (int i = 0; i < gpDataTables.pMagicAffixDataTables.nMagicAffixTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->pMagicAffixDataTables.nMagicAffixTxtRecordCount; ++i)
 	{
-		gpDataTables.pMagicAffixDataTables.pMagicAffixTxt[i].wTblIndex = D2LANG_GetTblIndex(gpDataTables.pMagicAffixDataTables.pMagicAffixTxt[i].szName, &pUnicode);
+		sgptDataTables->pMagicAffixDataTables.pMagicAffixTxt[i].wTblIndex = D2LANG_GetTblIndex(sgptDataTables->pMagicAffixDataTables.pMagicAffixTxt[i].szName, &pUnicode);
 	}
 }
 
 //D2Common.0x6FD58080
 void __fastcall DATATBLS_UnloadMagicSuffix_Prefix_AutomagicTxt()
 {
-	if (gpDataTables.pMagicAffixDataTables.pMagicAffixTxt)
+	if (sgptDataTables->pMagicAffixDataTables.pMagicAffixTxt)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pMagicAffixDataTables.pMagicAffixTxt, __FILE__, __LINE__, 0);
+		FOG_FreeServerMemory(NULL, sgptDataTables->pMagicAffixDataTables.pMagicAffixTxt, __FILE__, __LINE__, 0);
 	}
-	gpDataTables.pMagicAffixDataTables.pMagicAffixTxt = NULL;
+	sgptDataTables->pMagicAffixDataTables.pMagicAffixTxt = NULL;
 }
 
 //D2Common.0x6FD580B0 (#10603)
 D2MagicAffixDataTbl* __stdcall DATATBLS_GetMagicAffixDataTables()
 {
-	return &gpDataTables.pMagicAffixDataTables;
+	return &sgptDataTables->pMagicAffixDataTables;
 }
 
 //D2Common.0x6FD580C0 (#10604)
 D2MagicAffixTxt* __stdcall DATATBLS_GetMagicAffixTxtRecord(int nIndex)
 {
-	D2_ASSERT(gpDataTables.pMagicAffixDataTables.pMagicAffixTxt);
-	if (nIndex > gpDataTables.pMagicAffixDataTables.nMagicAffixTxtRecordCount || nIndex <= 0)
+	D2_ASSERT(sgptDataTables->pMagicAffixDataTables.pMagicAffixTxt);
+	if (nIndex > sgptDataTables->pMagicAffixDataTables.nMagicAffixTxtRecordCount || nIndex <= 0)
 	{
 		return NULL;
 	}
 	else
 	{
-		return &gpDataTables.pMagicAffixDataTables.pMagicAffixTxt[nIndex - 1];
+		return &sgptDataTables->pMagicAffixDataTables.pMagicAffixTxt[nIndex - 1];
 	}
 }
 
@@ -743,68 +743,68 @@ void __fastcall DATATBLS_LoadRareSuffix_PrefixTxt(void* pMemPool)
 	{
 		{ "name", TXTFIELD_ASCII, 31, 38, NULL },
 		{ "version", TXTFIELD_WORD, 0, 14, NULL },
-		{ "itype1", TXTFIELD_CODETOWORD, 0, 16, &gpDataTables.pItemTypesLinker },
-		{ "itype2", TXTFIELD_CODETOWORD, 0, 18, &gpDataTables.pItemTypesLinker },
-		{ "itype3", TXTFIELD_CODETOWORD, 0, 20, &gpDataTables.pItemTypesLinker },
-		{ "itype4", TXTFIELD_CODETOWORD, 0, 22, &gpDataTables.pItemTypesLinker },
-		{ "itype5", TXTFIELD_CODETOWORD, 0, 24, &gpDataTables.pItemTypesLinker },
-		{ "itype6", TXTFIELD_CODETOWORD, 0, 26, &gpDataTables.pItemTypesLinker },
-		{ "itype7", TXTFIELD_CODETOWORD, 0, 28, &gpDataTables.pItemTypesLinker },
-		{ "etype1", TXTFIELD_CODETOWORD, 0, 30, &gpDataTables.pItemTypesLinker },
-		{ "etype2", TXTFIELD_CODETOWORD, 0, 32, &gpDataTables.pItemTypesLinker },
-		{ "etype3", TXTFIELD_CODETOWORD, 0, 34, &gpDataTables.pItemTypesLinker },
-		{ "etype4", TXTFIELD_CODETOWORD, 0, 36, &gpDataTables.pItemTypesLinker },
+		{ "itype1", TXTFIELD_CODETOWORD, 0, 16, &sgptDataTables->pItemTypesLinker },
+		{ "itype2", TXTFIELD_CODETOWORD, 0, 18, &sgptDataTables->pItemTypesLinker },
+		{ "itype3", TXTFIELD_CODETOWORD, 0, 20, &sgptDataTables->pItemTypesLinker },
+		{ "itype4", TXTFIELD_CODETOWORD, 0, 22, &sgptDataTables->pItemTypesLinker },
+		{ "itype5", TXTFIELD_CODETOWORD, 0, 24, &sgptDataTables->pItemTypesLinker },
+		{ "itype6", TXTFIELD_CODETOWORD, 0, 26, &sgptDataTables->pItemTypesLinker },
+		{ "itype7", TXTFIELD_CODETOWORD, 0, 28, &sgptDataTables->pItemTypesLinker },
+		{ "etype1", TXTFIELD_CODETOWORD, 0, 30, &sgptDataTables->pItemTypesLinker },
+		{ "etype2", TXTFIELD_CODETOWORD, 0, 32, &sgptDataTables->pItemTypesLinker },
+		{ "etype3", TXTFIELD_CODETOWORD, 0, 34, &sgptDataTables->pItemTypesLinker },
+		{ "etype4", TXTFIELD_CODETOWORD, 0, 36, &sgptDataTables->pItemTypesLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 
 	pRareSuffix = (D2RareAffixTxt*)DATATBLS_CompileTxt(pMemPool, "raresuffix", pTbl, &nSuffixRecords, sizeof(D2RareAffixTxt));
 	pRarePrefix = (D2RareAffixTxt*)DATATBLS_CompileTxt(pMemPool, "rareprefix", pTbl, &nPrefixRecords, sizeof(D2RareAffixTxt));
 
-	gpDataTables.pRareAffixDataTables.nRareAffixTxtRecordCount = nPrefixRecords + nSuffixRecords;
+	sgptDataTables->pRareAffixDataTables.nRareAffixTxtRecordCount = nPrefixRecords + nSuffixRecords;
 
-	gpDataTables.pRareAffixDataTables.pRareAffixTxt = (D2RareAffixTxt*)FOG_AllocServerMemory(NULL, sizeof(D2RareAffixTxt) * (nPrefixRecords + nSuffixRecords), __FILE__, __LINE__, 0);
+	sgptDataTables->pRareAffixDataTables.pRareAffixTxt = (D2RareAffixTxt*)FOG_AllocServerMemory(NULL, sizeof(D2RareAffixTxt) * (nPrefixRecords + nSuffixRecords), __FILE__, __LINE__, 0);
 
-	gpDataTables.pRareAffixDataTables.pRareSuffix = gpDataTables.pRareAffixDataTables.pRareAffixTxt;
-	memcpy(gpDataTables.pRareAffixDataTables.pRareAffixTxt, pRareSuffix, sizeof(D2RareAffixTxt) * nSuffixRecords);
-	gpDataTables.pRareAffixDataTables.pRarePrefix = &gpDataTables.pRareAffixDataTables.pRareSuffix[nSuffixRecords];
-	memcpy(&gpDataTables.pRareAffixDataTables.pRareSuffix[nSuffixRecords], pRarePrefix, sizeof(D2RareAffixTxt) * nPrefixRecords);
+	sgptDataTables->pRareAffixDataTables.pRareSuffix = sgptDataTables->pRareAffixDataTables.pRareAffixTxt;
+	memcpy(sgptDataTables->pRareAffixDataTables.pRareAffixTxt, pRareSuffix, sizeof(D2RareAffixTxt) * nSuffixRecords);
+	sgptDataTables->pRareAffixDataTables.pRarePrefix = &sgptDataTables->pRareAffixDataTables.pRareSuffix[nSuffixRecords];
+	memcpy(&sgptDataTables->pRareAffixDataTables.pRareSuffix[nSuffixRecords], pRarePrefix, sizeof(D2RareAffixTxt) * nPrefixRecords);
 
 	DATATBLS_UnloadBin(pRarePrefix);
 	DATATBLS_UnloadBin(pRareSuffix);
 
-	for (int i = 0; i < gpDataTables.pRareAffixDataTables.nRareAffixTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->pRareAffixDataTables.nRareAffixTxtRecordCount; ++i)
 	{
-		gpDataTables.pRareAffixDataTables.pRareAffixTxt[i].wStringId = D2LANG_GetTblIndex(gpDataTables.pRareAffixDataTables.pRareAffixTxt[i].szName, &pUnicode);
+		sgptDataTables->pRareAffixDataTables.pRareAffixTxt[i].wStringId = D2LANG_GetTblIndex(sgptDataTables->pRareAffixDataTables.pRareAffixTxt[i].szName, &pUnicode);
 	}
 }
 
 //D2Common.0x6FD58450
 void __fastcall DATATBLS_UnloadRareSuffix_PrefixTxt()
 {
-	if (gpDataTables.pRareAffixDataTables.pRareAffixTxt)
+	if (sgptDataTables->pRareAffixDataTables.pRareAffixTxt)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pRareAffixDataTables.pRareAffixTxt, __FILE__, __LINE__, 0);
+		FOG_FreeServerMemory(NULL, sgptDataTables->pRareAffixDataTables.pRareAffixTxt, __FILE__, __LINE__, 0);
 	}
-	gpDataTables.pRareAffixDataTables.pRareAffixTxt = NULL;
+	sgptDataTables->pRareAffixDataTables.pRareAffixTxt = NULL;
 }
 
 //D2Common.0x6FD58480 (#10605)
 D2RareAffixDataTbl* __fastcall DATATBLS_GetRareAffixDataTables()
 {
-	return &gpDataTables.pRareAffixDataTables;
+	return &sgptDataTables->pRareAffixDataTables;
 }
 
 //D2Common.0x6FD58490 (#10606)
 D2RareAffixTxt* __stdcall DATATBLS_GetRareAffixTxtRecord(int nId)
 {
-	if (nId > gpDataTables.pRareAffixDataTables.nRareAffixTxtRecordCount || nId <= 0)
+	if (nId > sgptDataTables->pRareAffixDataTables.nRareAffixTxtRecordCount || nId <= 0)
 	{
 		return NULL;
 	}
 	else
 	{
-		D2_ASSERT(gpDataTables.pRareAffixDataTables.pRareAffixTxt);
-		return &gpDataTables.pRareAffixDataTables.pRareAffixTxt[nId - 1];
+		D2_ASSERT(sgptDataTables->pRareAffixDataTables.pRareAffixTxt);
+		return &sgptDataTables->pRareAffixDataTables.pRareAffixTxt[nId - 1];
 	}
 }
 
@@ -825,83 +825,83 @@ void __fastcall DATATBLS_LoadUniqueItemsTxt(void* pMemPool)
 		{ "lvl req", TXTFIELD_WORD, 0, 54, NULL },
 		{ "nolimit", TXTFIELD_BIT, 1, 44, NULL },
 		{ "carry1", TXTFIELD_BIT, 2, 44, NULL },
-		{ "chrtransform", TXTFIELD_CODETOBYTE, 0, 56, &gpDataTables.pColorsLinker },
-		{ "invtransform", TXTFIELD_CODETOBYTE, 0, 57, &gpDataTables.pColorsLinker },
+		{ "chrtransform", TXTFIELD_CODETOBYTE, 0, 56, &sgptDataTables->pColorsLinker },
+		{ "invtransform", TXTFIELD_CODETOBYTE, 0, 57, &sgptDataTables->pColorsLinker },
 		{ "flippyfile", TXTFIELD_ASCII, 31, 58, NULL },
 		{ "invfile", TXTFIELD_ASCII, 31, 90, NULL },
 		{ "cost mult", TXTFIELD_DWORD, 0, 124, NULL },
 		{ "cost add", TXTFIELD_DWORD, 0, 128, NULL },
-		{ "dropsound", TXTFIELD_NAMETOWORD, 0, 132, &gpDataTables.pSoundsLinker },
+		{ "dropsound", TXTFIELD_NAMETOWORD, 0, 132, &sgptDataTables->pSoundsLinker },
 		{ "dropsfxframe", TXTFIELD_BYTE, 0, 136, NULL },
-		{ "usesound", TXTFIELD_NAMETOWORD, 0, 134, &gpDataTables.pSoundsLinker },
-		{ "prop1", TXTFIELD_NAMETODWORD, 0, 140, &gpDataTables.pPropertiesLinker },
+		{ "usesound", TXTFIELD_NAMETOWORD, 0, 134, &sgptDataTables->pSoundsLinker },
+		{ "prop1", TXTFIELD_NAMETODWORD, 0, 140, &sgptDataTables->pPropertiesLinker },
 		{ "par1", TXTFIELD_CALCTODWORD, 0, 144, DATATBLS_ItemParamLinker },
 		{ "min1", TXTFIELD_DWORD, 0, 148, NULL },
 		{ "max1", TXTFIELD_DWORD, 0, 152, NULL },
-		{ "prop2", TXTFIELD_NAMETODWORD, 0, 156, &gpDataTables.pPropertiesLinker },
+		{ "prop2", TXTFIELD_NAMETODWORD, 0, 156, &sgptDataTables->pPropertiesLinker },
 		{ "par2", TXTFIELD_CALCTODWORD, 0, 160, DATATBLS_ItemParamLinker },
 		{ "min2", TXTFIELD_DWORD, 0, 164, NULL },
 		{ "max2", TXTFIELD_DWORD, 0, 168, NULL },
-		{ "prop3", TXTFIELD_NAMETODWORD, 0, 172, &gpDataTables.pPropertiesLinker },
+		{ "prop3", TXTFIELD_NAMETODWORD, 0, 172, &sgptDataTables->pPropertiesLinker },
 		{ "par3", TXTFIELD_CALCTODWORD, 0, 176, DATATBLS_ItemParamLinker },
 		{ "min3", TXTFIELD_DWORD, 0, 180, NULL },
 		{ "max3", TXTFIELD_DWORD, 0, 184, NULL },
-		{ "prop4", TXTFIELD_NAMETODWORD, 0, 188, &gpDataTables.pPropertiesLinker },
+		{ "prop4", TXTFIELD_NAMETODWORD, 0, 188, &sgptDataTables->pPropertiesLinker },
 		{ "par4", TXTFIELD_CALCTODWORD, 0, 192, DATATBLS_ItemParamLinker },
 		{ "min4", TXTFIELD_DWORD, 0, 196, NULL },
 		{ "max4", TXTFIELD_DWORD, 0, 200, NULL },
-		{ "prop5", TXTFIELD_NAMETODWORD, 0, 204, &gpDataTables.pPropertiesLinker },
+		{ "prop5", TXTFIELD_NAMETODWORD, 0, 204, &sgptDataTables->pPropertiesLinker },
 		{ "par5", TXTFIELD_CALCTODWORD, 0, 208, DATATBLS_ItemParamLinker },
 		{ "min5", TXTFIELD_DWORD, 0, 212, NULL },
 		{ "max5", TXTFIELD_DWORD, 0, 216, NULL },
-		{ "prop6", TXTFIELD_NAMETODWORD, 0, 220, &gpDataTables.pPropertiesLinker },
+		{ "prop6", TXTFIELD_NAMETODWORD, 0, 220, &sgptDataTables->pPropertiesLinker },
 		{ "par6", TXTFIELD_CALCTODWORD, 0, 224, DATATBLS_ItemParamLinker },
 		{ "min6", TXTFIELD_DWORD, 0, 228, NULL },
 		{ "max6", TXTFIELD_DWORD, 0, 232, NULL },
-		{ "prop7", TXTFIELD_NAMETODWORD, 0, 236, &gpDataTables.pPropertiesLinker },
+		{ "prop7", TXTFIELD_NAMETODWORD, 0, 236, &sgptDataTables->pPropertiesLinker },
 		{ "par7", TXTFIELD_CALCTODWORD, 0, 240, DATATBLS_ItemParamLinker },
 		{ "min7", TXTFIELD_DWORD, 0, 244, NULL },
 		{ "max7", TXTFIELD_DWORD, 0, 248, NULL },
-		{ "prop8", TXTFIELD_NAMETODWORD, 0, 252, &gpDataTables.pPropertiesLinker },
+		{ "prop8", TXTFIELD_NAMETODWORD, 0, 252, &sgptDataTables->pPropertiesLinker },
 		{ "par8", TXTFIELD_CALCTODWORD, 0, 256, DATATBLS_ItemParamLinker },
 		{ "min8", TXTFIELD_DWORD, 0, 260, NULL },
 		{ "max8", TXTFIELD_DWORD, 0, 264, NULL },
-		{ "prop9", TXTFIELD_NAMETODWORD, 0, 268, &gpDataTables.pPropertiesLinker },
+		{ "prop9", TXTFIELD_NAMETODWORD, 0, 268, &sgptDataTables->pPropertiesLinker },
 		{ "par9", TXTFIELD_CALCTODWORD, 0, 272, DATATBLS_ItemParamLinker },
 		{ "min9", TXTFIELD_DWORD, 0, 276, NULL },
 		{ "max9", TXTFIELD_DWORD, 0, 280, NULL },
-		{ "prop10", TXTFIELD_NAMETODWORD, 0, 284, &gpDataTables.pPropertiesLinker },
+		{ "prop10", TXTFIELD_NAMETODWORD, 0, 284, &sgptDataTables->pPropertiesLinker },
 		{ "par10", TXTFIELD_CALCTODWORD, 0, 288, DATATBLS_ItemParamLinker },
 		{ "min10", TXTFIELD_DWORD, 0, 292, NULL },
 		{ "max10", TXTFIELD_DWORD, 0, 296, NULL },
-		{ "prop11", TXTFIELD_NAMETODWORD, 0, 300, &gpDataTables.pPropertiesLinker },
+		{ "prop11", TXTFIELD_NAMETODWORD, 0, 300, &sgptDataTables->pPropertiesLinker },
 		{ "par11", TXTFIELD_CALCTODWORD, 0, 304, DATATBLS_ItemParamLinker },
 		{ "min11", TXTFIELD_DWORD, 0, 308, NULL },
 		{ "max11", TXTFIELD_DWORD, 0, 312, NULL },
-		{ "prop12", TXTFIELD_NAMETODWORD, 0, 316, &gpDataTables.pPropertiesLinker },
+		{ "prop12", TXTFIELD_NAMETODWORD, 0, 316, &sgptDataTables->pPropertiesLinker },
 		{ "par12", TXTFIELD_CALCTODWORD, 0, 320, DATATBLS_ItemParamLinker },
 		{ "min12", TXTFIELD_DWORD, 0, 324, NULL },
 		{ "max12", TXTFIELD_DWORD, 0, 328, NULL },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pUniqueItemsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pUniqueItemsTxt = (D2UniqueItemsTxt*)DATATBLS_CompileTxt(pMemPool, "uniqueitems", pTbl, &gpDataTables.nUniqueItemsTxtRecordCount, sizeof(D2UniqueItemsTxt));
+	sgptDataTables->pUniqueItemsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pUniqueItemsTxt = (D2UniqueItemsTxt*)DATATBLS_CompileTxt(pMemPool, "uniqueitems", pTbl, &sgptDataTables->nUniqueItemsTxtRecordCount, sizeof(D2UniqueItemsTxt));
 
-	if (gpDataTables.nUniqueItemsTxtRecordCount >= 32767)
+	if (sgptDataTables->nUniqueItemsTxtRecordCount >= 32767)
 	{
 		FOG_10025("uniqueitems table exceeded maximum number of entries.", __FILE__, __LINE__);
 	}
 
-	for (int i = 0; i < gpDataTables.nUniqueItemsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nUniqueItemsTxtRecordCount; ++i)
 	{
-		gpDataTables.pUniqueItemsTxt[i].wId = i;
-		FOG_10216_AddRecordToLinkingTable(gpDataTables.pUniqueItemsLinker, gpDataTables.pUniqueItemsTxt[i].szName);
+		sgptDataTables->pUniqueItemsTxt[i].wId = i;
+		FOG_10216_AddRecordToLinkingTable(sgptDataTables->pUniqueItemsLinker, sgptDataTables->pUniqueItemsTxt[i].szName);
 
-		gpDataTables.pUniqueItemsTxt[i].wTblIndex = D2LANG_GetTblIndex(gpDataTables.pUniqueItemsTxt[i].szName, &pUnicode);
-		if (gpDataTables.pUniqueItemsTxt[i].wTblIndex == 0)
+		sgptDataTables->pUniqueItemsTxt[i].wTblIndex = D2LANG_GetTblIndex(sgptDataTables->pUniqueItemsTxt[i].szName, &pUnicode);
+		if (sgptDataTables->pUniqueItemsTxt[i].wTblIndex == 0)
 		{
-			gpDataTables.pUniqueItemsTxt[i].wTblIndex = 5383;
+			sgptDataTables->pUniqueItemsTxt[i].wTblIndex = 5383;
 		}
 	}
 }
@@ -909,9 +909,9 @@ void __fastcall DATATBLS_LoadUniqueItemsTxt(void* pMemPool)
 //D2Common.0x6FD59110
 void __fastcall DATATBLS_UnloadUniqueItemsTxt()
 {
-	FOG_FreeLinker(gpDataTables.pUniqueItemsLinker);
-	DATATBLS_UnloadBin(gpDataTables.pUniqueItemsTxt);
-	gpDataTables.nUniqueItemsTxtRecordCount = 0;
+	FOG_FreeLinker(sgptDataTables->pUniqueItemsLinker);
+	DATATBLS_UnloadBin(sgptDataTables->pUniqueItemsTxt);
+	sgptDataTables->nUniqueItemsTxtRecordCount = 0;
 }
 
 //D2Common.0x6FD59140
@@ -922,70 +922,70 @@ void __fastcall DATATBLS_LoadSets_SetItemsTxt(void* pMemPool)
 
 	D2BinFieldStrc pSetsTbl[] =
 	{
-		{ "index", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pSetsLinker },
+		{ "index", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pSetsLinker },
 		{ "name", TXTFIELD_KEYTOWORD, 0, TXTFIELD_DWORD, DATATBLS_GetStringIdFromReferenceString },
 		{ "version", TXTFIELD_WORD, 0, 4, NULL },
-		{ "pcode2a", TXTFIELD_NAMETODWORD, 0, 16, &gpDataTables.pPropertiesLinker },
+		{ "pcode2a", TXTFIELD_NAMETODWORD, 0, 16, &sgptDataTables->pPropertiesLinker },
 		{ "pparam2a", TXTFIELD_CALCTODWORD, 0, 20, DATATBLS_ItemParamLinker },
 		{ "pmin2a", TXTFIELD_DWORD, 0, 24, NULL },
 		{ "pmax2a", TXTFIELD_DWORD, 0, 28, NULL },
-		{ "pcode2b", TXTFIELD_NAMETODWORD, 0, 32, &gpDataTables.pPropertiesLinker },
+		{ "pcode2b", TXTFIELD_NAMETODWORD, 0, 32, &sgptDataTables->pPropertiesLinker },
 		{ "pparam2b", TXTFIELD_CALCTODWORD, 0, 36, DATATBLS_ItemParamLinker },
 		{ "pmin2b", TXTFIELD_DWORD, 0, 40, NULL },
 		{ "pmax2b", TXTFIELD_DWORD, 0, 44, NULL },
-		{ "pcode3a", TXTFIELD_NAMETODWORD, 0, 48, &gpDataTables.pPropertiesLinker },
+		{ "pcode3a", TXTFIELD_NAMETODWORD, 0, 48, &sgptDataTables->pPropertiesLinker },
 		{ "pparam3a", TXTFIELD_CALCTODWORD, 0, 52, DATATBLS_ItemParamLinker },
 		{ "pmin3a", TXTFIELD_DWORD, 0, 56, NULL },
 		{ "pmax3a", TXTFIELD_DWORD, 0, 60, NULL },
-		{ "pcode3b", TXTFIELD_NAMETODWORD, 0, 64, &gpDataTables.pPropertiesLinker },
+		{ "pcode3b", TXTFIELD_NAMETODWORD, 0, 64, &sgptDataTables->pPropertiesLinker },
 		{ "pparam3b", TXTFIELD_CALCTODWORD, 0, 68, DATATBLS_ItemParamLinker },
 		{ "pmin3b", TXTFIELD_DWORD, 0, 72, NULL },
 		{ "pmax3b", TXTFIELD_DWORD, 0, 76, NULL },
-		{ "pcode4a", TXTFIELD_NAMETODWORD, 0, 80, &gpDataTables.pPropertiesLinker },
+		{ "pcode4a", TXTFIELD_NAMETODWORD, 0, 80, &sgptDataTables->pPropertiesLinker },
 		{ "pparam4a", TXTFIELD_CALCTODWORD, 0, 84, DATATBLS_ItemParamLinker },
 		{ "pmin4a", TXTFIELD_DWORD, 0, 88, NULL },
 		{ "pmax4a", TXTFIELD_DWORD, 0, 92, NULL },
-		{ "pcode4b", TXTFIELD_NAMETODWORD, 0, 96, &gpDataTables.pPropertiesLinker },
+		{ "pcode4b", TXTFIELD_NAMETODWORD, 0, 96, &sgptDataTables->pPropertiesLinker },
 		{ "pparam4b", TXTFIELD_CALCTODWORD, 0, 100, DATATBLS_ItemParamLinker },
 		{ "pmin4b", TXTFIELD_DWORD, 0, 104, NULL },
 		{ "pmax4b", TXTFIELD_DWORD, 0, 108, NULL },
-		{ "pcode5a", TXTFIELD_NAMETODWORD, 0, 112, &gpDataTables.pPropertiesLinker },
+		{ "pcode5a", TXTFIELD_NAMETODWORD, 0, 112, &sgptDataTables->pPropertiesLinker },
 		{ "pparam5a", TXTFIELD_CALCTODWORD, 0, 116, DATATBLS_ItemParamLinker },
 		{ "pmin5a", TXTFIELD_DWORD, 0, 120, NULL },
 		{ "pmax5a", TXTFIELD_DWORD, 0, 124, NULL },
-		{ "pcode5b", TXTFIELD_NAMETODWORD, 0, 128, &gpDataTables.pPropertiesLinker },
+		{ "pcode5b", TXTFIELD_NAMETODWORD, 0, 128, &sgptDataTables->pPropertiesLinker },
 		{ "pparam5b", TXTFIELD_CALCTODWORD, 0, 132, DATATBLS_ItemParamLinker },
 		{ "pmin5b", TXTFIELD_DWORD, 0, 136, NULL },
 		{ "pmax5b", TXTFIELD_DWORD, 0, 140, NULL },
-		{ "fcode1", TXTFIELD_NAMETODWORD, 0, 144, &gpDataTables.pPropertiesLinker },
+		{ "fcode1", TXTFIELD_NAMETODWORD, 0, 144, &sgptDataTables->pPropertiesLinker },
 		{ "fparam1", TXTFIELD_CALCTODWORD, 0, 148, DATATBLS_ItemParamLinker },
 		{ "fmin1", TXTFIELD_DWORD, 0, 152, NULL },
 		{ "fmax1", TXTFIELD_DWORD, 0, 156, NULL },
-		{ "fcode2", TXTFIELD_NAMETODWORD, 0, 160, &gpDataTables.pPropertiesLinker },
+		{ "fcode2", TXTFIELD_NAMETODWORD, 0, 160, &sgptDataTables->pPropertiesLinker },
 		{ "fparam2", TXTFIELD_CALCTODWORD, 0, 164, DATATBLS_ItemParamLinker },
 		{ "fmin2", TXTFIELD_DWORD, 0, 168, NULL },
 		{ "fmax2", TXTFIELD_DWORD, 0, 172, NULL },
-		{ "fcode3", TXTFIELD_NAMETODWORD, 0, 176, &gpDataTables.pPropertiesLinker },
+		{ "fcode3", TXTFIELD_NAMETODWORD, 0, 176, &sgptDataTables->pPropertiesLinker },
 		{ "fparam3", TXTFIELD_CALCTODWORD, 0, 180, DATATBLS_ItemParamLinker },
 		{ "fmin3", TXTFIELD_DWORD, 0, 184, NULL },
 		{ "fmax3", TXTFIELD_DWORD, 0, 188, NULL },
-		{ "fcode4", TXTFIELD_NAMETODWORD, 0, 192, &gpDataTables.pPropertiesLinker },
+		{ "fcode4", TXTFIELD_NAMETODWORD, 0, 192, &sgptDataTables->pPropertiesLinker },
 		{ "fparam4", TXTFIELD_CALCTODWORD, 0, 196, DATATBLS_ItemParamLinker },
 		{ "fmin4", TXTFIELD_DWORD, 0, 200, NULL },
 		{ "fmax4", TXTFIELD_DWORD, 0, 204, NULL },
-		{ "fcode5", TXTFIELD_NAMETODWORD, 0, 208, &gpDataTables.pPropertiesLinker },
+		{ "fcode5", TXTFIELD_NAMETODWORD, 0, 208, &sgptDataTables->pPropertiesLinker },
 		{ "fparam5", TXTFIELD_CALCTODWORD, 0, 212, DATATBLS_ItemParamLinker },
 		{ "fmin5", TXTFIELD_DWORD, 0, 216, NULL },
 		{ "fmax5", TXTFIELD_DWORD, 0, 220, NULL },
-		{ "fcode6", TXTFIELD_NAMETODWORD, 0, 224, &gpDataTables.pPropertiesLinker },
+		{ "fcode6", TXTFIELD_NAMETODWORD, 0, 224, &sgptDataTables->pPropertiesLinker },
 		{ "fparam6", TXTFIELD_CALCTODWORD, 0, 228, DATATBLS_ItemParamLinker },
 		{ "fmin6", TXTFIELD_DWORD, 0, 232, NULL },
 		{ "fmax6", TXTFIELD_DWORD, 0, 236, NULL },
-		{ "fcode7", TXTFIELD_NAMETODWORD, 0, 240, &gpDataTables.pPropertiesLinker },
+		{ "fcode7", TXTFIELD_NAMETODWORD, 0, 240, &sgptDataTables->pPropertiesLinker },
 		{ "fparam7", TXTFIELD_CALCTODWORD, 0, 244, DATATBLS_ItemParamLinker },
 		{ "fmin7", TXTFIELD_DWORD, 0, 248, NULL },
 		{ "fmax7", TXTFIELD_DWORD, 0, 252, NULL },
-		{ "fcode8", TXTFIELD_NAMETODWORD, 0, 256, &gpDataTables.pPropertiesLinker },
+		{ "fcode8", TXTFIELD_NAMETODWORD, 0, 256, &sgptDataTables->pPropertiesLinker },
 		{ "fparam8", TXTFIELD_CALCTODWORD, 0, 260, DATATBLS_ItemParamLinker },
 		{ "fmin8", TXTFIELD_DWORD, 0, 264, NULL },
 		{ "fmax8", TXTFIELD_DWORD, 0, 268, NULL },
@@ -996,140 +996,140 @@ void __fastcall DATATBLS_LoadSets_SetItemsTxt(void* pMemPool)
 	{
 		{ "index", TXTFIELD_ASCII, 31, TXTFIELD_DWORD, NULL },
 		{ "item", TXTFIELD_RAW, 0, 40, NULL },
-		{ "set", TXTFIELD_NAMETOWORD, 0, 44, &gpDataTables.pSetsLinker },
+		{ "set", TXTFIELD_NAMETOWORD, 0, 44, &sgptDataTables->pSetsLinker },
 		{ "lvl", TXTFIELD_WORD, 0, 48, NULL },
 		{ "lvl req", TXTFIELD_WORD, 0, 50, NULL },
 		{ "rarity", TXTFIELD_DWORD, 0, 52, NULL },
 		{ "cost mult", TXTFIELD_DWORD, 0, 56, NULL },
 		{ "cost add", TXTFIELD_DWORD, 0, 60, NULL },
-		{ "chrtransform", TXTFIELD_CODETOBYTE, 0, 64, &gpDataTables.pColorsLinker },
-		{ "invtransform", TXTFIELD_CODETOBYTE, 0, 65, &gpDataTables.pColorsLinker },
+		{ "chrtransform", TXTFIELD_CODETOBYTE, 0, 64, &sgptDataTables->pColorsLinker },
+		{ "invtransform", TXTFIELD_CODETOBYTE, 0, 65, &sgptDataTables->pColorsLinker },
 		{ "flippyfile", TXTFIELD_ASCII, 31, 66, NULL },
 		{ "invfile", TXTFIELD_ASCII, 31, 98, NULL },
-		{ "dropsound", TXTFIELD_NAMETOWORD, 0, 130, &gpDataTables.pSoundsLinker },
+		{ "dropsound", TXTFIELD_NAMETOWORD, 0, 130, &sgptDataTables->pSoundsLinker },
 		{ "dropsfxframe", TXTFIELD_BYTE, 0, 134, NULL },
-		{ "usesound", TXTFIELD_NAMETOWORD, 0, 132, &gpDataTables.pSoundsLinker },
+		{ "usesound", TXTFIELD_NAMETOWORD, 0, 132, &sgptDataTables->pSoundsLinker },
 		{ "add func", TXTFIELD_BYTE, 0, 135, NULL },
-		{ "prop1", TXTFIELD_NAMETODWORD, 0, 136, &gpDataTables.pPropertiesLinker },
+		{ "prop1", TXTFIELD_NAMETODWORD, 0, 136, &sgptDataTables->pPropertiesLinker },
 		{ "par1", TXTFIELD_CALCTODWORD, 0, 140, DATATBLS_ItemParamLinker },
 		{ "min1", TXTFIELD_DWORD, 0, 144, NULL },
 		{ "max1", TXTFIELD_DWORD, 0, 148, NULL },
-		{ "prop2", TXTFIELD_NAMETODWORD, 0, 152, &gpDataTables.pPropertiesLinker },
+		{ "prop2", TXTFIELD_NAMETODWORD, 0, 152, &sgptDataTables->pPropertiesLinker },
 		{ "par2", TXTFIELD_CALCTODWORD, 0, 156, DATATBLS_ItemParamLinker },
 		{ "min2", TXTFIELD_DWORD, 0, 160, NULL },
 		{ "max2", TXTFIELD_DWORD, 0, 164, NULL },
-		{ "prop3", TXTFIELD_NAMETODWORD, 0, 168, &gpDataTables.pPropertiesLinker },
+		{ "prop3", TXTFIELD_NAMETODWORD, 0, 168, &sgptDataTables->pPropertiesLinker },
 		{ "par3", TXTFIELD_CALCTODWORD, 0, 172, DATATBLS_ItemParamLinker },
 		{ "min3", TXTFIELD_DWORD, 0, 176, NULL },
 		{ "max3", TXTFIELD_DWORD, 0, 180, NULL },
-		{ "prop4", TXTFIELD_NAMETODWORD, 0, 184, &gpDataTables.pPropertiesLinker },
+		{ "prop4", TXTFIELD_NAMETODWORD, 0, 184, &sgptDataTables->pPropertiesLinker },
 		{ "par4", TXTFIELD_CALCTODWORD, 0, 188, DATATBLS_ItemParamLinker },
 		{ "min4", TXTFIELD_DWORD, 0, 192, NULL },
 		{ "max4", TXTFIELD_DWORD, 0, 196, NULL },
-		{ "prop5", TXTFIELD_NAMETODWORD, 0, 200, &gpDataTables.pPropertiesLinker },
+		{ "prop5", TXTFIELD_NAMETODWORD, 0, 200, &sgptDataTables->pPropertiesLinker },
 		{ "par5", TXTFIELD_CALCTODWORD, 0, 204, DATATBLS_ItemParamLinker },
 		{ "min5", TXTFIELD_DWORD, 0, 208, NULL },
 		{ "max5", TXTFIELD_DWORD, 0, 212, NULL },
-		{ "prop6", TXTFIELD_NAMETODWORD, 0, 216, &gpDataTables.pPropertiesLinker },
+		{ "prop6", TXTFIELD_NAMETODWORD, 0, 216, &sgptDataTables->pPropertiesLinker },
 		{ "par6", TXTFIELD_CALCTODWORD, 0, 220, DATATBLS_ItemParamLinker },
 		{ "min6", TXTFIELD_DWORD, 0, 224, NULL },
 		{ "max6", TXTFIELD_DWORD, 0, 228, NULL },
-		{ "prop7", TXTFIELD_NAMETODWORD, 0, 232, &gpDataTables.pPropertiesLinker },
+		{ "prop7", TXTFIELD_NAMETODWORD, 0, 232, &sgptDataTables->pPropertiesLinker },
 		{ "par7", TXTFIELD_CALCTODWORD, 0, 236, DATATBLS_ItemParamLinker },
 		{ "min7", TXTFIELD_DWORD, 0, 240, NULL },
 		{ "max7", TXTFIELD_DWORD, 0, 244, NULL },
-		{ "prop8", TXTFIELD_NAMETODWORD, 0, 248, &gpDataTables.pPropertiesLinker },
+		{ "prop8", TXTFIELD_NAMETODWORD, 0, 248, &sgptDataTables->pPropertiesLinker },
 		{ "par8", TXTFIELD_CALCTODWORD, 0, 252, DATATBLS_ItemParamLinker },
 		{ "min8", TXTFIELD_DWORD, 0, 256, NULL },
 		{ "max8", TXTFIELD_DWORD, 0, 260, NULL },
-		{ "prop9", TXTFIELD_NAMETODWORD, 0, 264, &gpDataTables.pPropertiesLinker },
+		{ "prop9", TXTFIELD_NAMETODWORD, 0, 264, &sgptDataTables->pPropertiesLinker },
 		{ "par9", TXTFIELD_CALCTODWORD, 0, 268, DATATBLS_ItemParamLinker },
 		{ "min9", TXTFIELD_DWORD, 0, 272, NULL },
 		{ "max9", TXTFIELD_DWORD, 0, 276, NULL },
-		{ "aprop1a", TXTFIELD_NAMETODWORD, 0, 280, &gpDataTables.pPropertiesLinker },
+		{ "aprop1a", TXTFIELD_NAMETODWORD, 0, 280, &sgptDataTables->pPropertiesLinker },
 		{ "apar1a", TXTFIELD_CALCTODWORD, 0, 284, DATATBLS_ItemParamLinker },
 		{ "amin1a", TXTFIELD_DWORD, 0, 288, NULL },
 		{ "amax1a", TXTFIELD_DWORD, 0, 292, NULL },
-		{ "aprop1b", TXTFIELD_NAMETODWORD, 0, 296, &gpDataTables.pPropertiesLinker },
+		{ "aprop1b", TXTFIELD_NAMETODWORD, 0, 296, &sgptDataTables->pPropertiesLinker },
 		{ "apar1b", TXTFIELD_CALCTODWORD, 0, 300, DATATBLS_ItemParamLinker },
 		{ "amin1b", TXTFIELD_DWORD, 0, 304, NULL },
 		{ "amax1b", TXTFIELD_DWORD, 0, 308, NULL },
-		{ "aprop2a", TXTFIELD_NAMETODWORD, 0, 312, &gpDataTables.pPropertiesLinker },
+		{ "aprop2a", TXTFIELD_NAMETODWORD, 0, 312, &sgptDataTables->pPropertiesLinker },
 		{ "apar2a", TXTFIELD_CALCTODWORD, 0, 316, DATATBLS_ItemParamLinker },
 		{ "amin2a", TXTFIELD_DWORD, 0, 320, NULL },
 		{ "amax2a", TXTFIELD_DWORD, 0, 324, NULL },
-		{ "aprop2b", TXTFIELD_NAMETODWORD, 0, 328, &gpDataTables.pPropertiesLinker },
+		{ "aprop2b", TXTFIELD_NAMETODWORD, 0, 328, &sgptDataTables->pPropertiesLinker },
 		{ "apar2b", TXTFIELD_CALCTODWORD, 0, 332, DATATBLS_ItemParamLinker },
 		{ "amin2b", TXTFIELD_DWORD, 0, 336, NULL },
 		{ "amax2b", TXTFIELD_DWORD, 0, 340, NULL },
-		{ "aprop3a", TXTFIELD_NAMETODWORD, 0, 344, &gpDataTables.pPropertiesLinker },
+		{ "aprop3a", TXTFIELD_NAMETODWORD, 0, 344, &sgptDataTables->pPropertiesLinker },
 		{ "apar3a", TXTFIELD_CALCTODWORD, 0, 348, DATATBLS_ItemParamLinker },
 		{ "amin3a", TXTFIELD_DWORD, 0, 352, NULL },
 		{ "amax3a", TXTFIELD_DWORD, 0, 356, NULL },
-		{ "aprop3b", TXTFIELD_NAMETODWORD, 0, 360, &gpDataTables.pPropertiesLinker },
+		{ "aprop3b", TXTFIELD_NAMETODWORD, 0, 360, &sgptDataTables->pPropertiesLinker },
 		{ "apar3b", TXTFIELD_CALCTODWORD, 0, 364, DATATBLS_ItemParamLinker },
 		{ "amin3b", TXTFIELD_DWORD, 0, 368, NULL },
 		{ "amax3b", TXTFIELD_DWORD, 0, 372, NULL },
-		{ "aprop4a", TXTFIELD_NAMETODWORD, 0, 376, &gpDataTables.pPropertiesLinker },
+		{ "aprop4a", TXTFIELD_NAMETODWORD, 0, 376, &sgptDataTables->pPropertiesLinker },
 		{ "apar4a", TXTFIELD_CALCTODWORD, 0, 380, DATATBLS_ItemParamLinker },
 		{ "amin4a", TXTFIELD_DWORD, 0, 384, NULL },
 		{ "amax4a", TXTFIELD_DWORD, 0, 388, NULL },
-		{ "aprop4b", TXTFIELD_NAMETODWORD, 0, 392, &gpDataTables.pPropertiesLinker },
+		{ "aprop4b", TXTFIELD_NAMETODWORD, 0, 392, &sgptDataTables->pPropertiesLinker },
 		{ "apar4b", TXTFIELD_CALCTODWORD, 0, 396, DATATBLS_ItemParamLinker },
 		{ "amin4b", TXTFIELD_DWORD, 0, 400, NULL },
 		{ "amax4b", TXTFIELD_DWORD, 0, 404, NULL },
-		{ "aprop5a", TXTFIELD_NAMETODWORD, 0, 408, &gpDataTables.pPropertiesLinker },
+		{ "aprop5a", TXTFIELD_NAMETODWORD, 0, 408, &sgptDataTables->pPropertiesLinker },
 		{ "apar5a", TXTFIELD_CALCTODWORD, 0, 412, DATATBLS_ItemParamLinker },
 		{ "amin5a", TXTFIELD_DWORD, 0, 416, NULL },
 		{ "amax5a", TXTFIELD_DWORD, 0, 420, NULL },
-		{ "aprop5b", TXTFIELD_NAMETODWORD, 0, 424, &gpDataTables.pPropertiesLinker },
+		{ "aprop5b", TXTFIELD_NAMETODWORD, 0, 424, &sgptDataTables->pPropertiesLinker },
 		{ "apar5b", TXTFIELD_CALCTODWORD, 0, 428, DATATBLS_ItemParamLinker },
 		{ "amin5b", TXTFIELD_DWORD, 0, 432, NULL },
 		{ "amax5b", TXTFIELD_DWORD, 0, 436, NULL },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pSetsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pSetsTxt = (D2SetsTxt*)DATATBLS_CompileTxt(pMemPool, "sets", pSetsTbl, &gpDataTables.nSetsTxtRecordCount, sizeof(D2SetsTxt));
+	sgptDataTables->pSetsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pSetsTxt = (D2SetsTxt*)DATATBLS_CompileTxt(pMemPool, "sets", pSetsTbl, &sgptDataTables->nSetsTxtRecordCount, sizeof(D2SetsTxt));
 
-	if (gpDataTables.nSetsTxtRecordCount >= 32767)
+	if (sgptDataTables->nSetsTxtRecordCount >= 32767)
 	{
 		FOG_10025("sets table exceeded maximum number of entries.", __FILE__, __LINE__);
 	}
 
-	gpDataTables.pSetItemsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pSetItemsTxt = (D2SetItemsTxt*)DATATBLS_CompileTxt(pMemPool, "setitems", pSetItemsTbl, &gpDataTables.nSetItemsTxtRecordCount, sizeof(D2SetItemsTxt));
+	sgptDataTables->pSetItemsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pSetItemsTxt = (D2SetItemsTxt*)DATATBLS_CompileTxt(pMemPool, "setitems", pSetItemsTbl, &sgptDataTables->nSetItemsTxtRecordCount, sizeof(D2SetItemsTxt));
 
-	if (gpDataTables.nSetItemsTxtRecordCount >= 32767)
+	if (sgptDataTables->nSetItemsTxtRecordCount >= 32767)
 	{
 		FOG_10025("setitems table exceeded maximum number of entries.", __FILE__, __LINE__);
 	}
 
-	for (int i = 0; i < gpDataTables.nSetItemsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nSetItemsTxtRecordCount; ++i)
 	{
-		gpDataTables.pSetItemsTxt[i].wSetItemId = i;
-		FOG_10216_AddRecordToLinkingTable(gpDataTables.pSetItemsLinker, gpDataTables.pSetItemsTxt[i].szName);
+		sgptDataTables->pSetItemsTxt[i].wSetItemId = i;
+		FOG_10216_AddRecordToLinkingTable(sgptDataTables->pSetItemsLinker, sgptDataTables->pSetItemsTxt[i].szName);
 
-		gpDataTables.pSetItemsTxt[i].wStringId = D2LANG_GetTblIndex(gpDataTables.pSetItemsTxt[i].szName, &pUnicode);
-		if (!gpDataTables.pSetItemsTxt[i].wStringId)
+		sgptDataTables->pSetItemsTxt[i].wStringId = D2LANG_GetTblIndex(sgptDataTables->pSetItemsTxt[i].szName, &pUnicode);
+		if (!sgptDataTables->pSetItemsTxt[i].wStringId)
 		{
-			gpDataTables.pSetItemsTxt[i].wStringId = 5383;
+			sgptDataTables->pSetItemsTxt[i].wStringId = 5383;
 		}
 
-		nSetId = gpDataTables.pSetItemsTxt[i].nSetId;
-		if (nSetId >= 0 && nSetId < gpDataTables.nSetsTxtRecordCount)
+		nSetId = sgptDataTables->pSetItemsTxt[i].nSetId;
+		if (nSetId >= 0 && nSetId < sgptDataTables->nSetsTxtRecordCount)
 		{
-			if (gpDataTables.pSetsTxt[nSetId].nSetItems < 6)
+			if (sgptDataTables->pSetsTxt[nSetId].nSetItems < 6)
 			{
-				gpDataTables.pSetItemsTxt[i].wVersion = gpDataTables.pSetsTxt[nSetId].wVersion;
-				gpDataTables.pSetItemsTxt[i].nSetItems = gpDataTables.pSetsTxt[nSetId].nSetItems;
-				gpDataTables.pSetsTxt[nSetId].pSetItem[gpDataTables.pSetsTxt[nSetId].nSetItems] = &gpDataTables.pSetItemsTxt[i];
+				sgptDataTables->pSetItemsTxt[i].wVersion = sgptDataTables->pSetsTxt[nSetId].wVersion;
+				sgptDataTables->pSetItemsTxt[i].nSetItems = sgptDataTables->pSetsTxt[nSetId].nSetItems;
+				sgptDataTables->pSetsTxt[nSetId].pSetItem[sgptDataTables->pSetsTxt[nSetId].nSetItems] = &sgptDataTables->pSetItemsTxt[i];
 
-				++gpDataTables.pSetsTxt[nSetId].nSetItems;//TODO: Increment SetItemsTxt-Counter, too? (Not done in the original code)
+				++sgptDataTables->pSetsTxt[nSetId].nSetItems;//TODO: Increment SetItemsTxt-Counter, too? (Not done in the original code)
 			}
 			else
 			{
-				FOG_WriteToLogFile("Error: too many items in set %d", gpDataTables.pSetsTxt[nSetId].wSetId);
+				FOG_WriteToLogFile("Error: too many items in set %d", sgptDataTables->pSetsTxt[nSetId].wSetId);
 			}
 		}
 	}
@@ -1138,12 +1138,12 @@ void __fastcall DATATBLS_LoadSets_SetItemsTxt(void* pMemPool)
 //D2Common.0x6FD5AE00
 void __fastcall DATATBLS_UnloadSets_SetItemsTxt()
 {
-	FOG_FreeLinker(gpDataTables.pSetsLinker);
-	FOG_FreeLinker(gpDataTables.pSetItemsLinker);
-	DATATBLS_UnloadBin(gpDataTables.pSetItemsTxt);
-	DATATBLS_UnloadBin(gpDataTables.pSetsTxt);
-	gpDataTables.nSetsTxtRecordCount = 0;
-	gpDataTables.nSetItemsTxtRecordCount = 0;
+	FOG_FreeLinker(sgptDataTables->pSetsLinker);
+	FOG_FreeLinker(sgptDataTables->pSetItemsLinker);
+	DATATBLS_UnloadBin(sgptDataTables->pSetItemsTxt);
+	DATATBLS_UnloadBin(sgptDataTables->pSetsTxt);
+	sgptDataTables->nSetsTxtRecordCount = 0;
+	sgptDataTables->nSetItemsTxtRecordCount = 0;
 }
 
 //D2Common.0x6FD5AE40
@@ -1154,8 +1154,8 @@ void __fastcall DATATBLS_LoadQualityItemsTxt(void* pMemPool)
 	D2BinFieldStrc pTbl[] =
 	{
 		{ "nummods", TXTFIELD_BYTE, 0, 10, NULL },
-		{ "mod1code", TXTFIELD_NAMETODWORD, 0, 12, &gpDataTables.pPropertiesLinker },
-		{ "mod2code", TXTFIELD_NAMETODWORD, 0, 28, &gpDataTables.pPropertiesLinker },
+		{ "mod1code", TXTFIELD_NAMETODWORD, 0, 12, &sgptDataTables->pPropertiesLinker },
+		{ "mod2code", TXTFIELD_NAMETODWORD, 0, 28, &sgptDataTables->pPropertiesLinker },
 		{ "mod1param", TXTFIELD_DWORD, 0, 16, NULL },
 		{ "mod1min", TXTFIELD_DWORD, 0, 20, NULL },
 		{ "mod1max", TXTFIELD_DWORD, 0, 24, NULL },
@@ -1177,18 +1177,18 @@ void __fastcall DATATBLS_LoadQualityItemsTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pQualityItemDataTables.pQualityItemsTxt = (D2QualityItemsTxt*)DATATBLS_CompileTxt(pMemPool, "qualityitems", pTbl, &gpDataTables.pQualityItemDataTables.nQualityItemsTxtRecordCount, sizeof(D2QualityItemsTxt));
+	sgptDataTables->pQualityItemDataTables.pQualityItemsTxt = (D2QualityItemsTxt*)DATATBLS_CompileTxt(pMemPool, "qualityitems", pTbl, &sgptDataTables->pQualityItemDataTables.nQualityItemsTxtRecordCount, sizeof(D2QualityItemsTxt));
 
-	for (int i = 0; i < gpDataTables.pQualityItemDataTables.nQualityItemsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->pQualityItemDataTables.nQualityItemsTxtRecordCount; ++i)
 	{
-		if (gpDataTables.pQualityItemDataTables.pQualityItemsTxt[i].szEffect1[0])
+		if (sgptDataTables->pQualityItemDataTables.pQualityItemsTxt[i].szEffect1[0])
 		{
-			gpDataTables.pQualityItemDataTables.pQualityItemsTxt[i].wEffect1TblId = D2LANG_GetTblIndex(gpDataTables.pQualityItemDataTables.pQualityItemsTxt[i].szEffect1, &pUnicode);
+			sgptDataTables->pQualityItemDataTables.pQualityItemsTxt[i].wEffect1TblId = D2LANG_GetTblIndex(sgptDataTables->pQualityItemDataTables.pQualityItemsTxt[i].szEffect1, &pUnicode);
 		}
 
-		if (gpDataTables.pQualityItemDataTables.pQualityItemsTxt[i].szEffect2[0])
+		if (sgptDataTables->pQualityItemDataTables.pQualityItemsTxt[i].szEffect2[0])
 		{
-			gpDataTables.pQualityItemDataTables.pQualityItemsTxt[i].wEffect2TblId = D2LANG_GetTblIndex(gpDataTables.pQualityItemDataTables.pQualityItemsTxt[i].szEffect2, &pUnicode);
+			sgptDataTables->pQualityItemDataTables.pQualityItemsTxt[i].wEffect2TblId = D2LANG_GetTblIndex(sgptDataTables->pQualityItemDataTables.pQualityItemsTxt[i].szEffect2, &pUnicode);
 		}
 	}
 }
@@ -1196,27 +1196,27 @@ void __fastcall DATATBLS_LoadQualityItemsTxt(void* pMemPool)
 //D2Common.0x6FD5B250
 void __fastcall DATATBLS_UnloadQualityItemsTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pQualityItemDataTables.pQualityItemsTxt);
+	DATATBLS_UnloadBin(sgptDataTables->pQualityItemDataTables.pQualityItemsTxt);
 }
 
 //D2Common.0x6FD5B260 (#10611)
 D2QualityItemDataTbl* __fastcall DATATBLS_GetQualityItemDataTables()
 {
-	return &gpDataTables.pQualityItemDataTables;
+	return &sgptDataTables->pQualityItemDataTables;
 }
 
 //D2Common.0x6FD5B270 (#10612)
 D2QualityItemsTxt* __stdcall DATATBLS_GetQualityItemsTxtRecord(int nIndex)
 {
-	if (nIndex >= gpDataTables.pQualityItemDataTables.nQualityItemsTxtRecordCount || nIndex == -1)
+	if (nIndex >= sgptDataTables->pQualityItemDataTables.nQualityItemsTxtRecordCount || nIndex == -1)
 	{
 		return NULL;
 	}
 	else
 	{
-		D2_ASSERT(gpDataTables.pQualityItemDataTables.pQualityItemsTxt);
-		D2_ASSERT(&gpDataTables.pQualityItemDataTables.pQualityItemsTxt[nIndex]);
-		return &gpDataTables.pQualityItemDataTables.pQualityItemsTxt[nIndex];
+		D2_ASSERT(sgptDataTables->pQualityItemDataTables.pQualityItemsTxt);
+		D2_ASSERT(&sgptDataTables->pQualityItemDataTables.pQualityItemsTxt[nIndex]);
+		return &sgptDataTables->pQualityItemDataTables.pQualityItemsTxt[nIndex];
 	}
 }
 
@@ -1231,68 +1231,68 @@ void __fastcall DATATBLS_LoadGemsTxt(void* pMemPool)
 	{
 		{ "name", TXTFIELD_ASCII, 31, 0, NULL },
 		{ "letter", TXTFIELD_ASCII, 5, 32, NULL },
-		{ "code", TXTFIELD_UNKNOWN3, 0, 40, &gpDataTables.pItemsLinker },
+		{ "code", TXTFIELD_UNKNOWN3, 0, 40, &sgptDataTables->pItemsLinker },
 		{ "transform", TXTFIELD_BYTE, 0, 47, NULL },
 		{ "nummods", TXTFIELD_BYTE, 0, 46, NULL },
-		{ "weaponmod1code", TXTFIELD_NAMETODWORD, 0, 48, &gpDataTables.pPropertiesLinker },
+		{ "weaponmod1code", TXTFIELD_NAMETODWORD, 0, 48, &sgptDataTables->pPropertiesLinker },
 		{ "weaponmod1param", TXTFIELD_CALCTODWORD, 0, 52, DATATBLS_ItemParamLinker },
 		{ "weaponmod1min", TXTFIELD_DWORD, 0, 56, NULL },
 		{ "weaponmod1max", TXTFIELD_DWORD, 0, 60, NULL },
-		{ "weaponmod2code", TXTFIELD_NAMETODWORD, 0, 64, &gpDataTables.pPropertiesLinker },
+		{ "weaponmod2code", TXTFIELD_NAMETODWORD, 0, 64, &sgptDataTables->pPropertiesLinker },
 		{ "weaponmod2param", TXTFIELD_CALCTODWORD, 0, 68, DATATBLS_ItemParamLinker },
 		{ "weaponmod2min", TXTFIELD_DWORD, 0, 72, NULL },
 		{ "weaponmod2max", TXTFIELD_DWORD, 0, 76, NULL },
-		{ "weaponmod3code", TXTFIELD_NAMETODWORD, 0, 80, &gpDataTables.pPropertiesLinker },
+		{ "weaponmod3code", TXTFIELD_NAMETODWORD, 0, 80, &sgptDataTables->pPropertiesLinker },
 		{ "weaponmod3param", TXTFIELD_CALCTODWORD, 0, 84, DATATBLS_ItemParamLinker },
 		{ "weaponmod3min", TXTFIELD_DWORD, 0, 88, NULL },
 		{ "weaponmod3max", TXTFIELD_DWORD, 0, 92, NULL },
-		{ "helmmod1code", TXTFIELD_NAMETODWORD, 0, 96, &gpDataTables.pPropertiesLinker },
+		{ "helmmod1code", TXTFIELD_NAMETODWORD, 0, 96, &sgptDataTables->pPropertiesLinker },
 		{ "helmmod1param", TXTFIELD_CALCTODWORD, 0, 100, DATATBLS_ItemParamLinker },
 		{ "helmmod1min", TXTFIELD_DWORD, 0, 104, NULL },
 		{ "helmmod1max", TXTFIELD_DWORD, 0, 108, NULL },
-		{ "helmmod2code", TXTFIELD_NAMETODWORD, 0, 112, &gpDataTables.pPropertiesLinker },
+		{ "helmmod2code", TXTFIELD_NAMETODWORD, 0, 112, &sgptDataTables->pPropertiesLinker },
 		{ "helmmod2param", TXTFIELD_CALCTODWORD, 0, 116, DATATBLS_ItemParamLinker },
 		{ "helmmod2min", TXTFIELD_DWORD, 0, 120, NULL },
 		{ "helmmod2max", TXTFIELD_DWORD, 0, 124, NULL },
-		{ "helmmod3code", TXTFIELD_NAMETODWORD, 0, 128, &gpDataTables.pPropertiesLinker },
+		{ "helmmod3code", TXTFIELD_NAMETODWORD, 0, 128, &sgptDataTables->pPropertiesLinker },
 		{ "helmmod3param", TXTFIELD_CALCTODWORD, 0, 132, DATATBLS_ItemParamLinker },
 		{ "helmmod3min", TXTFIELD_DWORD, 0, 136, NULL },
 		{ "helmmod3max", TXTFIELD_DWORD, 0, 140, NULL },
-		{ "shieldmod1code", TXTFIELD_NAMETODWORD, 0, 144, &gpDataTables.pPropertiesLinker },
+		{ "shieldmod1code", TXTFIELD_NAMETODWORD, 0, 144, &sgptDataTables->pPropertiesLinker },
 		{ "shieldmod1param", TXTFIELD_CALCTODWORD, 0, 148, DATATBLS_ItemParamLinker },
 		{ "shieldmod1min", TXTFIELD_DWORD, 0, 152, NULL },
 		{ "shieldmod1max", TXTFIELD_DWORD, 0, 156, NULL },
-		{ "shieldmod2code", TXTFIELD_NAMETODWORD, 0, 160, &gpDataTables.pPropertiesLinker },
+		{ "shieldmod2code", TXTFIELD_NAMETODWORD, 0, 160, &sgptDataTables->pPropertiesLinker },
 		{ "shieldmod2param", TXTFIELD_CALCTODWORD, 0, 164, DATATBLS_ItemParamLinker },
 		{ "shieldmod2min", TXTFIELD_DWORD, 0, 168, NULL },
 		{ "shieldmod2max", TXTFIELD_DWORD, 0, 172, NULL },
-		{ "shieldmod3code", TXTFIELD_NAMETODWORD, 0, 176, &gpDataTables.pPropertiesLinker },
+		{ "shieldmod3code", TXTFIELD_NAMETODWORD, 0, 176, &sgptDataTables->pPropertiesLinker },
 		{ "shieldmod3param", TXTFIELD_CALCTODWORD, 0, 180, DATATBLS_ItemParamLinker },
 		{ "shieldmod3min", TXTFIELD_DWORD, 0, 184, NULL },
 		{ "shieldmod3max", TXTFIELD_DWORD, 0, 188, NULL },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pGemDataTables.pGemsTxt = (D2GemsTxt*)DATATBLS_CompileTxt(pMemPool, "gems", pTbl, &gpDataTables.pGemDataTables.nGemsTxtRecordCount, sizeof(D2GemsTxt));
+	sgptDataTables->pGemDataTables.pGemsTxt = (D2GemsTxt*)DATATBLS_CompileTxt(pMemPool, "gems", pTbl, &sgptDataTables->pGemDataTables.nGemsTxtRecordCount, sizeof(D2GemsTxt));
 
 
-	for (int i = 0; i < gpDataTables.pGemDataTables.nGemsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->pGemDataTables.nGemsTxtRecordCount; ++i)
 	{
-		szReference[0] = gpDataTables.pGemDataTables.pGemsTxt[i].szItemCode[0] & ((gpDataTables.pGemDataTables.pGemsTxt[i].szItemCode[0] == ' ') - 1);
-		szReference[1] = gpDataTables.pGemDataTables.pGemsTxt[i].szItemCode[1] & ((gpDataTables.pGemDataTables.pGemsTxt[i].szItemCode[1] == ' ') - 1);
-		szReference[2] = gpDataTables.pGemDataTables.pGemsTxt[i].szItemCode[2] & ((gpDataTables.pGemDataTables.pGemsTxt[i].szItemCode[2] == ' ') - 1);
+		szReference[0] = sgptDataTables->pGemDataTables.pGemsTxt[i].szItemCode[0] & ((sgptDataTables->pGemDataTables.pGemsTxt[i].szItemCode[0] == ' ') - 1);
+		szReference[1] = sgptDataTables->pGemDataTables.pGemsTxt[i].szItemCode[1] & ((sgptDataTables->pGemDataTables.pGemsTxt[i].szItemCode[1] == ' ') - 1);
+		szReference[2] = sgptDataTables->pGemDataTables.pGemsTxt[i].szItemCode[2] & ((sgptDataTables->pGemDataTables.pGemsTxt[i].szItemCode[2] == ' ') - 1);
 		szReference[3] = 0;
 
-		gpDataTables.pGemDataTables.pGemsTxt[i].wStringId = D2LANG_GetTblIndex(szReference, &pUnicode);
+		sgptDataTables->pGemDataTables.pGemsTxt[i].wStringId = D2LANG_GetTblIndex(szReference, &pUnicode);
 	}
 
-	for (int i = 0; i < gpDataTables.pGemDataTables.nGemsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->pGemDataTables.nGemsTxtRecordCount; ++i)
 	{
-		gpDataTables.pItemDataTables.pItemsTxt[i].dwGemOffset = -1;
-		nItemCode = gpDataTables.pGemDataTables.pGemsTxt[i].dwItemCode;
+		sgptDataTables->pItemDataTables.pItemsTxt[i].dwGemOffset = -1;
+		nItemCode = sgptDataTables->pGemDataTables.pGemsTxt[i].dwItemCode;
 		if (nItemCode >= 0)
 		{
-			gpDataTables.pItemDataTables.pItemsTxt[nItemCode].dwGemOffset = i;
+			sgptDataTables->pItemDataTables.pItemsTxt[nItemCode].dwGemOffset = i;
 		}
 	}
 }
@@ -1300,27 +1300,27 @@ void __fastcall DATATBLS_LoadGemsTxt(void* pMemPool)
 //D2Common.0x6FD5BAE0
 void __fastcall DATATBLS_UnloadGemsTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pGemDataTables.pGemsTxt);
+	DATATBLS_UnloadBin(sgptDataTables->pGemDataTables.pGemsTxt);
 }
 
 //D2Common.0x6FD5BAF0 (#10615)
 D2GemDataTbl* __fastcall DATATBLS_GetGemDataTables()
 {
-	return &gpDataTables.pGemDataTables;
+	return &sgptDataTables->pGemDataTables;
 }
 
 //D2Common.0x6FD5BB00 (#10616)
 D2GemsTxt* __stdcall DATATBLS_GetGemsTxtRecord(int nGemId)
 {
-	if (nGemId >= gpDataTables.pGemDataTables.nGemsTxtRecordCount || nGemId == -1)
+	if (nGemId >= sgptDataTables->pGemDataTables.nGemsTxtRecordCount || nGemId == -1)
 	{
 		return NULL;
 	}
 	else
 	{
-		D2_ASSERT(gpDataTables.pGemDataTables.pGemsTxt);
-		D2_ASSERT(&gpDataTables.pGemDataTables.pGemsTxt[nGemId]);
-		return &gpDataTables.pGemDataTables.pGemsTxt[nGemId];
+		D2_ASSERT(sgptDataTables->pGemDataTables.pGemsTxt);
+		D2_ASSERT(&sgptDataTables->pGemDataTables.pGemsTxt[nGemId]);
+		return &sgptDataTables->pGemDataTables.pGemsTxt[nGemId];
 	}
 }
 
@@ -1333,42 +1333,42 @@ void __fastcall DATATBLS_LoadBooksTxt(void* pMemPool)
 		{ "scrollspellcode", TXTFIELD_RAW, 0, 24, NULL },
 		{ "bookspellcode", TXTFIELD_RAW, 0, 28, NULL },
 		{ "pSpell", TXTFIELD_DWORD, 0, 4, NULL },
-		{ "scrollskill", TXTFIELD_NAMETODWORD, 0, 8, &gpDataTables.pSkillsLinker },
-		{ "bookskill", TXTFIELD_NAMETODWORD, 0, 12, &gpDataTables.pSkillsLinker },
+		{ "scrollskill", TXTFIELD_NAMETODWORD, 0, 8, &sgptDataTables->pSkillsLinker },
+		{ "bookskill", TXTFIELD_NAMETODWORD, 0, 12, &sgptDataTables->pSkillsLinker },
 		{ "spellicon", TXTFIELD_BYTE, 0, 2, NULL },
 		{ "basecost", TXTFIELD_DWORD, 0, 16, NULL },
 		{ "costpercharge", TXTFIELD_DWORD, 0, 20, NULL },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pBookDataTables.pBooksTxt = (D2BooksTxt*)DATATBLS_CompileTxt(pMemPool, "books", pTbl, &gpDataTables.pBookDataTables.nBooksTxtRecordCount, sizeof(D2BooksTxt));
+	sgptDataTables->pBookDataTables.pBooksTxt = (D2BooksTxt*)DATATBLS_CompileTxt(pMemPool, "books", pTbl, &sgptDataTables->pBookDataTables.nBooksTxtRecordCount, sizeof(D2BooksTxt));
 }
 
 //D2Common.0x6FD5BD10
 void __fastcall DATATBLS_UnloadBooksTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pBookDataTables.pBooksTxt);
+	DATATBLS_UnloadBin(sgptDataTables->pBookDataTables.pBooksTxt);
 }
 
 //D2Common.0x6FD5BD20 (#10617)
 D2BookDataTbl* __fastcall DATATBLS_GetBookDataTables()
 {
-	return &gpDataTables.pBookDataTables;
+	return &sgptDataTables->pBookDataTables;
 }
 
 //D2Common.0x6FD5BD30 (#10618)
 D2BooksTxt* __stdcall DATATBLS_GetBooksTxtRecord(int nBookId)
 {
-	if (nBookId >= gpDataTables.pBookDataTables.nBooksTxtRecordCount || nBookId == -1)
+	if (nBookId >= sgptDataTables->pBookDataTables.nBooksTxtRecordCount || nBookId == -1)
 	{
 		return NULL;
 	}
 	else
 	{
-		D2_ASSERT(gpDataTables.pBookDataTables.pBooksTxt);
-		D2_ASSERT(&gpDataTables.pBookDataTables.pBooksTxt[nBookId]);
+		D2_ASSERT(sgptDataTables->pBookDataTables.pBooksTxt);
+		D2_ASSERT(&sgptDataTables->pBookDataTables.pBooksTxt[nBookId]);
 
-		return &gpDataTables.pBookDataTables.pBooksTxt[nBookId];
+		return &sgptDataTables->pBookDataTables.pBooksTxt[nBookId];
 	}
 }
 
@@ -1382,39 +1382,39 @@ void __fastcall DATATBLS_LoadLowQualityItemsTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pLowQualityItemDataTables.pLowQualityItemsTxt = (D2LowQualityItemsTxt *)DATATBLS_CompileTxt(pMemPool, "lowqualityitems", pTbl, &gpDataTables.pLowQualityItemDataTables.nLowQualityItemsTxtRecordCount, sizeof(D2LowQualityItemsTxt));
+	sgptDataTables->pLowQualityItemDataTables.pLowQualityItemsTxt = (D2LowQualityItemsTxt *)DATATBLS_CompileTxt(pMemPool, "lowqualityitems", pTbl, &sgptDataTables->pLowQualityItemDataTables.nLowQualityItemsTxtRecordCount, sizeof(D2LowQualityItemsTxt));
 
-	for (int i = 0; i < gpDataTables.pLowQualityItemDataTables.nLowQualityItemsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->pLowQualityItemDataTables.nLowQualityItemsTxtRecordCount; ++i)
 	{
-		gpDataTables.pLowQualityItemDataTables.pLowQualityItemsTxt[i].wTblId = D2LANG_GetTblIndex(gpDataTables.pLowQualityItemDataTables.pLowQualityItemsTxt[i].szName, &pUnicode);
+		sgptDataTables->pLowQualityItemDataTables.pLowQualityItemsTxt[i].wTblId = D2LANG_GetTblIndex(sgptDataTables->pLowQualityItemDataTables.pLowQualityItemsTxt[i].szName, &pUnicode);
 	}
 }
 
 //D2Common.0x6FD5BE40
 void __fastcall DATATBLS_UnloadLowQualityItemsTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pLowQualityItemDataTables.pLowQualityItemsTxt);
+	DATATBLS_UnloadBin(sgptDataTables->pLowQualityItemDataTables.pLowQualityItemsTxt);
 }
 
 //D2Common.0x6FD5BE50 (#10613)
 D2LowQualityItemDataTbl* __fastcall DATATBLS_GetLowQualityItemDataTables()
 {
-	return &gpDataTables.pLowQualityItemDataTables;
+	return &sgptDataTables->pLowQualityItemDataTables;
 }
 
 //D2Common.0x6FD5BE60 (#10614)
 D2LowQualityItemsTxt* __stdcall DATATBLS_GetLowQualityItemsTxtRecord(int nId)
 {
-	if (nId >= gpDataTables.pLowQualityItemDataTables.nLowQualityItemsTxtRecordCount || nId == -1)
+	if (nId >= sgptDataTables->pLowQualityItemDataTables.nLowQualityItemsTxtRecordCount || nId == -1)
 	{
 		return NULL;
 	}
 	else
 	{
-		D2_ASSERT(gpDataTables.pLowQualityItemDataTables.pLowQualityItemsTxt);
-		D2_ASSERT(&gpDataTables.pLowQualityItemDataTables.pLowQualityItemsTxt[nId]);
+		D2_ASSERT(sgptDataTables->pLowQualityItemDataTables.pLowQualityItemsTxt);
+		D2_ASSERT(&sgptDataTables->pLowQualityItemDataTables.pLowQualityItemsTxt[nId]);
 
-		return &gpDataTables.pLowQualityItemDataTables.pLowQualityItemsTxt[nId];
+		return &sgptDataTables->pLowQualityItemDataTables.pLowQualityItemsTxt[nId];
 	}
 }
 
@@ -1445,19 +1445,19 @@ void __fastcall DATATBLS_LoadItemRatioTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pItemRatioDataTables.pItemRatioTxt = (D2ItemRatioTxt*)DATATBLS_CompileTxt(pMemPool, "itemratio", pTbl, &gpDataTables.pItemRatioDataTables.nItemRatioTxtRecordCount, sizeof(D2ItemRatioTxt));
+	sgptDataTables->pItemRatioDataTables.pItemRatioTxt = (D2ItemRatioTxt*)DATATBLS_CompileTxt(pMemPool, "itemratio", pTbl, &sgptDataTables->pItemRatioDataTables.nItemRatioTxtRecordCount, sizeof(D2ItemRatioTxt));
 }
 
 //D2Common.0x6FD5C200
 void __fastcall DATATBLS_UnloadItemRatioTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pItemRatioDataTables.pItemRatioTxt);
+	DATATBLS_UnloadBin(sgptDataTables->pItemRatioDataTables.pItemRatioTxt);
 }
 
 //D2Common.0x6FD5C210 (#10622)
 D2ItemRatioDataTbl* __fastcall DATATBLS_GetItemRatioDataTables()
 {
-	return &gpDataTables.pItemRatioDataTables;
+	return &sgptDataTables->pItemRatioDataTables;
 }
 
 //D2Common.0x6FD5C220 (#10623)
@@ -1475,21 +1475,21 @@ D2ItemRatioTxt* __stdcall DATATBLS_GetItemRatioTxtRecord(int nItemId, BYTE nDiff
 #define ITEMS_EXPANSION_VERSION_BASE 100
 	D2_ASSERT(wVersion == ITEMS_PRE_EXPANSION_VERSION || wVersion == ITEMS_EXPANSION_VERSION_BASE);
 
-	for (int i = 0; i < gpDataTables.pItemRatioDataTables.nItemRatioTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->pItemRatioDataTables.nItemRatioTxtRecordCount; ++i)
 	{
-		if (nClass == gpDataTables.pItemRatioDataTables.pItemRatioTxt[i].nClassSpecific
-			&& nQuest == gpDataTables.pItemRatioDataTables.pItemRatioTxt[i].nUber
-			&& gpDataTables.pItemRatioDataTables.pItemRatioTxt[i].wVersion <= wVersion
-			&& gpDataTables.pItemRatioDataTables.pItemRatioTxt[i].wVersion >= nLastVersion)
+		if (nClass == sgptDataTables->pItemRatioDataTables.pItemRatioTxt[i].nClassSpecific
+			&& nQuest == sgptDataTables->pItemRatioDataTables.pItemRatioTxt[i].nUber
+			&& sgptDataTables->pItemRatioDataTables.pItemRatioTxt[i].wVersion <= wVersion
+			&& sgptDataTables->pItemRatioDataTables.pItemRatioTxt[i].wVersion >= nLastVersion)
 		{
-			nLastVersion = gpDataTables.pItemRatioDataTables.pItemRatioTxt[i].wVersion;
+			nLastVersion = sgptDataTables->pItemRatioDataTables.pItemRatioTxt[i].wVersion;
 			nId = i;
 		}
 	}
 
 	if (nId >= 0)
 	{
-		return &gpDataTables.pItemRatioDataTables.pItemRatioTxt[nId];
+		return &sgptDataTables->pItemRatioDataTables.pItemRatioTxt[nId];
 	}
 
 	return NULL;
@@ -1528,7 +1528,7 @@ void __fastcall DATATBLS_LoadItemStatCostTxt(void* pMemPool)
 
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "stat", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pItemStatCostLinker },
+		{ "stat", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pItemStatCostLinker },
 		{ "send bits", TXTFIELD_BYTE, 0, 8, NULL },
 		{ "send param bits", TXTFIELD_BYTE, 0, 9, NULL },
 		{ "divide", TXTFIELD_DWORD, 0, 12, NULL },
@@ -1554,10 +1554,10 @@ void __fastcall DATATBLS_LoadItemStatCostTxt(void* pMemPool)
 		{ "csvsigned", TXTFIELD_BIT, 13, 4, NULL },
 		{ "csvbits", TXTFIELD_BYTE, 0, 10, NULL },
 		{ "csvparam", TXTFIELD_BYTE, 0, 11, NULL },
-		{ "maxstat", TXTFIELD_NAMETOWORD, 0, 50, &gpDataTables.pItemStatCostLinker },
-		{ "itemevent1", TXTFIELD_NAMETOWORD, 0, 72, &gpDataTables.pEventsLinker },
+		{ "maxstat", TXTFIELD_NAMETOWORD, 0, 50, &sgptDataTables->pItemStatCostLinker },
+		{ "itemevent1", TXTFIELD_NAMETOWORD, 0, 72, &sgptDataTables->pEventsLinker },
 		{ "itemeventfunc1", TXTFIELD_WORD, 0, 76, NULL },
-		{ "itemevent2", TXTFIELD_NAMETOWORD, 0, 74, &gpDataTables.pEventsLinker },
+		{ "itemevent2", TXTFIELD_NAMETOWORD, 0, 74, &sgptDataTables->pEventsLinker },
 		{ "itemeventfunc2", TXTFIELD_WORD, 0, 78, NULL },
 		{ "descpriority", TXTFIELD_WORD, 0, 52, NULL },
 		{ "descfunc", TXTFIELD_BYTE, 0, 54, NULL },
@@ -1573,104 +1573,104 @@ void __fastcall DATATBLS_LoadItemStatCostTxt(void* pMemPool)
 		{ "dgrpstr2", TXTFIELD_KEYTOWORD, 0, 70, DATATBLS_GetStringIdFromReferenceString },
 		{ "keepzero", TXTFIELD_BYTE, 0, 80, NULL },
 		{ "op", TXTFIELD_BYTE, 0, 84, NULL },
-		{ "op base", TXTFIELD_NAMETOWORD, 0, 86, &gpDataTables.pItemStatCostLinker },
+		{ "op base", TXTFIELD_NAMETOWORD, 0, 86, &sgptDataTables->pItemStatCostLinker },
 		{ "op param", TXTFIELD_BYTE, 0, 85, NULL },
-		{ "op stat1", TXTFIELD_NAMETOWORD, 0, 88, &gpDataTables.pItemStatCostLinker },
-		{ "op stat2", TXTFIELD_NAMETOWORD, 0, 90, &gpDataTables.pItemStatCostLinker },
-		{ "op stat3", TXTFIELD_NAMETOWORD, 0, 92, &gpDataTables.pItemStatCostLinker },
+		{ "op stat1", TXTFIELD_NAMETOWORD, 0, 88, &sgptDataTables->pItemStatCostLinker },
+		{ "op stat2", TXTFIELD_NAMETOWORD, 0, 90, &sgptDataTables->pItemStatCostLinker },
+		{ "op stat3", TXTFIELD_NAMETOWORD, 0, 92, &sgptDataTables->pItemStatCostLinker },
 		{ "stuff", TXTFIELD_DWORD, 0, 320, NULL },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pItemStatCostLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pItemStatCostTxt = (D2ItemStatCostTxt*)DATATBLS_CompileTxt(pMemPool, "itemstatcost", pTbl, &gpDataTables.nItemStatCostTxtRecordCount, sizeof(D2ItemStatCostTxt));
+	sgptDataTables->pItemStatCostLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pItemStatCostTxt = (D2ItemStatCostTxt*)DATATBLS_CompileTxt(pMemPool, "itemstatcost", pTbl, &sgptDataTables->nItemStatCostTxtRecordCount, sizeof(D2ItemStatCostTxt));
 
 #define MAX_STATS 511
-	D2_ASSERT(gpDataTables.nItemStatCostTxtRecordCount <= MAX_STATS);
+	D2_ASSERT(sgptDataTables->nItemStatCostTxtRecordCount <= MAX_STATS);
 
-	gpDataTables.nStuff = gpDataTables.pItemStatCostTxt->dwStuff;
-	if (gpDataTables.nStuff <= 0 || gpDataTables.nStuff > 8)
+	sgptDataTables->nStuff = sgptDataTables->pItemStatCostTxt->dwStuff;
+	if (sgptDataTables->nStuff <= 0 || sgptDataTables->nStuff > 8)
 	{
-		gpDataTables.nStuff = 6;
+		sgptDataTables->nStuff = 6;
 	}
-	gpDataTables.nShiftedStuff = (1 << gpDataTables.nStuff) - 1;
+	sgptDataTables->nShiftedStuff = (1 << sgptDataTables->nStuff) - 1;
 
-	for (int i = 0; i < gpDataTables.nItemStatCostTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nItemStatCostTxtRecordCount; ++i)
 	{
-		memset(gpDataTables.pItemStatCostTxt[i].unk0x5E, -1, sizeof(gpDataTables.pItemStatCostTxt[i].unk0x5E));
+		memset(sgptDataTables->pItemStatCostTxt[i].unk0x5E, -1, sizeof(sgptDataTables->pItemStatCostTxt[i].unk0x5E));
 	}
 
-	for (int nStatId = 0; nStatId < gpDataTables.nItemStatCostTxtRecordCount; ++nStatId)
+	for (int nStatId = 0; nStatId < sgptDataTables->nItemStatCostTxtRecordCount; ++nStatId)
 	{
-		pOp = &gpDataTables.pItemStatCostTxt[nStatId].nOp;
+		pOp = &sgptDataTables->pItemStatCostTxt[nStatId].nOp;
 
 		if (*pOp > 0 && *pOp < 14)
 		{
-			nOpBase = gpDataTables.pItemStatCostTxt[nStatId].wOpBase;
+			nOpBase = sgptDataTables->pItemStatCostTxt[nStatId].wOpBase;
 
-			if (nOpBase < gpDataTables.nItemStatCostTxtRecordCount)
+			if (nOpBase < sgptDataTables->nItemStatCostTxtRecordCount)
 			{
-				gpDataTables.pItemStatCostTxt[nOpBase].unk0x51[0] = 1;
+				sgptDataTables->pItemStatCostTxt[nOpBase].unk0x51[0] = 1;
 
 				nNextFreeId = 0;
-				while (nNextFreeId < ARRAY_SIZE(gpDataTables.pItemStatCostTxt[nOpBase].unk0x5E))
+				while (nNextFreeId < ARRAY_SIZE(sgptDataTables->pItemStatCostTxt[nOpBase].unk0x5E))
 				{
-					if (gpDataTables.pItemStatCostTxt[nOpBase].unk0x5E[nNextFreeId] >= gpDataTables.nItemStatCostTxtRecordCount)
+					if (sgptDataTables->pItemStatCostTxt[nOpBase].unk0x5E[nNextFreeId] >= sgptDataTables->nItemStatCostTxtRecordCount)
 					{
-						gpDataTables.pItemStatCostTxt[nOpBase].unk0x5E[nNextFreeId] = nStatId;
+						sgptDataTables->pItemStatCostTxt[nOpBase].unk0x5E[nNextFreeId] = nStatId;
 						break;
 					}
 
 					++nNextFreeId;
 				}
 
-				if (nNextFreeId >= ARRAY_SIZE(gpDataTables.pItemStatCostTxt[nOpBase].unk0x5E) && gpDataTables.bCompileTxt)
+				if (nNextFreeId >= ARRAY_SIZE(sgptDataTables->pItemStatCostTxt[nOpBase].unk0x5E) && sgptDataTables->bCompileTxt)
 				{
-					FOG_WriteToLogFile("Error: greater than %d ops applied to target %s\n", 3, FOG_10255(gpDataTables.pItemStatCostLinker, nOpBase, 0));
+					FOG_WriteToLogFile("Error: greater than %d ops applied to target %s\n", 3, FOG_10255(sgptDataTables->pItemStatCostLinker, nOpBase, 0));
 				}
 
 				if (*pOp == 4 || *pOp == 5)
 				{
-					gpDataTables.pItemStatCostTxt[nStatId].unk0x51[2] = 1;
+					sgptDataTables->pItemStatCostTxt[nStatId].unk0x51[2] = 1;
 				}
 			}
 
-			pOpStat = gpDataTables.pItemStatCostTxt[nStatId].wOpStat;
-			for (int nOpCounter = 0; nOpCounter < ARRAY_SIZE(gpDataTables.pItemStatCostTxt[nStatId].wOpStat); ++nOpCounter)
+			pOpStat = sgptDataTables->pItemStatCostTxt[nStatId].wOpStat;
+			for (int nOpCounter = 0; nOpCounter < ARRAY_SIZE(sgptDataTables->pItemStatCostTxt[nStatId].wOpStat); ++nOpCounter)
 			{
-				if (pOpStat[nOpCounter] >= gpDataTables.nItemStatCostTxtRecordCount)
+				if (pOpStat[nOpCounter] >= sgptDataTables->nItemStatCostTxtRecordCount)
 				{
 					break;
 				}
 
-				gpDataTables.pItemStatCostTxt[nStatId].unk0x51[0] = 1;
+				sgptDataTables->pItemStatCostTxt[nStatId].unk0x51[0] = 1;
 
 				nNextFreeId = 0;
 				while (nNextFreeId < 16)
 				{
-					if (!gpDataTables.pItemStatCostTxt[pOpStat[nOpCounter]].pOpStatData[nNextFreeId].nOp)
+					if (!sgptDataTables->pItemStatCostTxt[pOpStat[nOpCounter]].pOpStatData[nNextFreeId].nOp)
 					{
-						gpDataTables.pItemStatCostTxt[pOpStat[nOpCounter]].pOpStatData[nNextFreeId].nStat = nStatId;
-						gpDataTables.pItemStatCostTxt[pOpStat[nOpCounter]].pOpStatData[nNextFreeId].nOp = *pOp;
-						gpDataTables.pItemStatCostTxt[pOpStat[nOpCounter]].pOpStatData[nNextFreeId].nOpBase = nOpBase;
-						gpDataTables.pItemStatCostTxt[pOpStat[nOpCounter]].pOpStatData[nNextFreeId].nOpParam = gpDataTables.pItemStatCostTxt[nStatId].nOpParam;
+						sgptDataTables->pItemStatCostTxt[pOpStat[nOpCounter]].pOpStatData[nNextFreeId].nStat = nStatId;
+						sgptDataTables->pItemStatCostTxt[pOpStat[nOpCounter]].pOpStatData[nNextFreeId].nOp = *pOp;
+						sgptDataTables->pItemStatCostTxt[pOpStat[nOpCounter]].pOpStatData[nNextFreeId].nOpBase = nOpBase;
+						sgptDataTables->pItemStatCostTxt[pOpStat[nOpCounter]].pOpStatData[nNextFreeId].nOpParam = sgptDataTables->pItemStatCostTxt[nStatId].nOpParam;
 
-						gpDataTables.pItemStatCostTxt[pOpStat[nOpCounter]].unk0x51[1] = 1;
+						sgptDataTables->pItemStatCostTxt[pOpStat[nOpCounter]].unk0x51[1] = 1;
 
 						if (nStatId == STAT_MAXHP || pOpStat[nOpCounter] == STAT_MAXHP)
 						{
-							gpDataTables.pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_HP];
-							gpDataTables.pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_HP_MANA_STAMINA];
+							sgptDataTables->pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_HP];
+							sgptDataTables->pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_HP_MANA_STAMINA];
 						}
 						else if (nStatId == STAT_MAXMANA || pOpStat[nOpCounter] == STAT_MAXMANA)
 						{
-							gpDataTables.pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_MANA];
-							gpDataTables.pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_HP_MANA_STAMINA];
+							sgptDataTables->pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_MANA];
+							sgptDataTables->pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_HP_MANA_STAMINA];
 						}
 						else if (nStatId == STAT_MAXSTAMINA || pOpStat[nOpCounter] == STAT_MAXSTAMINA)
 						{
-							gpDataTables.pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_STAMINA];
-							gpDataTables.pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_HP_MANA_STAMINA];
+							sgptDataTables->pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_STAMINA];
+							sgptDataTables->pItemStatCostTxt[nStatId].dwItemStatFlags |= gdwBitMasks[ITEMSTATCOSTFLAGINDEX_HP_MANA_STAMINA];
 						}
 						break;
 					}
@@ -1678,9 +1678,9 @@ void __fastcall DATATBLS_LoadItemStatCostTxt(void* pMemPool)
 					++nNextFreeId;
 				}
 
-				if (nNextFreeId >= 16 && gpDataTables.bCompileTxt)
+				if (nNextFreeId >= 16 && sgptDataTables->bCompileTxt)
 				{
-					FOG_WriteToLogFile("Error: greater than %d ops applied to target %s\n", 16, FOG_10255(gpDataTables.pItemStatCostLinker, gpDataTables.pItemStatCostTxt[pOpStat[nOpCounter]].wStatId, 0));
+					FOG_WriteToLogFile("Error: greater than %d ops applied to target %s\n", 16, FOG_10255(sgptDataTables->pItemStatCostLinker, sgptDataTables->pItemStatCostTxt[pOpStat[nOpCounter]].wStatId, 0));
 				}
 			}
 		}
@@ -1691,47 +1691,47 @@ void __fastcall DATATBLS_LoadItemStatCostTxt(void* pMemPool)
 	}
 
 	nStatsWithDescFunc = 0;
-	for (int i = 0; i < gpDataTables.nItemStatCostTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nItemStatCostTxtRecordCount; ++i)
 	{
-		if (gpDataTables.pItemStatCostTxt[i].nDescFunc)
+		if (sgptDataTables->pItemStatCostTxt[i].nDescFunc)
 		{
 			pStatsWithDescFunc[nStatsWithDescFunc].nRecordId = i;
-			pStatsWithDescFunc[nStatsWithDescFunc].nDescPriority = gpDataTables.pItemStatCostTxt[i].nDescPriority;
+			pStatsWithDescFunc[nStatsWithDescFunc].nDescPriority = sgptDataTables->pItemStatCostTxt[i].nDescPriority;
 			++nStatsWithDescFunc;
 		}
 	}
-	gpDataTables.nStatsWithDescFunc = nStatsWithDescFunc;
+	sgptDataTables->nStatsWithDescFunc = nStatsWithDescFunc;
 
 	qsort(pStatsWithDescFunc, nStatsWithDescFunc, sizeof(D2ItemStatCostDescStrc), DATATBLS_CompareItemStatCostDescs);
 
-	gpDataTables.pStatsWithDescFunc = (WORD*)FOG_AllocServerMemory(NULL, sizeof(WORD) * gpDataTables.nStatsWithDescFunc, __FILE__, __LINE__, 0);
-	for (int i = 0; i < gpDataTables.nStatsWithDescFunc; ++i)
+	sgptDataTables->pStatsWithDescFunc = (WORD*)FOG_AllocServerMemory(NULL, sizeof(WORD) * sgptDataTables->nStatsWithDescFunc, __FILE__, __LINE__, 0);
+	for (int i = 0; i < sgptDataTables->nStatsWithDescFunc; ++i)
 	{
-		gpDataTables.pStatsWithDescFunc[i] = pStatsWithDescFunc[i].nRecordId;
+		sgptDataTables->pStatsWithDescFunc[i] = pStatsWithDescFunc[i].nRecordId;
 	}
 }
 
 //D2Common.0x6FD5D070
 void __fastcall DATATBLS_UnloadItemStatCostTxt()
 {
-	if (gpDataTables.pItemStatCostTxt)
+	if (sgptDataTables->pItemStatCostTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pItemStatCostTxt);
+		DATATBLS_UnloadBin(sgptDataTables->pItemStatCostTxt);
 	}
-	gpDataTables.pItemStatCostTxt = NULL;
+	sgptDataTables->pItemStatCostTxt = NULL;
 
-	if (gpDataTables.pItemStatCostLinker)
+	if (sgptDataTables->pItemStatCostLinker)
 	{
-		FOG_FreeLinker(gpDataTables.pItemStatCostLinker);
+		FOG_FreeLinker(sgptDataTables->pItemStatCostLinker);
 	}
-	gpDataTables.pItemStatCostLinker = NULL;
-	gpDataTables.nItemStatCostTxtRecordCount = 0;
+	sgptDataTables->pItemStatCostLinker = NULL;
+	sgptDataTables->nItemStatCostTxtRecordCount = 0;
 
-	if (gpDataTables.pStatsWithDescFunc)
+	if (sgptDataTables->pStatsWithDescFunc)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pStatsWithDescFunc, __FILE__, __LINE__, 0);
+		FOG_FreeServerMemory(NULL, sgptDataTables->pStatsWithDescFunc, __FILE__, __LINE__, 0);
 	}
-	gpDataTables.nStatsWithDescFunc = 0;
+	sgptDataTables->nStatsWithDescFunc = 0;
 }
 
 //D2Common.0x6FD5D0D0
@@ -1739,47 +1739,47 @@ void __fastcall DATATBLS_LoadPropertiesTxt(void* pMemPool)
 {
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "code", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pPropertiesLinker },
+		{ "code", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pPropertiesLinker },
 		{ "set1", TXTFIELD_BYTE, 0, 2, NULL },
 		{ "val1", TXTFIELD_WORD, 0, 10, NULL },
 		{ "func1", TXTFIELD_BYTE, 0, 24, NULL },
-		{ "stat1", TXTFIELD_NAMETOWORD, 0, 32, &gpDataTables.pItemStatCostLinker },
+		{ "stat1", TXTFIELD_NAMETOWORD, 0, 32, &sgptDataTables->pItemStatCostLinker },
 		{ "set2", TXTFIELD_BYTE, 0, 3, NULL },
 		{ "val2", TXTFIELD_WORD, 0, 12, NULL },
 		{ "func2", TXTFIELD_BYTE, 0, 25, NULL },
-		{ "stat2", TXTFIELD_NAMETOWORD, 0, 34, &gpDataTables.pItemStatCostLinker },
+		{ "stat2", TXTFIELD_NAMETOWORD, 0, 34, &sgptDataTables->pItemStatCostLinker },
 		{ "set3", TXTFIELD_BYTE, 0, 4, NULL },
 		{ "val3", TXTFIELD_WORD, 0, 14, NULL },
 		{ "func3", TXTFIELD_BYTE, 0, 26, NULL },
-		{ "stat3", TXTFIELD_NAMETOWORD, 0, 36, &gpDataTables.pItemStatCostLinker },
+		{ "stat3", TXTFIELD_NAMETOWORD, 0, 36, &sgptDataTables->pItemStatCostLinker },
 		{ "set4", TXTFIELD_BYTE, 0, 5, NULL },
 		{ "val4", TXTFIELD_WORD, 0, 16, NULL },
 		{ "func4", TXTFIELD_BYTE, 0, 27, NULL },
-		{ "stat4", TXTFIELD_NAMETOWORD, 0, 38, &gpDataTables.pItemStatCostLinker },
+		{ "stat4", TXTFIELD_NAMETOWORD, 0, 38, &sgptDataTables->pItemStatCostLinker },
 		{ "set5", TXTFIELD_BYTE, 0, 6, NULL },
 		{ "val5", TXTFIELD_WORD, 0, 18, NULL },
 		{ "func5", TXTFIELD_BYTE, 0, 28, NULL },
-		{ "stat5", TXTFIELD_NAMETOWORD, 0, 40, &gpDataTables.pItemStatCostLinker },
+		{ "stat5", TXTFIELD_NAMETOWORD, 0, 40, &sgptDataTables->pItemStatCostLinker },
 		{ "set6", TXTFIELD_BYTE, 0, 7, NULL },
 		{ "val6", TXTFIELD_WORD, 0, TXTFIELD_NAMETOWORD, NULL },
 		{ "func6", TXTFIELD_BYTE, 0, 29, NULL },
-		{ "stat6", TXTFIELD_NAMETOWORD, 0, 42, &gpDataTables.pItemStatCostLinker },
+		{ "stat6", TXTFIELD_NAMETOWORD, 0, 42, &sgptDataTables->pItemStatCostLinker },
 		{ "set7", TXTFIELD_BYTE, 0, 8, NULL },
 		{ "val7", TXTFIELD_WORD, 0, 22, NULL },
 		{ "func7", TXTFIELD_BYTE, 0, 30, NULL },
-		{ "stat7", TXTFIELD_NAMETOWORD, 0, 44, &gpDataTables.pItemStatCostLinker },
+		{ "stat7", TXTFIELD_NAMETOWORD, 0, 44, &sgptDataTables->pItemStatCostLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pPropertiesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pPropertiesTxt = (D2PropertiesTxt*)DATATBLS_CompileTxt(pMemPool, "properties", pTbl, &gpDataTables.nPropertiesTxtRecordCount, sizeof(D2PropertiesTxt));
+	sgptDataTables->pPropertiesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pPropertiesTxt = (D2PropertiesTxt*)DATATBLS_CompileTxt(pMemPool, "properties", pTbl, &sgptDataTables->nPropertiesTxtRecordCount, sizeof(D2PropertiesTxt));
 }
 
 //D2Common.0x6FD5D5E0
 void __fastcall DATATBLS_UnloadPropertiesTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pPropertiesTxt);
-	FOG_FreeLinker(gpDataTables.pPropertiesLinker);
+	DATATBLS_UnloadBin(sgptDataTables->pPropertiesTxt);
+	FOG_FreeLinker(sgptDataTables->pPropertiesLinker);
 }
 
 //D2Common.0x6FD5D600
@@ -1795,47 +1795,47 @@ void __fastcall DATATBLS_LoadGambleTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	pGambleTxt = (D2GambleTxt*)DATATBLS_CompileTxt(pMemPool, "gamble", pTbl, &gpDataTables.pGambleDataTables.nGambleTxtRecordCount, sizeof(D2GambleTxt));
+	pGambleTxt = (D2GambleTxt*)DATATBLS_CompileTxt(pMemPool, "gamble", pTbl, &sgptDataTables->pGambleDataTables.nGambleTxtRecordCount, sizeof(D2GambleTxt));
 
-	if (gpDataTables.pGambleDataTables.nGambleTxtRecordCount)
+	if (sgptDataTables->pGambleDataTables.nGambleTxtRecordCount)
 	{
-		gpDataTables.pGambleDataTables.pGambleSelection = (DWORD*)FOG_AllocServerMemory(NULL, sizeof(DWORD) * gpDataTables.pGambleDataTables.nGambleTxtRecordCount, __FILE__, __LINE__, 0);
-		for (int i = 0; i < gpDataTables.pGambleDataTables.nGambleTxtRecordCount; ++i)
+		sgptDataTables->pGambleDataTables.pGambleSelection = (DWORD*)FOG_AllocServerMemory(NULL, sizeof(DWORD) * sgptDataTables->pGambleDataTables.nGambleTxtRecordCount, __FILE__, __LINE__, 0);
+		for (int i = 0; i < sgptDataTables->pGambleDataTables.nGambleTxtRecordCount; ++i)
 		{
-			nItemId = FOG_GetLinkIndex(gpDataTables.pItemsLinker, pGambleTxt[i].dwItemCode, 0);
-			D2_ASSERT(nItemId >= 0 && &gpDataTables.pItemDataTables.pItemsTxt[nItemId]);
+			nItemId = FOG_GetLinkIndex(sgptDataTables->pItemsLinker, pGambleTxt[i].dwItemCode, 0);
+			D2_ASSERT(nItemId >= 0 && &sgptDataTables->pItemDataTables.pItemsTxt[nItemId]);
 			pGambleTxt[i].nItemId = nItemId;
-			pGambleTxt[i].nLevel = gpDataTables.pItemDataTables.pItemsTxt[nItemId].nLevel;
+			pGambleTxt[i].nLevel = sgptDataTables->pItemDataTables.pItemsTxt[nItemId].nLevel;
 		}
-		qsort(pGambleTxt, gpDataTables.pGambleDataTables.nGambleTxtRecordCount, sizeof(D2GambleTxt), DATATBLS_CompareGambleTxtRecords);
+		qsort(pGambleTxt, sgptDataTables->pGambleDataTables.nGambleTxtRecordCount, sizeof(D2GambleTxt), DATATBLS_CompareGambleTxtRecords);
 	}
 	else
 	{
-		gpDataTables.pGambleDataTables.pGambleSelection = NULL;
+		sgptDataTables->pGambleDataTables.pGambleSelection = NULL;
 	}
 
-	for (int i = 0; i < gpDataTables.pGambleDataTables.nGambleTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->pGambleDataTables.nGambleTxtRecordCount; ++i)
 	{
-		gpDataTables.pGambleDataTables.pGambleSelection[i] = pGambleTxt[i].nItemId;
+		sgptDataTables->pGambleDataTables.pGambleSelection[i] = pGambleTxt[i].nItemId;
 	}
 
-	gpDataTables.pGambleDataTables.pGambleChooseLimit[0] = 2;
+	sgptDataTables->pGambleDataTables.pGambleChooseLimit[0] = 2;
 
-	for (int i = 1; i < ARRAY_SIZE(gpDataTables.pGambleDataTables.pGambleChooseLimit); ++i)
+	for (int i = 1; i < ARRAY_SIZE(sgptDataTables->pGambleDataTables.pGambleChooseLimit); ++i)
 	{
-		gpDataTables.pGambleDataTables.pGambleChooseLimit[i] = gpDataTables.pGambleDataTables.nGambleTxtRecordCount;
+		sgptDataTables->pGambleDataTables.pGambleChooseLimit[i] = sgptDataTables->pGambleDataTables.nGambleTxtRecordCount;
 
-		if (gpDataTables.pGambleDataTables.nGambleTxtRecordCount > 0)
+		if (sgptDataTables->pGambleDataTables.nGambleTxtRecordCount > 0)
 		{
 			nCounter = 0;
-			while (nCounter < gpDataTables.pGambleDataTables.nGambleTxtRecordCount && i >= pGambleTxt[nCounter].nLevel)
+			while (nCounter < sgptDataTables->pGambleDataTables.nGambleTxtRecordCount && i >= pGambleTxt[nCounter].nLevel)
 			{
 				++nCounter;
 			}
 
-			if (nCounter < gpDataTables.pGambleDataTables.nGambleTxtRecordCount)
+			if (nCounter < sgptDataTables->pGambleDataTables.nGambleTxtRecordCount)
 			{
-				gpDataTables.pGambleDataTables.pGambleChooseLimit[i] = nCounter;
+				sgptDataTables->pGambleDataTables.pGambleChooseLimit[i] = nCounter;
 			}
 		}
 	}
@@ -1866,18 +1866,18 @@ int __cdecl DATATBLS_CompareGambleTxtRecords(const void* pRecord1, const void* p
 //D2Common.0x6FD5D7B0
 void __fastcall DATATBLS_UnloadGambleTxt()
 {
-	if (gpDataTables.pGambleDataTables.pGambleSelection)
+	if (sgptDataTables->pGambleDataTables.pGambleSelection)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pGambleDataTables.pGambleSelection, __FILE__, __LINE__, 0);
-		gpDataTables.pGambleDataTables.pGambleSelection = NULL;
-		gpDataTables.pGambleDataTables.nGambleTxtRecordCount = 0;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pGambleDataTables.pGambleSelection, __FILE__, __LINE__, 0);
+		sgptDataTables->pGambleDataTables.pGambleSelection = NULL;
+		sgptDataTables->pGambleDataTables.nGambleTxtRecordCount = 0;
 	}
 }
 
 //D2Common.0x6FD5D7F0 (#10671)
 D2GambleDataTbl* __fastcall DATATBLS_GetGambleDataTables()
 {
-	return &gpDataTables.pGambleDataTables;
+	return &sgptDataTables->pGambleDataTables;
 }
 
 //D2Common.0x6FD5D800
@@ -1893,7 +1893,7 @@ BOOL __fastcall DATATBLS_CheckNestedItemTypes(int nItemType1, int nItemType2)
 		return TRUE;
 	}
 
-	if (nItemType1 > 0 && nItemType1 < gpDataTables.nItemTypesTxtRecordCount)
+	if (nItemType1 > 0 && nItemType1 < sgptDataTables->nItemTypesTxtRecordCount)
 	{
 		nParentItemTypes[1] = nItemType1;
 		nIndex = 1;
@@ -1908,7 +1908,7 @@ BOOL __fastcall DATATBLS_CheckNestedItemTypes(int nItemType1, int nItemType2)
 				return TRUE;
 			}
 
-			if (nItemType >= gpDataTables.nItemTypesTxtRecordCount)
+			if (nItemType >= sgptDataTables->nItemTypesTxtRecordCount)
 			{
 				FOG_WriteToLogFile("Invalid item type at line %d of file %s", __LINE__, __FILE__);
 				return FALSE;
@@ -1919,7 +1919,7 @@ BOOL __fastcall DATATBLS_CheckNestedItemTypes(int nItemType1, int nItemType2)
 				return FALSE;
 			}
 
-			pItemTypesTxtRecord = &gpDataTables.pItemTypesTxt[nItemType];
+			pItemTypesTxtRecord = &sgptDataTables->pItemTypesTxt[nItemType];
 
 			if (pItemTypesTxtRecord->nEquiv1 > 0)
 			{
@@ -1951,15 +1951,15 @@ void __fastcall DATATBLS_LoadItemTypesTxt(void* pMemPool)
 
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &gpDataTables.pItemTypesLinker },
-		{ "equiv1", TXTFIELD_CODETOWORD, 0, TXTFIELD_BYTE, &gpDataTables.pItemTypesLinker },
-		{ "equiv2", TXTFIELD_CODETOWORD, 0, 6, &gpDataTables.pItemTypesLinker },
+		{ "code", TXTFIELD_ASCIITOCODE, 0, 0, &sgptDataTables->pItemTypesLinker },
+		{ "equiv1", TXTFIELD_CODETOWORD, 0, TXTFIELD_BYTE, &sgptDataTables->pItemTypesLinker },
+		{ "equiv2", TXTFIELD_CODETOWORD, 0, 6, &sgptDataTables->pItemTypesLinker },
 		{ "repair", TXTFIELD_BYTE, 0, 8, NULL },
 		{ "body", TXTFIELD_BYTE, 0, 9, NULL },
-		{ "bodyloc1", TXTFIELD_CODETOBYTE, 0, 10, &gpDataTables.pBodyLocsLinker },
-		{ "bodyloc2", TXTFIELD_CODETOBYTE, 0, 11, &gpDataTables.pBodyLocsLinker },
-		{ "shoots", TXTFIELD_CODETOWORD, 0, 12, &gpDataTables.pItemTypesLinker },
-		{ "quiver", TXTFIELD_CODETOWORD, 0, 14, &gpDataTables.pItemTypesLinker },
+		{ "bodyloc1", TXTFIELD_CODETOBYTE, 0, 10, &sgptDataTables->pBodyLocsLinker },
+		{ "bodyloc2", TXTFIELD_CODETOBYTE, 0, 11, &sgptDataTables->pBodyLocsLinker },
+		{ "shoots", TXTFIELD_CODETOWORD, 0, 12, &sgptDataTables->pItemTypesLinker },
+		{ "quiver", TXTFIELD_CODETOWORD, 0, 14, &sgptDataTables->pItemTypesLinker },
 		{ "throwable", TXTFIELD_BYTE, 0, 16, NULL },
 		{ "reload", TXTFIELD_BYTE, 0, 17, NULL },
 		{ "reequip", TXTFIELD_BYTE, 0, 18, NULL },
@@ -1975,10 +1975,10 @@ void __fastcall DATATBLS_LoadItemTypesTxt(void* pMemPool)
 		{ "maxsock40", TXTFIELD_BYTE, 0, 28, NULL },
 		{ "treasureclass", TXTFIELD_BYTE, 0, 29, NULL },
 		{ "rarity", TXTFIELD_BYTE, 0, 30, NULL },
-		{ "staffmods", TXTFIELD_CODETOBYTE, 0, 31, &gpDataTables.pPlayerClassLinker },
+		{ "staffmods", TXTFIELD_CODETOBYTE, 0, 31, &sgptDataTables->pPlayerClassLinker },
 		{ "costformula", TXTFIELD_BYTE, 0, 32, NULL },
-		{ "class", TXTFIELD_CODETOBYTE, 0, 33, &gpDataTables.pPlayerClassLinker },
-		{ "storepage", TXTFIELD_CODETOBYTE, 0, 34, &gpDataTables.pStorePageLinker },
+		{ "class", TXTFIELD_CODETOBYTE, 0, 33, &sgptDataTables->pPlayerClassLinker },
+		{ "storepage", TXTFIELD_CODETOBYTE, 0, 34, &sgptDataTables->pStorePageLinker },
 		{ "varinvgfx", TXTFIELD_BYTE, 0, 35, NULL },
 		{ "invgfx1", TXTFIELD_ASCII, 31, 36, NULL },
 		{ "invgfx2", TXTFIELD_ASCII, 31, 68, NULL },
@@ -1989,26 +1989,26 @@ void __fastcall DATATBLS_LoadItemTypesTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pItemTypesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pItemTypesTxt = (D2ItemTypesTxt*)DATATBLS_CompileTxt(pMemPool, "itemtypes", pTbl, &gpDataTables.nItemTypesTxtRecordCount, sizeof(D2ItemTypesTxt));
+	sgptDataTables->pItemTypesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pItemTypesTxt = (D2ItemTypesTxt*)DATATBLS_CompileTxt(pMemPool, "itemtypes", pTbl, &sgptDataTables->nItemTypesTxtRecordCount, sizeof(D2ItemTypesTxt));
 
-	if (!gpDataTables.bCompileTxt && dword_6FDD6A24)
+	if (!sgptDataTables->bCompileTxt && dword_6FDD6A24)
 	{
-		for (int i = 0; i < gpDataTables.nItemTypesTxtRecordCount; ++i)
+		for (int i = 0; i < sgptDataTables->nItemTypesTxtRecordCount; ++i)
 		{
-			FOG_10215(gpDataTables.pItemTypesLinker, *(DWORD*)&gpDataTables.pItemTypesTxt[i].szCode[0]);
+			FOG_10215(sgptDataTables->pItemTypesLinker, *(DWORD*)&sgptDataTables->pItemTypesTxt[i].szCode[0]);
 		}
 	}
 
-	gpDataTables.nItemTypesIndex = (gpDataTables.nItemTypesTxtRecordCount + 31) / 32;
-	gpDataTables.pItemTypesNest = (DWORD*)FOG_AllocServerMemory(NULL, sizeof(DWORD) * gpDataTables.nItemTypesTxtRecordCount * gpDataTables.nItemTypesIndex, __FILE__, __LINE__, 0);
-	memset(gpDataTables.pItemTypesNest, 0x00, sizeof(DWORD) * gpDataTables.nItemTypesTxtRecordCount * gpDataTables.nItemTypesIndex);
+	sgptDataTables->nItemTypesIndex = (sgptDataTables->nItemTypesTxtRecordCount + 31) / 32;
+	sgptDataTables->pItemTypesNest = (DWORD*)FOG_AllocServerMemory(NULL, sizeof(DWORD) * sgptDataTables->nItemTypesTxtRecordCount * sgptDataTables->nItemTypesIndex, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->pItemTypesNest, 0x00, sizeof(DWORD) * sgptDataTables->nItemTypesTxtRecordCount * sgptDataTables->nItemTypesIndex);
 
-	for (int i = 0; i < gpDataTables.nItemTypesTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nItemTypesTxtRecordCount; ++i)
 	{
-		pItemTypesNest = &gpDataTables.pItemTypesNest[gpDataTables.nItemTypesIndex * i];
+		pItemTypesNest = &sgptDataTables->pItemTypesNest[sgptDataTables->nItemTypesIndex * i];
 
-		for (int j = 0; j < gpDataTables.nItemTypesTxtRecordCount; ++j)
+		for (int j = 0; j < sgptDataTables->nItemTypesTxtRecordCount; ++j)
 		{
 			if (DATATBLS_CheckNestedItemTypes(i, j))
 			{
@@ -2021,9 +2021,9 @@ void __fastcall DATATBLS_LoadItemTypesTxt(void* pMemPool)
 //D2Common.0x6FD5DFE0
 void __fastcall DATATBLS_UnloadItemTypesTxt()
 {
-	FOG_FreeServerMemory(NULL, gpDataTables.pItemTypesNest, __FILE__, __LINE__, 0);
-	DATATBLS_UnloadBin(gpDataTables.pItemTypesTxt);
-	FOG_FreeLinker(gpDataTables.pItemTypesLinker);
+	FOG_FreeServerMemory(NULL, sgptDataTables->pItemTypesNest, __FILE__, __LINE__, 0);
+	DATATBLS_UnloadBin(sgptDataTables->pItemTypesTxt);
+	FOG_FreeLinker(sgptDataTables->pItemTypesLinker);
 }
 
 //D2Common.0x6FD5E020
@@ -2038,53 +2038,53 @@ void __fastcall DATATBLS_LoadRunesTxt(void* pMemPool)
 		{ "rune name", TXTFIELD_ASCII, 63, 64, NULL },
 		{ "complete", TXTFIELD_BYTE, 0, 128, NULL },
 		{ "server", TXTFIELD_BYTE, 0, 129, NULL },
-		{ "itype1", TXTFIELD_CODETOWORD, 0, 134, &gpDataTables.pItemTypesLinker },
-		{ "itype2", TXTFIELD_CODETOWORD, 0, 136, &gpDataTables.pItemTypesLinker },
-		{ "itype3", TXTFIELD_CODETOWORD, 0, 138, &gpDataTables.pItemTypesLinker },
-		{ "itype4", TXTFIELD_CODETOWORD, 0, 140, &gpDataTables.pItemTypesLinker },
-		{ "itype5", TXTFIELD_CODETOWORD, 0, 142, &gpDataTables.pItemTypesLinker },
-		{ "itype6", TXTFIELD_CODETOWORD, 0, 144, &gpDataTables.pItemTypesLinker },
-		{ "etype1", TXTFIELD_CODETOWORD, 0, 146, &gpDataTables.pItemTypesLinker },
-		{ "etype2", TXTFIELD_CODETOWORD, 0, 148, &gpDataTables.pItemTypesLinker },
-		{ "etype3", TXTFIELD_CODETOWORD, 0, 150, &gpDataTables.pItemTypesLinker },
-		{ "rune1", TXTFIELD_UNKNOWN3, 0, 152, &gpDataTables.pItemsLinker },
-		{ "rune2", TXTFIELD_UNKNOWN3, 0, 156, &gpDataTables.pItemsLinker },
-		{ "rune3", TXTFIELD_UNKNOWN3, 0, 160, &gpDataTables.pItemsLinker },
-		{ "rune4", TXTFIELD_UNKNOWN3, 0, 164, &gpDataTables.pItemsLinker },
-		{ "rune5", TXTFIELD_UNKNOWN3, 0, 168, &gpDataTables.pItemsLinker },
-		{ "rune6", TXTFIELD_UNKNOWN3, 0, 172, &gpDataTables.pItemsLinker },
-		{ "t1code1", TXTFIELD_NAMETODWORD, 0, 176, &gpDataTables.pPropertiesLinker },
+		{ "itype1", TXTFIELD_CODETOWORD, 0, 134, &sgptDataTables->pItemTypesLinker },
+		{ "itype2", TXTFIELD_CODETOWORD, 0, 136, &sgptDataTables->pItemTypesLinker },
+		{ "itype3", TXTFIELD_CODETOWORD, 0, 138, &sgptDataTables->pItemTypesLinker },
+		{ "itype4", TXTFIELD_CODETOWORD, 0, 140, &sgptDataTables->pItemTypesLinker },
+		{ "itype5", TXTFIELD_CODETOWORD, 0, 142, &sgptDataTables->pItemTypesLinker },
+		{ "itype6", TXTFIELD_CODETOWORD, 0, 144, &sgptDataTables->pItemTypesLinker },
+		{ "etype1", TXTFIELD_CODETOWORD, 0, 146, &sgptDataTables->pItemTypesLinker },
+		{ "etype2", TXTFIELD_CODETOWORD, 0, 148, &sgptDataTables->pItemTypesLinker },
+		{ "etype3", TXTFIELD_CODETOWORD, 0, 150, &sgptDataTables->pItemTypesLinker },
+		{ "rune1", TXTFIELD_UNKNOWN3, 0, 152, &sgptDataTables->pItemsLinker },
+		{ "rune2", TXTFIELD_UNKNOWN3, 0, 156, &sgptDataTables->pItemsLinker },
+		{ "rune3", TXTFIELD_UNKNOWN3, 0, 160, &sgptDataTables->pItemsLinker },
+		{ "rune4", TXTFIELD_UNKNOWN3, 0, 164, &sgptDataTables->pItemsLinker },
+		{ "rune5", TXTFIELD_UNKNOWN3, 0, 168, &sgptDataTables->pItemsLinker },
+		{ "rune6", TXTFIELD_UNKNOWN3, 0, 172, &sgptDataTables->pItemsLinker },
+		{ "t1code1", TXTFIELD_NAMETODWORD, 0, 176, &sgptDataTables->pPropertiesLinker },
 		{ "t1param1", TXTFIELD_CALCTODWORD, 0, 180, DATATBLS_ItemParamLinker },
 		{ "t1min1", TXTFIELD_DWORD, 0, 184, NULL },
 		{ "t1max1", TXTFIELD_DWORD, 0, 188, NULL },
-		{ "t1code2", TXTFIELD_NAMETODWORD, 0, 192, &gpDataTables.pPropertiesLinker },
+		{ "t1code2", TXTFIELD_NAMETODWORD, 0, 192, &sgptDataTables->pPropertiesLinker },
 		{ "t1param2", TXTFIELD_CALCTODWORD, 0, 196, DATATBLS_ItemParamLinker },
 		{ "t1min2", TXTFIELD_DWORD, 0, 200, NULL },
 		{ "t1max2", TXTFIELD_DWORD, 0, 204, NULL },
-		{ "t1code3", TXTFIELD_NAMETODWORD, 0, 208, &gpDataTables.pPropertiesLinker },
+		{ "t1code3", TXTFIELD_NAMETODWORD, 0, 208, &sgptDataTables->pPropertiesLinker },
 		{ "t1param3", TXTFIELD_CALCTODWORD, 0, 212, DATATBLS_ItemParamLinker },
 		{ "t1min3", TXTFIELD_DWORD, 0, 216, NULL },
 		{ "t1max3", TXTFIELD_DWORD, 0, 220, NULL },
-		{ "t1code4", TXTFIELD_NAMETODWORD, 0, 224, &gpDataTables.pPropertiesLinker },
+		{ "t1code4", TXTFIELD_NAMETODWORD, 0, 224, &sgptDataTables->pPropertiesLinker },
 		{ "t1param4", TXTFIELD_CALCTODWORD, 0, 228, DATATBLS_ItemParamLinker },
 		{ "t1min4", TXTFIELD_DWORD, 0, 232, NULL },
 		{ "t1max4", TXTFIELD_DWORD, 0, 236, NULL },
-		{ "t1code5", TXTFIELD_NAMETODWORD, 0, 240, &gpDataTables.pPropertiesLinker },
+		{ "t1code5", TXTFIELD_NAMETODWORD, 0, 240, &sgptDataTables->pPropertiesLinker },
 		{ "t1param5", TXTFIELD_CALCTODWORD, 0, 244, DATATBLS_ItemParamLinker },
 		{ "t1min5", TXTFIELD_DWORD, 0, 248, NULL },
 		{ "t1max5", TXTFIELD_DWORD, 0, 252, NULL },
-		{ "t1code6", TXTFIELD_NAMETODWORD, 0, 256, &gpDataTables.pPropertiesLinker },
+		{ "t1code6", TXTFIELD_NAMETODWORD, 0, 256, &sgptDataTables->pPropertiesLinker },
 		{ "t1param6", TXTFIELD_CALCTODWORD, 0, 260, DATATBLS_ItemParamLinker },
 		{ "t1min6", TXTFIELD_DWORD, 0, 264, NULL },
 		{ "t1max6", TXTFIELD_DWORD, 0, 268, NULL },
-		{ "t1code7", TXTFIELD_NAMETODWORD, 0, 272, &gpDataTables.pPropertiesLinker },
+		{ "t1code7", TXTFIELD_NAMETODWORD, 0, 272, &sgptDataTables->pPropertiesLinker },
 		{ "t1param7", TXTFIELD_CALCTODWORD, 0, 276, DATATBLS_ItemParamLinker },
 		{ "t1min7", TXTFIELD_DWORD, 0, 280, NULL },
 		{ "t1max7", TXTFIELD_DWORD, 0, 284, NULL },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pRunesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pRunesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
 
 	wsprintfA(szPath, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", "runessrv", ".txt");
 	if (DATATBLS_CheckIfFileExists(pMemPool, szPath, &pFileHandle, 1))
@@ -2107,25 +2107,25 @@ void __fastcall DATATBLS_LoadRunesTxt(void* pMemPool)
 		FOG_10025("Found runessrv.xls in archive - This file should only be in server builds.", __FILE__, __LINE__);
 	}
 
-	gpDataTables.pRuneDataTables.pRunesTxt = (D2RunesTxt*)DATATBLS_CompileTxt(pMemPool, "runes", pTbl, &gpDataTables.pRuneDataTables.nRunesTxtRecordCount, sizeof(D2RunesTxt));
+	sgptDataTables->pRuneDataTables.pRunesTxt = (D2RunesTxt*)DATATBLS_CompileTxt(pMemPool, "runes", pTbl, &sgptDataTables->pRuneDataTables.nRunesTxtRecordCount, sizeof(D2RunesTxt));
 
-	for (int i = 0; i < gpDataTables.pRuneDataTables.nRunesTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->pRuneDataTables.nRunesTxtRecordCount; ++i)
 	{
-		gpDataTables.pRuneDataTables.pRunesTxt[i].wStringId = D2LANG_GetTblIndex(gpDataTables.pRuneDataTables.pRunesTxt[i].szName, &pUnicode);
+		sgptDataTables->pRuneDataTables.pRunesTxt[i].wStringId = D2LANG_GetTblIndex(sgptDataTables->pRuneDataTables.pRunesTxt[i].szName, &pUnicode);
 	}
 }
 
 //D2Common.0x6FD5E9C0
 void __fastcall DATATBLS_UnloadRunesTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pRuneDataTables.pRunesTxt);
-	FOG_FreeLinker(gpDataTables.pRunesLinker);
+	DATATBLS_UnloadBin(sgptDataTables->pRuneDataTables.pRunesTxt);
+	FOG_FreeLinker(sgptDataTables->pRunesLinker);
 }
 
 //D2Common.0x6FD5E9E0 (#10619)
 D2RuneDataTbl* __fastcall DATATBLS_GetRuneDataTables()
 {
-	return &gpDataTables.pRuneDataTables;
+	return &sgptDataTables->pRuneDataTables;
 }
 
 //D2Common.0x6FD5E9F0 (#10621)
@@ -2136,14 +2136,14 @@ void __stdcall DATATBLS_AddOrChangeRunesTxtRecord(int nRecordId, D2RunesTxt* pRe
 
 	int nSize = 0;
 
-	if (nRecordId >= gpDataTables.pRuneDataTables.nRunesTxtRecordCount)
+	if (nRecordId >= sgptDataTables->pRuneDataTables.nRunesTxtRecordCount)
 	{
-		pRunesTxt = gpDataTables.pRuneDataTables.pRunesTxt;
+		pRunesTxt = sgptDataTables->pRuneDataTables.pRunesTxt;
 		nSize = sizeof(D2RunesTxt) * (nRecordId + 1);
 
 		if (dword_6FDD6A24)
 		{
-			pRunesTxt = (D2RunesTxt*)((char*)gpDataTables.pRuneDataTables.pRunesTxt - 4);
+			pRunesTxt = (D2RunesTxt*)((char*)sgptDataTables->pRuneDataTables.pRunesTxt - 4);
 			nSize += 4;
 		}
 
@@ -2154,18 +2154,18 @@ void __stdcall DATATBLS_AddOrChangeRunesTxtRecord(int nRecordId, D2RunesTxt* pRe
 			*(DWORD*)pTmp = nRecordId + 1;
 			pTmp = (D2RunesTxt*)((char*)pTmp + 4);
 		}
-		gpDataTables.pRuneDataTables.pRunesTxt = pTmp;
+		sgptDataTables->pRuneDataTables.pRunesTxt = pTmp;
 
-		memset(&pTmp[gpDataTables.pRuneDataTables.nRunesTxtRecordCount], 0x00, sizeof(D2RunesTxt) * (nRecordId - gpDataTables.pRuneDataTables.nRunesTxtRecordCount));
-		gpDataTables.pRuneDataTables.nRunesTxtRecordCount = nRecordId + 1;
+		memset(&pTmp[sgptDataTables->pRuneDataTables.nRunesTxtRecordCount], 0x00, sizeof(D2RunesTxt) * (nRecordId - sgptDataTables->pRuneDataTables.nRunesTxtRecordCount));
+		sgptDataTables->pRuneDataTables.nRunesTxtRecordCount = nRecordId + 1;
 	}
 
-	memcpy(&gpDataTables.pRuneDataTables.pRunesTxt[nRecordId], pRecord, sizeof(gpDataTables.pRuneDataTables.pRunesTxt[nRecordId]));
+	memcpy(&sgptDataTables->pRuneDataTables.pRunesTxt[nRecordId], pRecord, sizeof(sgptDataTables->pRuneDataTables.pRunesTxt[nRecordId]));
 }
 
 //D2Common.0x6FD5EAA0 (#10620)
 D2RunesTxt* __stdcall DATATBLS_GetRunesTxtRecord(int nRunewordId)
 {
-	D2_ASSERT(nRunewordId > 0 || nRunewordId < gpDataTables.pRuneDataTables.nRunesTxtRecordCount);
-	return &gpDataTables.pRuneDataTables.pRunesTxt[nRunewordId];
+	D2_ASSERT(nRunewordId > 0 || nRunewordId < sgptDataTables->pRuneDataTables.nRunesTxtRecordCount);
+	return &sgptDataTables->pRuneDataTables.pRunesTxt[nRunewordId];
 }

--- a/source/D2Common/src/DataTbls/MissilesTbls.cpp
+++ b/source/D2Common/src/DataTbls/MissilesTbls.cpp
@@ -34,7 +34,7 @@ int __fastcall DATATBLS_MapMissilesTxtKeywordToNumber(char* szKey)
 //TODO: Find a name
 int __fastcall sub_6FD62F20(char* szText, int* a2, int a3, int nKeywordNumber)
 {
-	D2TxtLinkStrc* pLinker = gpDataTables.pMissileCalcLinker;
+	D2TxtLinkStrc* pLinker = sgptDataTables->pMissileCalcLinker;
 	char szCode[4] = {};
 	int nRow = 0;
 
@@ -42,23 +42,23 @@ int __fastcall sub_6FD62F20(char* szText, int* a2, int a3, int nKeywordNumber)
 	{
 		if (nKeywordNumber == 3)
 		{
-			if (gpDataTables.iSkillCode)
+			if (sgptDataTables->iSkillCode)
 			{
-				nRow = FOG_GetRowFromTxt(gpDataTables.iSkillCode, szText, 0);
+				nRow = FOG_GetRowFromTxt(sgptDataTables->iSkillCode, szText, 0);
 				if (nRow >= 0)
 				{
 					*a2 = 1;
 					return nRow;
 				}
 
-				pLinker = gpDataTables.pSkillCalcLinker;
+				pLinker = sgptDataTables->pSkillCalcLinker;
 			}
 		}
 		else if (nKeywordNumber == 4)
 		{
-			if (gpDataTables.pMissilesLinker)
+			if (sgptDataTables->pMissilesLinker)
 			{
-				nRow = FOG_GetRowFromTxt(gpDataTables.pMissilesLinker, szText, 0);
+				nRow = FOG_GetRowFromTxt(sgptDataTables->pMissilesLinker, szText, 0);
 				if (nRow >= 0)
 				{
 					*a2 = 1;
@@ -66,7 +66,7 @@ int __fastcall sub_6FD62F20(char* szText, int* a2, int a3, int nKeywordNumber)
 				}
 			}
 
-			pLinker = gpDataTables.pMissileCalcLinker;
+			pLinker = sgptDataTables->pMissileCalcLinker;
 		}
 	}
 
@@ -128,7 +128,7 @@ void __fastcall DATATBLS_MissileCalcLinker(char* pSrc, void* pRecord, int nOffse
 			nBufferSize = FOG_10254(pSrc, pBuffer, sizeof(pBuffer), DATATBLS_MapMissilesTxtKeywordToNumber, NULL, sub_6FD62F20);
 			if (nBufferSize > 0)
 			{
-				*(DWORD*)((char*)pRecord + nOffset) = DATATBLS_AppendMemoryBuffer(&gpDataTables.pMissCode, (int*)&gpDataTables.nMissCodeSize, &gpDataTables.nMissCodeSizeEx, pBuffer, nBufferSize);
+				*(DWORD*)((char*)pRecord + nOffset) = DATATBLS_AppendMemoryBuffer(&sgptDataTables->pMissCode, (int*)&sgptDataTables->nMissCodeSize, &sgptDataTables->nMissCodeSizeEx, pBuffer, nBufferSize);
 			}
 			else
 			{
@@ -147,7 +147,7 @@ void __fastcall DATATBLS_LoadMissilesTxt(void* pMemPool)
 {
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "Missile", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pMissilesLinker },
+		{ "Missile", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pMissilesLinker },
 		{ "LastCollide", TXTFIELD_BIT, 0, 4, NULL },
 		{ "Explosion", TXTFIELD_BIT, 1, 4, NULL },
 		{ "Pierce", TXTFIELD_BIT, 2, 4, NULL },
@@ -190,25 +190,25 @@ void __fastcall DATATBLS_LoadMissilesTxt(void* pMemPool)
 		{ "dParam1", TXTFIELD_DWORD, 0, 120, NULL },
 		{ "dParam2", TXTFIELD_DWORD, 0, 124, NULL },
 		{ "DmgCalc1", TXTFIELD_CALCTODWORD, 0, 144, DATATBLS_MissileCalcLinker },
-		{ "TravelSound", TXTFIELD_NAMETOWORD, 0, 18, &gpDataTables.pSoundsLinker },
-		{ "HitSound", TXTFIELD_NAMETOWORD, 0, 20, &gpDataTables.pSoundsLinker },
-		{ "ProgSound", TXTFIELD_NAMETOWORD, 0, 52, &gpDataTables.pSoundsLinker },
-		{ "ProgOverlay", TXTFIELD_NAMETOWORD, 0, 54, &gpDataTables.pOverlayLinker },
-		{ "ExplosionMissile", TXTFIELD_NAMETOWORD, 0, 22, &gpDataTables.pMissilesLinker },
-		{ "SubMissile1", TXTFIELD_NAMETOWORD, 0, 24, &gpDataTables.pMissilesLinker },
-		{ "SubMissile2", TXTFIELD_NAMETOWORD, 0, 26, &gpDataTables.pMissilesLinker },
-		{ "SubMissile3", TXTFIELD_NAMETOWORD, 0, 28, &gpDataTables.pMissilesLinker },
-		{ "HitSubMissile1", TXTFIELD_NAMETOWORD, 0, 36, &gpDataTables.pMissilesLinker },
-		{ "HitSubMissile2", TXTFIELD_NAMETOWORD, 0, 38, &gpDataTables.pMissilesLinker },
-		{ "HitSubMissile3", TXTFIELD_NAMETOWORD, 0, 40, &gpDataTables.pMissilesLinker },
-		{ "HitSubMissile4", TXTFIELD_NAMETOWORD, 0, 42, &gpDataTables.pMissilesLinker },
-		{ "CltSubMissile1", TXTFIELD_NAMETOWORD, 0, 30, &gpDataTables.pMissilesLinker },
-		{ "CltSubMissile2", TXTFIELD_NAMETOWORD, 0, 32, &gpDataTables.pMissilesLinker },
-		{ "CltSubMissile3", TXTFIELD_NAMETOWORD, 0, 34, &gpDataTables.pMissilesLinker },
-		{ "CltHitSubMissile1", TXTFIELD_NAMETOWORD, 0, 44, &gpDataTables.pMissilesLinker },
-		{ "CltHitSubMissile2", TXTFIELD_NAMETOWORD, 0, 46, &gpDataTables.pMissilesLinker },
-		{ "CltHitSubMissile3", TXTFIELD_NAMETOWORD, 0, 48, &gpDataTables.pMissilesLinker },
-		{ "CltHitSubMissile4", TXTFIELD_NAMETOWORD, 0, 50, &gpDataTables.pMissilesLinker },
+		{ "TravelSound", TXTFIELD_NAMETOWORD, 0, 18, &sgptDataTables->pSoundsLinker },
+		{ "HitSound", TXTFIELD_NAMETOWORD, 0, 20, &sgptDataTables->pSoundsLinker },
+		{ "ProgSound", TXTFIELD_NAMETOWORD, 0, 52, &sgptDataTables->pSoundsLinker },
+		{ "ProgOverlay", TXTFIELD_NAMETOWORD, 0, 54, &sgptDataTables->pOverlayLinker },
+		{ "ExplosionMissile", TXTFIELD_NAMETOWORD, 0, 22, &sgptDataTables->pMissilesLinker },
+		{ "SubMissile1", TXTFIELD_NAMETOWORD, 0, 24, &sgptDataTables->pMissilesLinker },
+		{ "SubMissile2", TXTFIELD_NAMETOWORD, 0, 26, &sgptDataTables->pMissilesLinker },
+		{ "SubMissile3", TXTFIELD_NAMETOWORD, 0, 28, &sgptDataTables->pMissilesLinker },
+		{ "HitSubMissile1", TXTFIELD_NAMETOWORD, 0, 36, &sgptDataTables->pMissilesLinker },
+		{ "HitSubMissile2", TXTFIELD_NAMETOWORD, 0, 38, &sgptDataTables->pMissilesLinker },
+		{ "HitSubMissile3", TXTFIELD_NAMETOWORD, 0, 40, &sgptDataTables->pMissilesLinker },
+		{ "HitSubMissile4", TXTFIELD_NAMETOWORD, 0, 42, &sgptDataTables->pMissilesLinker },
+		{ "CltSubMissile1", TXTFIELD_NAMETOWORD, 0, 30, &sgptDataTables->pMissilesLinker },
+		{ "CltSubMissile2", TXTFIELD_NAMETOWORD, 0, 32, &sgptDataTables->pMissilesLinker },
+		{ "CltSubMissile3", TXTFIELD_NAMETOWORD, 0, 34, &sgptDataTables->pMissilesLinker },
+		{ "CltHitSubMissile1", TXTFIELD_NAMETOWORD, 0, 44, &sgptDataTables->pMissilesLinker },
+		{ "CltHitSubMissile2", TXTFIELD_NAMETOWORD, 0, 46, &sgptDataTables->pMissilesLinker },
+		{ "CltHitSubMissile3", TXTFIELD_NAMETOWORD, 0, 48, &sgptDataTables->pMissilesLinker },
+		{ "CltHitSubMissile4", TXTFIELD_NAMETOWORD, 0, 50, &sgptDataTables->pMissilesLinker },
 		{ "ResultFlags", TXTFIELD_WORD, 0, 172, NULL },
 		{ "HitFlags", TXTFIELD_DWORD2, 0, 168, NULL },
 		{ "HitClass", TXTFIELD_BYTE, 0, 148, NULL },
@@ -220,7 +220,7 @@ void __fastcall DATATBLS_LoadMissilesTxt(void* pMemPool)
 		{ "yoffset", TXTFIELD_WORD, 0, 164, NULL },
 		{ "zoffset", TXTFIELD_WORD, 0, 166, NULL },
 		{ "MissileSkill", TXTFIELD_BIT, 15, 4, NULL },
-		{ "Skill", TXTFIELD_NAMETOWORD, 0, 404, &gpDataTables.iSkillCode },
+		{ "Skill", TXTFIELD_NAMETOWORD, 0, 404, &sgptDataTables->iSkillCode },
 		{ "MinDamage", TXTFIELD_DWORD, 0, 176, NULL },
 		{ "MinLevDam1", TXTFIELD_DWORD, 0, 184, NULL },
 		{ "MinLevDam2", TXTFIELD_DWORD, 0, 188, NULL },
@@ -234,7 +234,7 @@ void __fastcall DATATBLS_LoadMissilesTxt(void* pMemPool)
 		{ "MaxLevDam4", TXTFIELD_DWORD, 0, 216, NULL },
 		{ "MaxLevDam5", TXTFIELD_DWORD, 0, 220, NULL },
 		{ "DmgSymPerCalc", TXTFIELD_CALCTODWORD, 0, 224, DATATBLS_MissileCalcLinker },
-		{ "EType", TXTFIELD_CODETOBYTE, 0, 228, &gpDataTables.pElemTypesLinker },
+		{ "EType", TXTFIELD_CODETOBYTE, 0, 228, &sgptDataTables->pElemTypesLinker },
 		{ "EMin", TXTFIELD_DWORD, 0, 232, NULL },
 		{ "MinELev1", TXTFIELD_DWORD, 0, 240, NULL },
 		{ "MinELev2", TXTFIELD_DWORD, 0, 244, NULL },
@@ -296,52 +296,52 @@ void __fastcall DATATBLS_LoadMissilesTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMissilesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pMissilesTxt = (D2MissilesTxt*)DATATBLS_CompileTxt(pMemPool, "missiles", pTbl, &gpDataTables.nMissilesTxtRecordCount, sizeof(D2MissilesTxt));
+	sgptDataTables->pMissilesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pMissilesTxt = (D2MissilesTxt*)DATATBLS_CompileTxt(pMemPool, "missiles", pTbl, &sgptDataTables->nMissilesTxtRecordCount, sizeof(D2MissilesTxt));
 
-	for (int i = 0; i < gpDataTables.nMissilesTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nMissilesTxtRecordCount; ++i)
 	{
-		if (gpDataTables.pMissilesTxt[i].nCollideType > 8)
+		if (sgptDataTables->pMissilesTxt[i].nCollideType > 8)
 		{
 			FOG_WriteToLogFile("Range error in entry %d in table '%s' field '%s'.  Value must be between %d and %d.", i, "missiles", "CollideType", 0, 8);
 		}
 
-		if (gpDataTables.pMissilesTxt[i].nCollideType < 0)
+		if (sgptDataTables->pMissilesTxt[i].nCollideType < 0)
 		{
-			gpDataTables.pMissilesTxt[i].nCollideType = 0;
+			sgptDataTables->pMissilesTxt[i].nCollideType = 0;
 		}
-		else if (gpDataTables.pMissilesTxt[i].nCollideType > 8)
+		else if (sgptDataTables->pMissilesTxt[i].nCollideType > 8)
 		{
-			gpDataTables.pMissilesTxt[i].nCollideType = 8;
+			sgptDataTables->pMissilesTxt[i].nCollideType = 8;
 		}
 	}
 
-	DATATBLS_GetBinFileHandle(pMemPool, "misscode", (void**)&gpDataTables.pMissCode, (int*)&gpDataTables.nMissCodeSize, &gpDataTables.nMissCodeSizeEx);
+	DATATBLS_GetBinFileHandle(pMemPool, "misscode", (void**)&sgptDataTables->pMissCode, (int*)&sgptDataTables->nMissCodeSize, &sgptDataTables->nMissCodeSizeEx);
 }
 
 //D2Common.0x6FD64B80
 void __fastcall DATATBLS_UnloadMissilesTxt()
 {
-	if (gpDataTables.pMissCode)
+	if (sgptDataTables->pMissCode)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pMissCode, __FILE__, __LINE__, 0);
-		gpDataTables.pMissCode = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pMissCode, __FILE__, __LINE__, 0);
+		sgptDataTables->pMissCode = NULL;
 	}
-	gpDataTables.nMissCodeSize = 0;
-	gpDataTables.nMissCodeSizeEx = 0;
+	sgptDataTables->nMissCodeSize = 0;
+	sgptDataTables->nMissCodeSizeEx = 0;
 
-	if (gpDataTables.pMissilesTxt)
+	if (sgptDataTables->pMissilesTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pMissilesTxt);
-		gpDataTables.pMissilesTxt = NULL;
+		DATATBLS_UnloadBin(sgptDataTables->pMissilesTxt);
+		sgptDataTables->pMissilesTxt = NULL;
 	}
 
-	if (gpDataTables.pMissilesLinker)
+	if (sgptDataTables->pMissilesLinker)
 	{
-		FOG_FreeLinker(gpDataTables.pMissilesLinker);
-		gpDataTables.pMissilesLinker = NULL;
+		FOG_FreeLinker(sgptDataTables->pMissilesLinker);
+		sgptDataTables->pMissilesLinker = NULL;
 	}
-	gpDataTables.nMissilesTxtRecordCount = 0;
+	sgptDataTables->nMissilesTxtRecordCount = 0;
 }
 
 //D2Common.0x6FD64BE0 (#10590)
@@ -362,9 +362,9 @@ D2MissilesTxt* __fastcall DATATBLS_GetMissilesTxtRecord(int nMissileId)
 {
 	D2MissilesTxt* pMissilesTxtRecord = NULL;
 
-	if (nMissileId >= 0 && nMissileId < gpDataTables.nMissilesTxtRecordCount)
+	if (nMissileId >= 0 && nMissileId < sgptDataTables->nMissilesTxtRecordCount)
 	{
-		return &gpDataTables.pMissilesTxt[nMissileId];
+		return &sgptDataTables->pMissilesTxt[nMissileId];
 	}
 
 	return NULL;

--- a/source/D2Common/src/DataTbls/MonsterTbls.cpp
+++ b/source/D2Common/src/DataTbls/MonsterTbls.cpp
@@ -123,7 +123,7 @@ void __fastcall DATATBLS_MonStatsSkillModeLinker(char* pSrc, void* pRecord, int 
 			if (~nInverseLength - 1 > 3)
 			{
 				pMonStatsTxtRecord->nSkillMode[nOffset] = MONMODE_SEQUENCE;
-				pMonStatsTxtRecord->nSequence[nOffset] = FOG_GetRowFromTxt(gpDataTables.pMonSeqLinker, pSrc, 1);
+				pMonStatsTxtRecord->nSequence[nOffset] = FOG_GetRowFromTxt(sgptDataTables->pMonSeqLinker, pSrc, 1);
 				return;
 			}
 
@@ -136,13 +136,13 @@ void __fastcall DATATBLS_MonStatsSkillModeLinker(char* pSrc, void* pRecord, int 
 			}
 			while (szCurrentChar);
 
-			nMode = FOG_GetLinkIndex(gpDataTables.pMonModeLinker, DATATBLS_StringToCode(szMode), 1);
+			nMode = FOG_GetLinkIndex(sgptDataTables->pMonModeLinker, DATATBLS_StringToCode(szMode), 1);
 			pMonStatsTxtRecord->nSkillMode[nOffset] = nMode;
 
 			if (nMode < 0 || nMode == MONMODE_SEQUENCE)
 			{
 				pMonStatsTxtRecord->nSkillMode[nOffset] = MONMODE_SEQUENCE;
-				pMonStatsTxtRecord->nSequence[nOffset] = FOG_GetRowFromTxt(gpDataTables.pMonSeqLinker, pSrc, 1);
+				pMonStatsTxtRecord->nSequence[nOffset] = FOG_GetRowFromTxt(sgptDataTables->pMonSeqLinker, pSrc, 1);
 			}
 		}
 	}
@@ -165,25 +165,25 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "Id", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pMonStatsLinker },
-		{ "BaseId", TXTFIELD_NAMETOWORD, 0, 2, &gpDataTables.pMonStatsLinker },
-		{ "NextInClass", TXTFIELD_NAMETOWORD, 0, 4, &gpDataTables.pMonStatsLinker },
+		{ "Id", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pMonStatsLinker },
+		{ "BaseId", TXTFIELD_NAMETOWORD, 0, 2, &sgptDataTables->pMonStatsLinker },
+		{ "NextInClass", TXTFIELD_NAMETOWORD, 0, 4, &sgptDataTables->pMonStatsLinker },
 		{ "NameStr", TXTFIELD_KEYTOWORD, 0, 6, DATATBLS_GetStringIdFromReferenceString },
 		{ "DescStr", TXTFIELD_KEYTOWORD, 0, 8, DATATBLS_GetStringIdFromReferenceString },
 		{ "Code", TXTFIELD_RAW, 0, 16, NULL },
 		{ "TransLvl", TXTFIELD_BYTE, 0, 77, NULL },
-		{ "MonSound", TXTFIELD_NAMETOWORD, 0, 20, &gpDataTables.pMonSoundsLinker },
-		{ "UMonSound", TXTFIELD_NAMETOWORD, 0, 22, &gpDataTables.pMonSoundsLinker },
-		{ "MonStatsEx", TXTFIELD_NAMETOWORD, 0, 24, &gpDataTables.pMonStats2Linker },
-		{ "MonType", TXTFIELD_NAMETOWORD, 0, 28, &gpDataTables.pMonTypeLinker },
-		{ "MonProp", TXTFIELD_NAMETOWORD, 0, 26, &gpDataTables.pMonPropLinker },
-		{ "AI", TXTFIELD_NAMETOWORD, 0, 30, &gpDataTables.pMonAiLinker },
-		{ "spawn", TXTFIELD_NAMETOWORD, 0, 32, &gpDataTables.pMonStatsLinker },
+		{ "MonSound", TXTFIELD_NAMETOWORD, 0, 20, &sgptDataTables->pMonSoundsLinker },
+		{ "UMonSound", TXTFIELD_NAMETOWORD, 0, 22, &sgptDataTables->pMonSoundsLinker },
+		{ "MonStatsEx", TXTFIELD_NAMETOWORD, 0, 24, &sgptDataTables->pMonStats2Linker },
+		{ "MonType", TXTFIELD_NAMETOWORD, 0, 28, &sgptDataTables->pMonTypeLinker },
+		{ "MonProp", TXTFIELD_NAMETOWORD, 0, 26, &sgptDataTables->pMonPropLinker },
+		{ "AI", TXTFIELD_NAMETOWORD, 0, 30, &sgptDataTables->pMonAiLinker },
+		{ "spawn", TXTFIELD_NAMETOWORD, 0, 32, &sgptDataTables->pMonStatsLinker },
 		{ "spawnx", TXTFIELD_BYTE, 0, 34, NULL },
 		{ "spawny", TXTFIELD_BYTE, 0, 35, NULL },
-		{ "spawnmode", TXTFIELD_CODETOBYTE, 0, 36, &gpDataTables.pMonModeLinker },
-		{ "minion1", TXTFIELD_NAMETOWORD, 0, 38, &gpDataTables.pMonStatsLinker },
-		{ "minion2", TXTFIELD_NAMETOWORD, 0, 40, &gpDataTables.pMonStatsLinker },
+		{ "spawnmode", TXTFIELD_CODETOBYTE, 0, 36, &sgptDataTables->pMonModeLinker },
+		{ "minion1", TXTFIELD_NAMETOWORD, 0, 38, &sgptDataTables->pMonStatsLinker },
+		{ "minion2", TXTFIELD_NAMETOWORD, 0, 40, &sgptDataTables->pMonStatsLinker },
 		{ "PartyMin", TXTFIELD_BYTE, 0, 44, NULL },
 		{ "PartyMax", TXTFIELD_BYTE, 0, 45, NULL },
 		{ "Rarity", TXTFIELD_BYTE, 0, 46, NULL },
@@ -221,26 +221,26 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 		{ "deathDmg", TXTFIELD_BIT, 20, 12, NULL },
 		{ "genericSpawn", TXTFIELD_BIT, 21, 12, NULL },
 		{ "zoo", TXTFIELD_BIT, 22, 12, NULL },
-		{ "MissA1", TXTFIELD_NAMETOWORD, 0, 58, &gpDataTables.pMissilesLinker },
-		{ "MissA2", TXTFIELD_NAMETOWORD, 0, 60, &gpDataTables.pMissilesLinker },
-		{ "MissS1", TXTFIELD_NAMETOWORD, 0, 62, &gpDataTables.pMissilesLinker },
-		{ "MissS2", TXTFIELD_NAMETOWORD, 0, 64, &gpDataTables.pMissilesLinker },
-		{ "MissS3", TXTFIELD_NAMETOWORD, 0, 66, &gpDataTables.pMissilesLinker },
-		{ "MissS4", TXTFIELD_NAMETOWORD, 0, 68, &gpDataTables.pMissilesLinker },
-		{ "MissC", TXTFIELD_NAMETOWORD, 0, 70, &gpDataTables.pMissilesLinker },
-		{ "MissSQ", TXTFIELD_NAMETOWORD, 0, 72, &gpDataTables.pMissilesLinker },
-		{ "TreasureClass1", TXTFIELD_NAMETOWORD, 0, 134, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass2", TXTFIELD_NAMETOWORD, 0, 136, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass3", TXTFIELD_NAMETOWORD, 0, 138, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass4", TXTFIELD_NAMETOWORD, 0, 140, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass1(N)", TXTFIELD_NAMETOWORD, 0, 142, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass2(N)", TXTFIELD_NAMETOWORD, 0, 144, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass3(N)", TXTFIELD_NAMETOWORD, 0, 146, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass4(N)", TXTFIELD_NAMETOWORD, 0, 148, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass1(H)", TXTFIELD_NAMETOWORD, 0, 150, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass2(H)", TXTFIELD_NAMETOWORD, 0, 152, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass3(H)", TXTFIELD_NAMETOWORD, 0, 154, &gpDataTables.pTreasureClassExLinker },
-		{ "TreasureClass4(H)", TXTFIELD_NAMETOWORD, 0, 156, &gpDataTables.pTreasureClassExLinker },
+		{ "MissA1", TXTFIELD_NAMETOWORD, 0, 58, &sgptDataTables->pMissilesLinker },
+		{ "MissA2", TXTFIELD_NAMETOWORD, 0, 60, &sgptDataTables->pMissilesLinker },
+		{ "MissS1", TXTFIELD_NAMETOWORD, 0, 62, &sgptDataTables->pMissilesLinker },
+		{ "MissS2", TXTFIELD_NAMETOWORD, 0, 64, &sgptDataTables->pMissilesLinker },
+		{ "MissS3", TXTFIELD_NAMETOWORD, 0, 66, &sgptDataTables->pMissilesLinker },
+		{ "MissS4", TXTFIELD_NAMETOWORD, 0, 68, &sgptDataTables->pMissilesLinker },
+		{ "MissC", TXTFIELD_NAMETOWORD, 0, 70, &sgptDataTables->pMissilesLinker },
+		{ "MissSQ", TXTFIELD_NAMETOWORD, 0, 72, &sgptDataTables->pMissilesLinker },
+		{ "TreasureClass1", TXTFIELD_NAMETOWORD, 0, 134, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass2", TXTFIELD_NAMETOWORD, 0, 136, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass3", TXTFIELD_NAMETOWORD, 0, 138, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass4", TXTFIELD_NAMETOWORD, 0, 140, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass1(N)", TXTFIELD_NAMETOWORD, 0, 142, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass2(N)", TXTFIELD_NAMETOWORD, 0, 144, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass3(N)", TXTFIELD_NAMETOWORD, 0, 146, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass4(N)", TXTFIELD_NAMETOWORD, 0, 148, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass1(H)", TXTFIELD_NAMETOWORD, 0, 150, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass2(H)", TXTFIELD_NAMETOWORD, 0, 152, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass3(H)", TXTFIELD_NAMETOWORD, 0, 154, &sgptDataTables->pTreasureClassExLinker },
+		{ "TreasureClass4(H)", TXTFIELD_NAMETOWORD, 0, 156, &sgptDataTables->pTreasureClassExLinker },
 		{ "TCQuestId", TXTFIELD_BYTE, 0, 158, NULL },
 		{ "TCQuestCP", TXTFIELD_BYTE, 0, 159, NULL },
 		{ "threat", TXTFIELD_BYTE, 0, 78, NULL },
@@ -277,7 +277,7 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 		{ "Level", TXTFIELD_WORD, 0, 170, NULL },
 		{ "Level(N)", TXTFIELD_WORD, 0, 172, NULL },
 		{ "Level(H)", TXTFIELD_WORD, 0, 174, NULL },
-		{ "SkillDamage", TXTFIELD_NAMETOWORD, 0, 168, &gpDataTables.pSkillsLinker },
+		{ "SkillDamage", TXTFIELD_NAMETOWORD, 0, 168, &sgptDataTables->pSkillsLinker },
 		{ "NoShldBlock", TXTFIELD_BIT, 26, 12, NULL },
 		{ "Drain", TXTFIELD_BYTE, 0, 160, NULL },
 		{ "Drain(N)", TXTFIELD_BYTE, 0, 161, NULL },
@@ -325,8 +325,8 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 		{ "S1MaxD", TXTFIELD_WORD, 0, 248, NULL },
 		{ "S1MaxD(N)", TXTFIELD_WORD, 0, 250, NULL },
 		{ "S1MaxD(H)", TXTFIELD_WORD, 0, 252, NULL },
-		{ "El1Mode", TXTFIELD_CODETOBYTE, 0, 254, &gpDataTables.pMonModeLinker },
-		{ "El1Type", TXTFIELD_CODETOBYTE, 0, 257, &gpDataTables.pElemTypesLinker },
+		{ "El1Mode", TXTFIELD_CODETOBYTE, 0, 254, &sgptDataTables->pMonModeLinker },
+		{ "El1Type", TXTFIELD_CODETOBYTE, 0, 257, &sgptDataTables->pElemTypesLinker },
 		{ "El1Pct", TXTFIELD_BYTE, 0, 260, NULL },
 		{ "El1Pct(N)", TXTFIELD_BYTE, 0, 261, NULL },
 		{ "El1Pct(H)", TXTFIELD_BYTE, 0, 262, NULL },
@@ -339,8 +339,8 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 		{ "El1Dur", TXTFIELD_WORD, 0, 306, NULL },
 		{ "El1Dur(N)", TXTFIELD_WORD, 0, 308, NULL },
 		{ "El1Dur(H)", TXTFIELD_WORD, 0, 310, NULL },
-		{ "El2Mode", TXTFIELD_CODETOBYTE, 0, 255, &gpDataTables.pMonModeLinker },
-		{ "El2Type", TXTFIELD_CODETOBYTE, 0, 258, &gpDataTables.pElemTypesLinker },
+		{ "El2Mode", TXTFIELD_CODETOBYTE, 0, 255, &sgptDataTables->pMonModeLinker },
+		{ "El2Type", TXTFIELD_CODETOBYTE, 0, 258, &sgptDataTables->pElemTypesLinker },
 		{ "El2Pct", TXTFIELD_BYTE, 0, 263, NULL },
 		{ "El2Pct(N)", TXTFIELD_BYTE, 0, 264, NULL },
 		{ "El2Pct(H)", TXTFIELD_BYTE, 0, 265, NULL },
@@ -353,8 +353,8 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 		{ "El2Dur", TXTFIELD_WORD, 0, 312, NULL },
 		{ "El2Dur(N)", TXTFIELD_WORD, 0, 314, NULL },
 		{ "El2Dur(H)", TXTFIELD_WORD, 0, 316, NULL },
-		{ "El3Mode", TXTFIELD_CODETOBYTE, 0, 256, &gpDataTables.pMonModeLinker },
-		{ "El3Type", TXTFIELD_CODETOBYTE, 0, 259, &gpDataTables.pElemTypesLinker },
+		{ "El3Mode", TXTFIELD_CODETOBYTE, 0, 256, &sgptDataTables->pMonModeLinker },
+		{ "El3Type", TXTFIELD_CODETOBYTE, 0, 259, &sgptDataTables->pElemTypesLinker },
 		{ "El3Pct", TXTFIELD_BYTE, 0, 266, NULL },
 		{ "El3Pct(N)", TXTFIELD_BYTE, 0, 267, NULL },
 		{ "El3Pct(H)", TXTFIELD_BYTE, 0, 268, NULL },
@@ -389,28 +389,28 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 		{ "ResPo(N)", TXTFIELD_WORD, 0, 356, NULL },
 		{ "ResPo(H)", TXTFIELD_WORD, 0, 358, NULL },
 		{ "SendSkills", TXTFIELD_DWORD2, 0, 364, NULL },
-		{ "Skill1", TXTFIELD_NAMETOWORD, 0, 368, &gpDataTables.pSkillsLinker },
+		{ "Skill1", TXTFIELD_NAMETOWORD, 0, 368, &sgptDataTables->pSkillsLinker },
 		{ "Sk1mode", TXTFIELD_CUSTOMLINK, 0, 0, DATATBLS_MonStatsSkillModeLinker },
 		{ "Sk1lvl", TXTFIELD_BYTE, 0, 408, NULL },
-		{ "Skill2", TXTFIELD_NAMETOWORD, 0, 370, &gpDataTables.pSkillsLinker },
+		{ "Skill2", TXTFIELD_NAMETOWORD, 0, 370, &sgptDataTables->pSkillsLinker },
 		{ "Sk2mode", TXTFIELD_CUSTOMLINK, 0, 1, DATATBLS_MonStatsSkillModeLinker },
 		{ "Sk2lvl", TXTFIELD_BYTE, 0, 409, NULL },
-		{ "Skill3", TXTFIELD_NAMETOWORD, 0, 372, &gpDataTables.pSkillsLinker },
+		{ "Skill3", TXTFIELD_NAMETOWORD, 0, 372, &sgptDataTables->pSkillsLinker },
 		{ "Sk3mode", TXTFIELD_CUSTOMLINK, 0, 2, DATATBLS_MonStatsSkillModeLinker },
 		{ "Sk3lvl", TXTFIELD_BYTE, 0, 410, NULL },
-		{ "Skill4", TXTFIELD_NAMETOWORD, 0, 374, &gpDataTables.pSkillsLinker },
+		{ "Skill4", TXTFIELD_NAMETOWORD, 0, 374, &sgptDataTables->pSkillsLinker },
 		{ "Sk4mode", TXTFIELD_CUSTOMLINK, 0, 3, DATATBLS_MonStatsSkillModeLinker },
 		{ "Sk4lvl", TXTFIELD_BYTE, 0, 411, NULL },
-		{ "Skill5", TXTFIELD_NAMETOWORD, 0, 376, &gpDataTables.pSkillsLinker },
+		{ "Skill5", TXTFIELD_NAMETOWORD, 0, 376, &sgptDataTables->pSkillsLinker },
 		{ "Sk5mode", TXTFIELD_CUSTOMLINK, 0, 4, DATATBLS_MonStatsSkillModeLinker },
 		{ "Sk5lvl", TXTFIELD_BYTE, 0, 412, NULL },
-		{ "Skill6", TXTFIELD_NAMETOWORD, 0, 378, &gpDataTables.pSkillsLinker },
+		{ "Skill6", TXTFIELD_NAMETOWORD, 0, 378, &sgptDataTables->pSkillsLinker },
 		{ "Sk6mode", TXTFIELD_CUSTOMLINK, 0, 5, DATATBLS_MonStatsSkillModeLinker },
 		{ "Sk6lvl", TXTFIELD_BYTE, 0, 413, NULL },
-		{ "Skill7", TXTFIELD_NAMETOWORD, 0, 380, &gpDataTables.pSkillsLinker },
+		{ "Skill7", TXTFIELD_NAMETOWORD, 0, 380, &sgptDataTables->pSkillsLinker },
 		{ "Sk7mode", TXTFIELD_CUSTOMLINK, 0, 6, DATATBLS_MonStatsSkillModeLinker },
 		{ "Sk7lvl", TXTFIELD_BYTE, 0, 414, NULL },
-		{ "Skill8", TXTFIELD_NAMETOWORD, 0, 382, &gpDataTables.pSkillsLinker },
+		{ "Skill8", TXTFIELD_NAMETOWORD, 0, 382, &sgptDataTables->pSkillsLinker },
 		{ "Sk8mode", TXTFIELD_CUSTOMLINK, 0, 7, DATATBLS_MonStatsSkillModeLinker },
 		{ "Sk8lvl", TXTFIELD_BYTE, 0, 415, NULL },
 		{ "DamageRegen", TXTFIELD_DWORD, 0, 416, NULL },
@@ -421,12 +421,12 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonStatsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pMonStatsTxt = (D2MonStatsTxt*)DATATBLS_CompileTxt(pMemPool, "monstats", pTbl, &gpDataTables.nMonStatsTxtRecordCount, sizeof(D2MonStatsTxt));
+	sgptDataTables->pMonStatsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pMonStatsTxt = (D2MonStatsTxt*)DATATBLS_CompileTxt(pMemPool, "monstats", pTbl, &sgptDataTables->nMonStatsTxtRecordCount, sizeof(D2MonStatsTxt));
 
-	D2_ASSERT(gpDataTables.nMonStatsTxtRecordCount < SHRT_MAX);
+	D2_ASSERT(sgptDataTables->nMonStatsTxtRecordCount < SHRT_MAX);
 
-	if (gpDataTables.nMonStatsTxtRecordCount > 0)
+	if (sgptDataTables->nMonStatsTxtRecordCount > 0)
 	{
 		nCounter = 0;
 		do
@@ -434,30 +434,30 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 			bFoundInChain = false;
 
 			nChainId = 0;
-			nId = gpDataTables.pMonStatsTxt[nCounter].nBaseId;
+			nId = sgptDataTables->pMonStatsTxt[nCounter].nBaseId;
 
 			do
 			{
-				if (gpDataTables.pMonStatsTxt[nId].nBaseId != gpDataTables.pMonStatsTxt[nCounter].nBaseId && gpDataTables.bCompileTxt)
+				if (sgptDataTables->pMonStatsTxt[nId].nBaseId != sgptDataTables->pMonStatsTxt[nCounter].nBaseId && sgptDataTables->bCompileTxt)
 				{
-					szMonsterName = FOG_10255(gpDataTables.pMonStatsLinker, gpDataTables.pMonStatsTxt[nId].nId, 0);
+					szMonsterName = FOG_10255(sgptDataTables->pMonStatsLinker, sgptDataTables->pMonStatsTxt[nId].nId, 0);
 					FOG_WriteToLogFile("BaseId/NextInClass chain -- unexpected baseid for monster '%s' (%d)", szMonsterName);
 				}
 
 				if (nId == nCounter)
 				{
 					bFoundInChain = true;
-					gpDataTables.pMonStatsTxt[nCounter].nChainId = nChainId;
+					sgptDataTables->pMonStatsTxt[nCounter].nChainId = nChainId;
 				}
 
-				nNextInClass = gpDataTables.pMonStatsTxt[nId].nNextInClass;
+				nNextInClass = sgptDataTables->pMonStatsTxt[nId].nNextInClass;
 
 				++nChainId;
 				if (nId == nNextInClass)
 				{
-					if (gpDataTables.bCompileTxt)
+					if (sgptDataTables->bCompileTxt)
 					{
-						szMonsterName = FOG_10255(gpDataTables.pMonStatsLinker, gpDataTables.pMonStatsTxt[nId].nId, 0);
+						szMonsterName = FOG_10255(sgptDataTables->pMonStatsLinker, sgptDataTables->pMonStatsTxt[nId].nId, 0);
 						FOG_WriteToLogFile("BaseId/NextInClass chain -- monster '%s' (%d) pointing to itself", szMonsterName);
 					}
 					break;
@@ -467,9 +467,9 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 
 				if (nChainId > 255)
 				{
-					if (gpDataTables.bCompileTxt)
+					if (sgptDataTables->bCompileTxt)
 					{
-						szMonsterName = FOG_10255(gpDataTables.pMonStatsLinker, gpDataTables.pMonStatsTxt[nNextInClass].nId, 0);
+						szMonsterName = FOG_10255(sgptDataTables->pMonStatsLinker, sgptDataTables->pMonStatsTxt[nNextInClass].nId, 0);
 						FOG_WriteToLogFile("BaseId/NextInClass chain exceeded 255 entries at monster '%s' (%d)", szMonsterName);
 					}
 					break;
@@ -477,54 +477,54 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 			}
 			while (nNextInClass >= 0);
 
-			if (!bFoundInChain && gpDataTables.bCompileTxt)
+			if (!bFoundInChain && sgptDataTables->bCompileTxt)
 			{
-				szMonsterName = FOG_10255(gpDataTables.pMonStatsLinker, gpDataTables.pMonStatsTxt[nCounter].nId, 0);
+				szMonsterName = FOG_10255(sgptDataTables->pMonStatsLinker, sgptDataTables->pMonStatsTxt[nCounter].nId, 0);
 				FOG_WriteToLogFile("BaseId/NextInClass monster '%s' (%d) not found in chain", szMonsterName);
 			}
-			gpDataTables.pMonStatsTxt[nCounter].nMaxChainId = nChainId;
+			sgptDataTables->pMonStatsTxt[nCounter].nMaxChainId = nChainId;
 
 			++nCounter;
 		}
-		while (nCounter < gpDataTables.nMonStatsTxtRecordCount);
+		while (nCounter < sgptDataTables->nMonStatsTxtRecordCount);
 	}
 
 
 	nCounter = 0;
-	while (nCounter < gpDataTables.nMonStatsTxtRecordCount)
+	while (nCounter < sgptDataTables->nMonStatsTxtRecordCount)
 	{
-		nBaseId = gpDataTables.pMonStatsTxt[nCounter].nBaseId;
-		if (nBaseId < 0 || nBaseId >= gpDataTables.nMonStatsTxtRecordCount)
+		nBaseId = sgptDataTables->pMonStatsTxt[nCounter].nBaseId;
+		if (nBaseId < 0 || nBaseId >= sgptDataTables->nMonStatsTxtRecordCount)
 		{
-			gpDataTables.pMonStatsTxt[nCounter].nBaseId = nCounter;
+			sgptDataTables->pMonStatsTxt[nCounter].nBaseId = nCounter;
 			nBaseId = nCounter;
 		}
 
 		nVelocity = *((DWORD*)DATATBLS_GetAnimDataRecord(0, nBaseId, MONMODE_WALK, 1, 0) + 3);
 		if (nBaseId != nCounter)
 		{
-			if (gpDataTables.pMonStatsTxt[nBaseId].nVelocity > 0)
+			if (sgptDataTables->pMonStatsTxt[nBaseId].nVelocity > 0)
 			{
-				nVelocity = nVelocity * gpDataTables.pMonStatsTxt[nCounter].nVelocity / (unsigned int)gpDataTables.pMonStatsTxt[nBaseId].nVelocity;
+				nVelocity = nVelocity * sgptDataTables->pMonStatsTxt[nCounter].nVelocity / (unsigned int)sgptDataTables->pMonStatsTxt[nBaseId].nVelocity;
 			}
 		}
 
 		if (nVelocity <= 0)
 		{
-			gpDataTables.pMonStatsTxt[nCounter].unk0x36 = 0;
+			sgptDataTables->pMonStatsTxt[nCounter].unk0x36 = 0;
 		}
 		else if (nVelocity >= 32767)
 		{
-			gpDataTables.pMonStatsTxt[nCounter].unk0x36 = 32767;
+			sgptDataTables->pMonStatsTxt[nCounter].unk0x36 = 32767;
 		}
 		else
 		{
-			gpDataTables.pMonStatsTxt[nCounter].unk0x36 = nVelocity;
+			sgptDataTables->pMonStatsTxt[nCounter].unk0x36 = nVelocity;
 		}
 
 		if (nCounter < 410)//Before Expansion
 		{
-			v21 = gpDataTables.pMonStatsTxt[nBaseId].unk0x36;
+			v21 = sgptDataTables->pMonStatsTxt[nBaseId].unk0x36;
 			nRun = ((signed int)v21 - HIDWORD(v21)) >> 1;
 		}
 		else
@@ -534,9 +534,9 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 
 		if (nBaseId != nCounter)
 		{
-			if (gpDataTables.pMonStatsTxt[nBaseId].nRun > 0)
+			if (sgptDataTables->pMonStatsTxt[nBaseId].nRun > 0)
 			{
-				nRun = nRun * gpDataTables.pMonStatsTxt[nCounter].nRun / (unsigned int)gpDataTables.pMonStatsTxt[nBaseId].nRun;
+				nRun = nRun * sgptDataTables->pMonStatsTxt[nCounter].nRun / (unsigned int)sgptDataTables->pMonStatsTxt[nBaseId].nRun;
 			}
 		}
 
@@ -549,7 +549,7 @@ void __fastcall DATATBLS_LoadMonStatsTxt(void* pMemPool)
 			nRun = 32767;
 		}
 
-		gpDataTables.pMonStatsTxt[nCounter].unk0x38 = nRun;
+		sgptDataTables->pMonStatsTxt[nCounter].unk0x38 = nRun;
 
 		++nCounter;
 	}
@@ -565,14 +565,14 @@ BOOL __stdcall DATATBLS_CalculateMonsterStatsByLevel(int nMonsterId, int nGameTy
 	pMonStatsTxtRecord = DATATBLS_GetMonStatsTxtRecord(nMonsterId);
 	if (pMonStatsTxtRecord)
 	{
-		if (nLevel > gpDataTables.nMonLvlTxtRecordCount - 1)
+		if (nLevel > sgptDataTables->nMonLvlTxtRecordCount - 1)
 		{
-			nLevel = gpDataTables.nMonLvlTxtRecordCount - 1;
+			nLevel = sgptDataTables->nMonLvlTxtRecordCount - 1;
 		}
 
-		if (nLevel >= 0 && nLevel < gpDataTables.nMonLvlTxtRecordCount)
+		if (nLevel >= 0 && nLevel < sgptDataTables->nMonLvlTxtRecordCount)
 		{
-			pMonLvlTxtRecord = &gpDataTables.pMonLvlTxt[nLevel];
+			pMonLvlTxtRecord = &sgptDataTables->pMonLvlTxt[nLevel];
 			if (pMonLvlTxtRecord)
 			{
 				if (nDifficulty < 0)
@@ -733,7 +733,7 @@ void __stdcall DATATBLS_SetVelocityInMonStatsTxtRecord(int nMonsterId, short nVe
 {
 	D2MonStatsTxt* pMonStatsTxtRecord = NULL;
 
-	D2_ASSERT(gpDataTables.pMonStatsTxt);
+	D2_ASSERT(sgptDataTables->pMonStatsTxt);
 
 	pMonStatsTxtRecord = DATATBLS_GetMonStatsTxtRecord(nMonsterId);
 	pMonStatsTxtRecord->nVelocity = nVelocity;
@@ -742,7 +742,7 @@ void __stdcall DATATBLS_SetVelocityInMonStatsTxtRecord(int nMonsterId, short nVe
 //D2Common.0x6FD68A00
 void __stdcall DATATBLS_ResetGlobalDefaultUnicodeString()
 {
-	gpDataTables.wszDefault = 0;
+	sgptDataTables->wszDefault = 0;
 }
 
 //D2Common.0x6FD68A10 (#10651)
@@ -751,20 +751,20 @@ wchar_t* __fastcall DATATBLS_RollRandomUniqueTitleString(D2UnitStrc* pUnit)
 	wchar_t* pString = NULL;
 	int nRand = 0;
 
-	if (pUnit && gpDataTables.nUniqueTitleTxtRecordCount > 0)
+	if (pUnit && sgptDataTables->nUniqueTitleTxtRecordCount > 0)
 	{
-		if ((gpDataTables.nUniqueTitleTxtRecordCount - 1) & gpDataTables.nUniqueTitleTxtRecordCount)
+		if ((sgptDataTables->nUniqueTitleTxtRecordCount - 1) & sgptDataTables->nUniqueTitleTxtRecordCount)
 		{
-			nRand = (unsigned int)SEED_RollRandomNumber(&pUnit->pSeed) % gpDataTables.nUniqueTitleTxtRecordCount;
+			nRand = (unsigned int)SEED_RollRandomNumber(&pUnit->pSeed) % sgptDataTables->nUniqueTitleTxtRecordCount;
 		}
 		else
 		{
-			nRand = SEED_RollRandomNumber(&pUnit->pSeed) & (gpDataTables.nUniqueTitleTxtRecordCount - 1);
+			nRand = SEED_RollRandomNumber(&pUnit->pSeed) & (sgptDataTables->nUniqueTitleTxtRecordCount - 1);
 		}
 
-		if (gpDataTables.pUniqueTitleTxt[nRand].wStringId)
+		if (sgptDataTables->pUniqueTitleTxt[nRand].wStringId)
 		{
-			pString = D2LANG_GetStringFromTblIndex(gpDataTables.pUniqueTitleTxt[nRand].wStringId);
+			pString = D2LANG_GetStringFromTblIndex(sgptDataTables->pUniqueTitleTxt[nRand].wStringId);
 			if (pString)
 			{
 				return pString;
@@ -772,7 +772,7 @@ wchar_t* __fastcall DATATBLS_RollRandomUniqueTitleString(D2UnitStrc* pUnit)
 		}
 	}
 
-	return &gpDataTables.wszDefault;
+	return &sgptDataTables->wszDefault;
 }
 
 //D2Common.0x6FD68A80 (#10652)
@@ -781,20 +781,20 @@ wchar_t* __fastcall DATATBLS_RollRandomUniquePrefixString(D2UnitStrc* pUnit)
 	wchar_t* pString = NULL;
 	int nRand = 0;
 
-	if (pUnit && gpDataTables.nUniquePrefixTxtRecordCount > 0)
+	if (pUnit && sgptDataTables->nUniquePrefixTxtRecordCount > 0)
 	{
-		if ((gpDataTables.nUniquePrefixTxtRecordCount - 1) & gpDataTables.nUniquePrefixTxtRecordCount)
+		if ((sgptDataTables->nUniquePrefixTxtRecordCount - 1) & sgptDataTables->nUniquePrefixTxtRecordCount)
 		{
-			nRand = (unsigned int)SEED_RollRandomNumber(&pUnit->pSeed) % gpDataTables.nUniquePrefixTxtRecordCount;
+			nRand = (unsigned int)SEED_RollRandomNumber(&pUnit->pSeed) % sgptDataTables->nUniquePrefixTxtRecordCount;
 		}
 		else
 		{
-			nRand = SEED_RollRandomNumber(&pUnit->pSeed) & (gpDataTables.nUniquePrefixTxtRecordCount - 1);
+			nRand = SEED_RollRandomNumber(&pUnit->pSeed) & (sgptDataTables->nUniquePrefixTxtRecordCount - 1);
 		}
 
-		if (gpDataTables.pUniquePrefixTxt[nRand].wStringId)
+		if (sgptDataTables->pUniquePrefixTxt[nRand].wStringId)
 		{
-			pString = D2LANG_GetStringFromTblIndex(gpDataTables.pUniquePrefixTxt[nRand].wStringId);
+			pString = D2LANG_GetStringFromTblIndex(sgptDataTables->pUniquePrefixTxt[nRand].wStringId);
 			if (pString)
 			{
 				return pString;
@@ -802,7 +802,7 @@ wchar_t* __fastcall DATATBLS_RollRandomUniquePrefixString(D2UnitStrc* pUnit)
 		}
 	}
 
-	return &gpDataTables.wszDefault;
+	return &sgptDataTables->wszDefault;
 }
 
 //D2Common.0x6FD68AF0 (#10653)
@@ -811,20 +811,20 @@ wchar_t* __fastcall DATATBLS_RollRandomUniqueSuffixString(D2UnitStrc* pUnit)
 	wchar_t* pString = NULL;
 	int nRand = 0;
 
-	if (pUnit && gpDataTables.nUniqueSuffixTxtRecordCount > 0)
+	if (pUnit && sgptDataTables->nUniqueSuffixTxtRecordCount > 0)
 	{
-		if ((gpDataTables.nUniqueSuffixTxtRecordCount - 1) & gpDataTables.nUniqueSuffixTxtRecordCount)
+		if ((sgptDataTables->nUniqueSuffixTxtRecordCount - 1) & sgptDataTables->nUniqueSuffixTxtRecordCount)
 		{
-			nRand = (unsigned int)SEED_RollRandomNumber(&pUnit->pSeed) % gpDataTables.nUniqueSuffixTxtRecordCount;
+			nRand = (unsigned int)SEED_RollRandomNumber(&pUnit->pSeed) % sgptDataTables->nUniqueSuffixTxtRecordCount;
 		}
 		else
 		{
-			nRand = SEED_RollRandomNumber(&pUnit->pSeed) & (gpDataTables.nUniqueSuffixTxtRecordCount - 1);
+			nRand = SEED_RollRandomNumber(&pUnit->pSeed) & (sgptDataTables->nUniqueSuffixTxtRecordCount - 1);
 		}
 
-		if (gpDataTables.pUniqueSuffixTxt[nRand].wStringId)
+		if (sgptDataTables->pUniqueSuffixTxt[nRand].wStringId)
 		{
-			pString = D2LANG_GetStringFromTblIndex(gpDataTables.pUniqueSuffixTxt[nRand].wStringId);
+			pString = D2LANG_GetStringFromTblIndex(sgptDataTables->pUniqueSuffixTxt[nRand].wStringId);
 			if (pString)
 			{
 				return pString;
@@ -832,7 +832,7 @@ wchar_t* __fastcall DATATBLS_RollRandomUniqueSuffixString(D2UnitStrc* pUnit)
 		}
 	}
 
-	return &gpDataTables.wszDefault;
+	return &sgptDataTables->wszDefault;
 }
 
 //D2Common.0x6FD68B60 (#10654)
@@ -841,20 +841,20 @@ wchar_t* __fastcall DATATBLS_RollRandomUniqueAppellationString(D2UnitStrc* pUnit
 	wchar_t* pString = NULL;
 	int nRand = 0;
 
-	if (pUnit && gpDataTables.nUniqueAppellationTxtRecordCount > 0)
+	if (pUnit && sgptDataTables->nUniqueAppellationTxtRecordCount > 0)
 	{
-		if ((gpDataTables.nUniqueAppellationTxtRecordCount - 1) & gpDataTables.nUniqueAppellationTxtRecordCount)
+		if ((sgptDataTables->nUniqueAppellationTxtRecordCount - 1) & sgptDataTables->nUniqueAppellationTxtRecordCount)
 		{
-			nRand = (unsigned int)SEED_RollRandomNumber(&pUnit->pSeed) % gpDataTables.nUniqueAppellationTxtRecordCount;
+			nRand = (unsigned int)SEED_RollRandomNumber(&pUnit->pSeed) % sgptDataTables->nUniqueAppellationTxtRecordCount;
 		}
 		else
 		{
-			nRand = SEED_RollRandomNumber(&pUnit->pSeed) & (gpDataTables.nUniqueAppellationTxtRecordCount - 1);
+			nRand = SEED_RollRandomNumber(&pUnit->pSeed) & (sgptDataTables->nUniqueAppellationTxtRecordCount - 1);
 		}
 
-		if (gpDataTables.pUniqueAppellationTxt[nRand].wStringId)
+		if (sgptDataTables->pUniqueAppellationTxt[nRand].wStringId)
 		{
-			pString = D2LANG_GetStringFromTblIndex(gpDataTables.pUniqueAppellationTxt[nRand].wStringId);
+			pString = D2LANG_GetStringFromTblIndex(sgptDataTables->pUniqueAppellationTxt[nRand].wStringId);
 			if (pString)
 			{
 				return pString;
@@ -862,7 +862,7 @@ wchar_t* __fastcall DATATBLS_RollRandomUniqueAppellationString(D2UnitStrc* pUnit
 		}
 	}
 
-	return &gpDataTables.wszDefault;
+	return &sgptDataTables->wszDefault;
 }
 
 //D2Common.0x6FD68BD0
@@ -962,10 +962,10 @@ int __fastcall DATATBLS_CalculatePercentage(signed int nValue1, signed int nValu
 //D2Common.0x6FD68DC0 (#10658)
 D2TCExShortStrc* __stdcall DATATBLS_GetTreasureClassExRecordFromName(char* szText)
 {
-	int nId = FOG_GetRowFromTxt(gpDataTables.pTreasureClassExLinker, szText, 0);
+	int nId = FOG_GetRowFromTxt(sgptDataTables->pTreasureClassExLinker, szText, 0);
 	if (nId >= 0)
 	{
-		return &gpDataTables.pTreasureClassEx[nId];
+		return &sgptDataTables->pTreasureClassEx[nId];
 	}
 
 	return NULL;
@@ -977,9 +977,9 @@ D2TCExShortStrc* __stdcall DATATBLS_GetTreasureClassExRecordFromIdAndLevel(WORD 
 	D2TCExShortStrc* pTCExRecord = NULL;
 	D2TCExShortStrc* pNext = NULL;
 
-	if (wTCId && wTCId < gpDataTables.nTreasureClassEx)
+	if (wTCId && wTCId < sgptDataTables->nTreasureClassEx)
 	{
-		pTCExRecord = &gpDataTables.pTreasureClassEx[wTCId];
+		pTCExRecord = &sgptDataTables->pTreasureClassEx[wTCId];
 		if (nLvl > 0 && pTCExRecord->nGroup)
 		{
 			pNext = pTCExRecord + 1;
@@ -1035,11 +1035,11 @@ D2TCExShortStrc* __stdcall DATATBLS_GetTreasureClassExRecordFromActAndDifficulty
 		{
 			nIndex = 2;
 		}
-		return gpDataTables.pChestTreasureClasses[nIndex + 3 * (nAct + 5 * nDifficulty)];
+		return sgptDataTables->pChestTreasureClasses[nIndex + 3 * (nAct + 5 * nDifficulty)];
 	}
 	else
 	{
-		return gpDataTables.pChestTreasureClasses[3 * (nAct + 5 * nDifficulty)];
+		return sgptDataTables->pChestTreasureClasses[3 * (nAct + 5 * nDifficulty)];
 	}
 }
 
@@ -1223,21 +1223,21 @@ void __fastcall DATATBLS_LoadTreasureClassExTxt(void* pMemPool)
 			break;
 		}
 
-		FOG_10216_AddRecordToLinkingTable(gpDataTables.pTreasureClassExLinker, pTreasureClassExTxt[i].szTreasureClass);
+		FOG_10216_AddRecordToLinkingTable(sgptDataTables->pTreasureClassExLinker, pTreasureClassExTxt[i].szTreasureClass);
 
-		if (!(gpDataTables.nTreasureClassEx % 16))
+		if (!(sgptDataTables->nTreasureClassEx % 16))
 		{
-			gpDataTables.pTreasureClassEx = (D2TCExShortStrc*)FOG_ReallocServerMemory(NULL, gpDataTables.pTreasureClassEx, sizeof(D2TCExShortStrc) * (gpDataTables.nTreasureClassEx + 16), __FILE__, __LINE__, 0);
+			sgptDataTables->pTreasureClassEx = (D2TCExShortStrc*)FOG_ReallocServerMemory(NULL, sgptDataTables->pTreasureClassEx, sizeof(D2TCExShortStrc) * (sgptDataTables->nTreasureClassEx + 16), __FILE__, __LINE__, 0);
 		}
-		memset(&gpDataTables.pTreasureClassEx[gpDataTables.nTreasureClassEx], 0x00, sizeof(gpDataTables.pTreasureClassEx[gpDataTables.nTreasureClassEx]));
+		memset(&sgptDataTables->pTreasureClassEx[sgptDataTables->nTreasureClassEx], 0x00, sizeof(sgptDataTables->pTreasureClassEx[sgptDataTables->nTreasureClassEx]));
 
-		pTCExTxtRecord = &gpDataTables.pTreasureClassEx[gpDataTables.nTreasureClassEx];
-		++gpDataTables.nTreasureClassEx;
+		pTCExTxtRecord = &sgptDataTables->pTreasureClassEx[sgptDataTables->nTreasureClassEx];
+		++sgptDataTables->nTreasureClassEx;
 		if (pTCExTxtRecord)
 		{
 			if (pTreasureClassExTxt[i].nGroup != 0)
 			{
-				pTCExTxtRecord->nGroup = gpDataTables.nTreasureClassItemTypes + pTreasureClassExTxt[i].nGroup;
+				pTCExTxtRecord->nGroup = sgptDataTables->nTreasureClassItemTypes + pTreasureClassExTxt[i].nGroup;
 			}
 
 			pTCExTxtRecord->nLevel = pTreasureClassExTxt[i].nLevel;
@@ -1319,7 +1319,7 @@ void __fastcall DATATBLS_LoadTreasureClassExTxt(void* pMemPool)
 					}
 					else
 					{
-						nTxtRow = FOG_GetRowFromTxt(gpDataTables.pTreasureClassExLinker, szText, 0);
+						nTxtRow = FOG_GetRowFromTxt(sgptDataTables->pTreasureClassExLinker, szText, 0);
 						if (nTxtRow > 0)
 						{
 							nTypes = pTCExTxtRecord->nTypes;
@@ -1331,15 +1331,15 @@ void __fastcall DATATBLS_LoadTreasureClassExTxt(void* pMemPool)
 							pTCExInfo->nProb = pTCExTxtRecord->nProb;
 							pTCExInfo->nItemId = nTxtRow;
 							pTCExInfo->nFlags |= 4;
-							if (!gpDataTables.pTreasureClassEx[nTxtRow].nClassic)
+							if (!sgptDataTables->pTreasureClassEx[nTxtRow].nClassic)
 							{
 								pTCExInfo->nFlags |= 0x10;
 							}
 
-							DATATBLS_UpdateTreasureClassProbabilities(pTCExTxtRecord, pTCExInfo, pTreasureClassExTxt[i].nProb[j], gpDataTables.pTreasureClassEx[nTxtRow].nClassic == 0);
+							DATATBLS_UpdateTreasureClassProbabilities(pTCExTxtRecord, pTCExInfo, pTreasureClassExTxt[i].nProb[j], sgptDataTables->pTreasureClassEx[nTxtRow].nClassic == 0);
 							DATATBLS_ProcessAdditionalTreasureClassArguments(pTCExInfo, szNext, i, j);
 						}
-						else if (gpDataTables.pUniqueItemsLinker && (nTxtRow = FOG_GetRowFromTxt(gpDataTables.pUniqueItemsLinker, szText, 0)) > 0)
+						else if (sgptDataTables->pUniqueItemsLinker && (nTxtRow = FOG_GetRowFromTxt(sgptDataTables->pUniqueItemsLinker, szText, 0)) > 0)
 						{
 							nTypes = pTCExTxtRecord->nTypes;
 							DATATBLS_ReallocTCExInfo(pTCExTxtRecord, nTypes + 1);
@@ -1348,7 +1348,7 @@ void __fastcall DATATBLS_LoadTreasureClassExTxt(void* pMemPool)
 
 							pTCExInfo->nClassic = pTCExTxtRecord->nClassic;
 							pTCExInfo->nProb = pTCExTxtRecord->nProb;
-							DATATBLS_GetItemRecordFromItemCode(gpDataTables.pUniqueItemsTxt[nTxtRow].dwBaseItemCode, &nItemId);
+							DATATBLS_GetItemRecordFromItemCode(sgptDataTables->pUniqueItemsTxt[nTxtRow].dwBaseItemCode, &nItemId);
 							pTCExInfo->nFlags |= 0x11;
 							pTCExInfo->nItemId = nItemId;
 							pTCExInfo->nTxtRow = nTxtRow;
@@ -1356,7 +1356,7 @@ void __fastcall DATATBLS_LoadTreasureClassExTxt(void* pMemPool)
 							DATATBLS_UpdateTreasureClassProbabilities(pTCExTxtRecord, pTCExInfo, pTreasureClassExTxt[i].nProb[j], TRUE);
 							DATATBLS_ProcessAdditionalTreasureClassArguments(pTCExInfo, szNext, i, j);
 						}
-						else if (gpDataTables.pSetItemsLinker && (nTxtRow = FOG_GetRowFromTxt(gpDataTables.pSetItemsLinker, szText, 0)) >= 0)
+						else if (sgptDataTables->pSetItemsLinker && (nTxtRow = FOG_GetRowFromTxt(sgptDataTables->pSetItemsLinker, szText, 0)) >= 0)
 						{
 							nTypes = pTCExTxtRecord->nTypes;
 							DATATBLS_ReallocTCExInfo(pTCExTxtRecord, nTypes + 1);
@@ -1365,7 +1365,7 @@ void __fastcall DATATBLS_LoadTreasureClassExTxt(void* pMemPool)
 
 							pTCExInfo->nClassic = pTCExTxtRecord->nClassic;
 							pTCExInfo->nProb = pTCExTxtRecord->nProb;
-							DATATBLS_GetItemRecordFromItemCode(gpDataTables.pSetItemsTxt[nTxtRow].szItemCode, &nItemId);
+							DATATBLS_GetItemRecordFromItemCode(sgptDataTables->pSetItemsTxt[nTxtRow].szItemCode, &nItemId);
 							pTCExInfo->nFlags |= 0x12;
 							pTCExInfo->nItemId = nItemId;
 							pTCExInfo->nTxtRow = nTxtRow;
@@ -1405,30 +1405,30 @@ void __fastcall DATATBLS_LoadMonItemPercentTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonItemPercentDataTables.pMonItemPercentTxt = (D2MonItemPercentTxt*)DATATBLS_CompileTxt(pMemPool, "monitempercent", pTbl, &gpDataTables.pMonItemPercentDataTables.nMonItemPercentTxtRecordCount, sizeof(D2MonItemPercentTxt));
+	sgptDataTables->pMonItemPercentDataTables.pMonItemPercentTxt = (D2MonItemPercentTxt*)DATATBLS_CompileTxt(pMemPool, "monitempercent", pTbl, &sgptDataTables->pMonItemPercentDataTables.nMonItemPercentTxtRecordCount, sizeof(D2MonItemPercentTxt));
 }
 
 //D2Common.0x6FD69C40
 void __fastcall DATATBLS_UnloadMonItemPercentTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pMonItemPercentDataTables.pMonItemPercentTxt);
-	gpDataTables.pMonItemPercentDataTables.pMonItemPercentTxt = NULL;
+	DATATBLS_UnloadBin(sgptDataTables->pMonItemPercentDataTables.pMonItemPercentTxt);
+	sgptDataTables->pMonItemPercentDataTables.pMonItemPercentTxt = NULL;
 }
 
 //D2Common.0x6FD69C50 (#10662)
 D2MonItemPercentDataTbl* __fastcall DATATBLS_GetMonItemPercentDataTables()
 {
-	return &gpDataTables.pMonItemPercentDataTables;
+	return &sgptDataTables->pMonItemPercentDataTables;
 }
 
 //D2Common.0x6FD69C60 (#10663)
 D2MonItemPercentTxt* __stdcall DATATBLS_GetMonItemPercentTxtRecord(int nId)
 {
-	if (nId >= 0 && nId < gpDataTables.pMonItemPercentDataTables.nMonItemPercentTxtRecordCount)
+	if (nId >= 0 && nId < sgptDataTables->pMonItemPercentDataTables.nMonItemPercentTxtRecordCount)
 	{
-		D2_ASSERT(gpDataTables.pMonItemPercentDataTables.pMonItemPercentTxt);
-		D2_ASSERT(&gpDataTables.pMonItemPercentDataTables.pMonItemPercentTxt[nId]);
-		return &gpDataTables.pMonItemPercentDataTables.pMonItemPercentTxt[nId];
+		D2_ASSERT(sgptDataTables->pMonItemPercentDataTables.pMonItemPercentTxt);
+		D2_ASSERT(&sgptDataTables->pMonItemPercentDataTables.pMonItemPercentTxt[nId]);
+		return &sgptDataTables->pMonItemPercentDataTables.pMonItemPercentTxt[nId];
 	}
 
 	return NULL;
@@ -1439,14 +1439,14 @@ void __fastcall DATATBLS_LoadMonUModTxt(void* pMemPool)
 {
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "uniquemod", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pMonUModLinker },
+		{ "uniquemod", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pMonUModLinker },
 		{ "version", TXTFIELD_WORD, 0, 4, NULL },
 		{ "enabled", TXTFIELD_BYTE, 0, 6, NULL },
 		{ "xfer", TXTFIELD_BYTE, 0, 7, NULL },
 		{ "champion", TXTFIELD_BYTE, 0, 8, NULL },
 		{ "fpick", TXTFIELD_BYTE, 0, 9, NULL },
-		{ "exclude1", TXTFIELD_NAMETOWORD, 0, 10, &gpDataTables.pMonTypeLinker },
-		{ "exclude2", TXTFIELD_NAMETOWORD, 0, 12, &gpDataTables.pMonTypeLinker },
+		{ "exclude1", TXTFIELD_NAMETOWORD, 0, 10, &sgptDataTables->pMonTypeLinker },
+		{ "exclude2", TXTFIELD_NAMETOWORD, 0, 12, &sgptDataTables->pMonTypeLinker },
 		{ "cpick", TXTFIELD_WORD, 0, 14, NULL },
 		{ "cpick (N)", TXTFIELD_WORD, 0, 16, NULL },
 		{ "cpick (H)", TXTFIELD_WORD, 0, 18, NULL },
@@ -1457,13 +1457,13 @@ void __fastcall DATATBLS_LoadMonUModTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonUModLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pMonUModTxt = (D2MonUModTxt*)DATATBLS_CompileTxt(pMemPool, "monumod", pTbl, &gpDataTables.nMonUModTxtRecordCount, sizeof(D2MonUModTxt));
+	sgptDataTables->pMonUModLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pMonUModTxt = (D2MonUModTxt*)DATATBLS_CompileTxt(pMemPool, "monumod", pTbl, &sgptDataTables->nMonUModTxtRecordCount, sizeof(D2MonUModTxt));
 
-	if (gpDataTables.nMonUModTxtRecordCount > 256)
+	if (sgptDataTables->nMonUModTxtRecordCount > 256)
 	{
 		FOG_WriteToLogFile("monumod.txt exceeded %d entries", 256);
-		gpDataTables.nMonUModTxtRecordCount = 256;
+		sgptDataTables->nMonUModTxtRecordCount = 256;
 	}
 }
 
@@ -1473,11 +1473,11 @@ void __fastcall DATATBLS_LoadSuperUniquesTxt(void* pMemPool)
 	int nId = 0;
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "Superunique", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pSuperUniquesLinker },
+		{ "Superunique", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pSuperUniquesLinker },
 		{ "Name", TXTFIELD_KEYTOWORD, 0, TXTFIELD_DWORD, DATATBLS_GetStringIdFromReferenceString },
-		{ "Class", TXTFIELD_NAMETODWORD, 0, 4, &gpDataTables.pMonStatsLinker },
+		{ "Class", TXTFIELD_NAMETODWORD, 0, 4, &sgptDataTables->pMonStatsLinker },
 		{ "hcIdx", TXTFIELD_DWORD, 0, 8, NULL },
-		{ "MonSound", TXTFIELD_NAMETODWORD, 0, 24, &gpDataTables.pMonSoundsLinker },
+		{ "MonSound", TXTFIELD_NAMETODWORD, 0, 24, &sgptDataTables->pMonSoundsLinker },
 		{ "Mod1", TXTFIELD_DWORD, 0, 12, NULL },
 		{ "Mod2", TXTFIELD_DWORD, 0, 16, NULL },
 		{ "Mod3", TXTFIELD_DWORD, 0, 20, NULL },
@@ -1490,45 +1490,45 @@ void __fastcall DATATBLS_LoadSuperUniquesTxt(void* pMemPool)
 		{ "Utrans", TXTFIELD_BYTE, 0, 40, NULL },
 		{ "Utrans(N)", TXTFIELD_BYTE, 0, 41, NULL },
 		{ "Utrans(H)", TXTFIELD_BYTE, 0, 42, NULL },
-		{ "TC", TXTFIELD_NAMETOWORD, 0, 44, &gpDataTables.pTreasureClassExLinker },
-		{ "TC(N)", TXTFIELD_NAMETOWORD, 0, 46, &gpDataTables.pTreasureClassExLinker },
-		{ "TC(H)", TXTFIELD_NAMETOWORD, 0, 48, &gpDataTables.pTreasureClassExLinker },
+		{ "TC", TXTFIELD_NAMETOWORD, 0, 44, &sgptDataTables->pTreasureClassExLinker },
+		{ "TC(N)", TXTFIELD_NAMETOWORD, 0, 46, &sgptDataTables->pTreasureClassExLinker },
+		{ "TC(H)", TXTFIELD_NAMETOWORD, 0, 48, &sgptDataTables->pTreasureClassExLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pSuperUniquesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pSuperUniquesTxt = (D2SuperUniquesTxt*)DATATBLS_CompileTxt(pMemPool, "superuniques", pTbl, &gpDataTables.nSuperUniquesTxtRecordCount, sizeof(D2SuperUniquesTxt));
+	sgptDataTables->pSuperUniquesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pSuperUniquesTxt = (D2SuperUniquesTxt*)DATATBLS_CompileTxt(pMemPool, "superuniques", pTbl, &sgptDataTables->nSuperUniquesTxtRecordCount, sizeof(D2SuperUniquesTxt));
 
-	if (gpDataTables.nSuperUniquesTxtRecordCount >= 512)
+	if (sgptDataTables->nSuperUniquesTxtRecordCount >= 512)
 	{
-		if (gpDataTables.bCompileTxt)
+		if (sgptDataTables->bCompileTxt)
 		{
 			FOG_WriteToLogFile("Cut off superuniques at %d entries", 512);
 		}
-		gpDataTables.nSuperUniquesTxtRecordCount = 512;
+		sgptDataTables->nSuperUniquesTxtRecordCount = 512;
 	}
 
-	memset(gpDataTables.nSuperUniqueIds, -1, sizeof(gpDataTables.nSuperUniqueIds));
+	memset(sgptDataTables->nSuperUniqueIds, -1, sizeof(sgptDataTables->nSuperUniqueIds));
 
-	for (int i = 0; i < gpDataTables.nSuperUniquesTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nSuperUniquesTxtRecordCount; ++i)
 	{
-		nId = gpDataTables.pSuperUniquesTxt[i].dwHcIdx;
-		if (nId < 0 || nId >= ARRAY_SIZE(gpDataTables.nSuperUniqueIds))
+		nId = sgptDataTables->pSuperUniquesTxt[i].dwHcIdx;
+		if (nId < 0 || nId >= ARRAY_SIZE(sgptDataTables->nSuperUniqueIds))
 		{
-			if (gpDataTables.bCompileTxt)
+			if (sgptDataTables->bCompileTxt)
 			{
 				FOG_WriteToLogFile("Invalid hcIdx (%d) -- value must be between 0 and %d.", nId, 65);
 			}
 		}
 		else
 		{
-			if (gpDataTables.nSuperUniqueIds[nId] == -1)
+			if (sgptDataTables->nSuperUniqueIds[nId] == -1)
 			{
-				gpDataTables.nSuperUniqueIds[nId] = i;
+				sgptDataTables->nSuperUniqueIds[nId] = i;
 			}
 			else
 			{
-				if (gpDataTables.bCompileTxt)
+				if (sgptDataTables->bCompileTxt)
 				{
 					FOG_WriteToLogFile("Duplicate hcIdx (%d) -- index must be unique.", nId);
 				}
@@ -1536,24 +1536,24 @@ void __fastcall DATATBLS_LoadSuperUniquesTxt(void* pMemPool)
 		}
 	}
 
-	for (int i = 0; i < ARRAY_SIZE(gpDataTables.nSuperUniqueIds); ++i)
+	for (int i = 0; i < ARRAY_SIZE(sgptDataTables->nSuperUniqueIds); ++i)
 	{
-		if (gpDataTables.nSuperUniqueIds[i] == -1 && gpDataTables.bCompileTxt)
+		if (sgptDataTables->nSuperUniqueIds[i] == -1 && sgptDataTables->bCompileTxt)
 		{
 			FOG_WriteToLogFile("Missing hcIdx (%d) -- index incomplete", i);
 		}
 
 #define SUPERUNIQUE_NONE -1
-		D2_ASSERT(gpDataTables.nSuperUniqueIds[i] != SUPERUNIQUE_NONE);
+		D2_ASSERT(sgptDataTables->nSuperUniqueIds[i] != SUPERUNIQUE_NONE);
 	}
 }
 
 //D2Common.0x6FD6A440 (#10668)
 D2SuperUniquesTxt* __stdcall DATATBLS_GetSuperUniquesTxtRecord(int nSuperUniqueId)
 {
-	if (nSuperUniqueId >= 0 && nSuperUniqueId < gpDataTables.nSuperUniquesTxtRecordCount)
+	if (nSuperUniqueId >= 0 && nSuperUniqueId < sgptDataTables->nSuperUniquesTxtRecordCount)
 	{
-		return &gpDataTables.pSuperUniquesTxt[nSuperUniqueId];
+		return &sgptDataTables->pSuperUniquesTxt[nSuperUniqueId];
 	}
 
 	return NULL;
@@ -1562,7 +1562,7 @@ D2SuperUniquesTxt* __stdcall DATATBLS_GetSuperUniquesTxtRecord(int nSuperUniqueI
 //D2Common.0x6FD6A470 (#11257)
 int __fastcall DATATBLS_GetSuperUniquesTxtRecordCount()
 {
-	return gpDataTables.nSuperUniquesTxtRecordCount;
+	return sgptDataTables->nSuperUniquesTxtRecordCount;
 }
 
 //D2Common.0x6FD6A480
@@ -1600,39 +1600,39 @@ void __fastcall DATATBLS_LoadHirelingTxt(void* pMemPool)
 		{ "dmg/lvl", TXTFIELD_DWORD, 0, 88, NULL },
 		{ "resist", TXTFIELD_DWORD, 0, 92, NULL },
 		{ "resist/lvl", TXTFIELD_DWORD, 0, 96, NULL },
-		{ "hiredesc", TXTFIELD_CODETOBYTE, 0, 210, &gpDataTables.pHireDescLinker },
+		{ "hiredesc", TXTFIELD_CODETOBYTE, 0, 210, &sgptDataTables->pHireDescLinker },
 		{ "defaultchance", TXTFIELD_DWORD, 0, 100, NULL },
-		{ "skill1", TXTFIELD_NAMETODWORD, 0, 120, &gpDataTables.pSkillsLinker },
+		{ "skill1", TXTFIELD_NAMETODWORD, 0, 120, &sgptDataTables->pSkillsLinker },
 		{ "mode1", TXTFIELD_BYTE, 0, 192, NULL },
 		{ "chance1", TXTFIELD_DWORD, 0, 144, NULL },
 		{ "chanceperlvl1", TXTFIELD_DWORD, 0, 168, NULL },
 		{ "level1", TXTFIELD_BYTE, 0, 198, NULL },
 		{ "lvlperlvl1", TXTFIELD_BYTE, 0, 204, NULL },
-		{ "skill2", TXTFIELD_NAMETODWORD, 0, 124, &gpDataTables.pSkillsLinker },
+		{ "skill2", TXTFIELD_NAMETODWORD, 0, 124, &sgptDataTables->pSkillsLinker },
 		{ "mode2", TXTFIELD_BYTE, 0, 193, NULL },
 		{ "chance2", TXTFIELD_DWORD, 0, 148, NULL },
 		{ "chanceperlvl2", TXTFIELD_DWORD, 0, 172, NULL },
 		{ "level2", TXTFIELD_BYTE, 0, 199, NULL },
 		{ "lvlperlvl2", TXTFIELD_BYTE, 0, 205, NULL },
-		{ "skill3", TXTFIELD_NAMETODWORD, 0, 128, &gpDataTables.pSkillsLinker },
+		{ "skill3", TXTFIELD_NAMETODWORD, 0, 128, &sgptDataTables->pSkillsLinker },
 		{ "mode3", TXTFIELD_BYTE, 0, 194, NULL },
 		{ "chance3", TXTFIELD_DWORD, 0, 152, NULL },
 		{ "chanceperlvl3", TXTFIELD_DWORD, 0, 176, NULL },
 		{ "level3", TXTFIELD_BYTE, 0, 200, NULL },
 		{ "lvlperlvl3", TXTFIELD_BYTE, 0, 206, NULL },
-		{ "skill4", TXTFIELD_NAMETODWORD, 0, 132, &gpDataTables.pSkillsLinker },
+		{ "skill4", TXTFIELD_NAMETODWORD, 0, 132, &sgptDataTables->pSkillsLinker },
 		{ "mode4", TXTFIELD_BYTE, 0, 195, NULL },
 		{ "chance4", TXTFIELD_DWORD, 0, 156, NULL },
 		{ "chanceperlvl4", TXTFIELD_DWORD, 0, 180, NULL },
 		{ "level4", TXTFIELD_BYTE, 0, 201, NULL },
 		{ "lvlperlvl4", TXTFIELD_BYTE, 0, 207, NULL },
-		{ "skill5", TXTFIELD_NAMETODWORD, 0, 136, &gpDataTables.pSkillsLinker },
+		{ "skill5", TXTFIELD_NAMETODWORD, 0, 136, &sgptDataTables->pSkillsLinker },
 		{ "mode5", TXTFIELD_BYTE, 0, 196, NULL },
 		{ "chance5", TXTFIELD_DWORD, 0, 160, NULL },
 		{ "chanceperlvl5", TXTFIELD_DWORD, 0, 184, NULL },
 		{ "level5", TXTFIELD_BYTE, 0, 202, NULL },
 		{ "lvlperlvl5", TXTFIELD_BYTE, 0, 208, NULL },
-		{ "skill6", TXTFIELD_NAMETODWORD, 0, 140, &gpDataTables.pSkillsLinker },
+		{ "skill6", TXTFIELD_NAMETODWORD, 0, 140, &sgptDataTables->pSkillsLinker },
 		{ "mode6", TXTFIELD_BYTE, 0, 197, NULL },
 		{ "chance6", TXTFIELD_DWORD, 0, 164, NULL },
 		{ "chanceperlvl6", TXTFIELD_DWORD, 0, 188, NULL },
@@ -1645,34 +1645,34 @@ void __fastcall DATATBLS_LoadHirelingTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pHirelingTxt = (D2HirelingTxt*)DATATBLS_CompileTxt(pMemPool, "hireling", pTbl, &gpDataTables.nHirelingTxtRecordCount, sizeof(D2HirelingTxt));
+	sgptDataTables->pHirelingTxt = (D2HirelingTxt*)DATATBLS_CompileTxt(pMemPool, "hireling", pTbl, &sgptDataTables->nHirelingTxtRecordCount, sizeof(D2HirelingTxt));
 
 	for (int i = 0; i < 256; ++i)
 	{
-		gpDataTables.nClassicHirelingStartRecordIds[i] = -1;
-		gpDataTables.nExpansionHirelingStartRecordIds[i] = -1;
+		sgptDataTables->nClassicHirelingStartRecordIds[i] = -1;
+		sgptDataTables->nExpansionHirelingStartRecordIds[i] = -1;
 	}
 
-	for (int i = 0; i < gpDataTables.nHirelingTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nHirelingTxtRecordCount; ++i)
 	{
-		gpDataTables.pHirelingTxt[i].wNameFirst = D2LANG_GetTblIndex(gpDataTables.pHirelingTxt[i].szNameFirst, &pUnicode);
-		gpDataTables.pHirelingTxt[i].wNameLast = D2LANG_GetTblIndex(gpDataTables.pHirelingTxt[i].szNameLast, &pUnicode);
+		sgptDataTables->pHirelingTxt[i].wNameFirst = D2LANG_GetTblIndex(sgptDataTables->pHirelingTxt[i].szNameFirst, &pUnicode);
+		sgptDataTables->pHirelingTxt[i].wNameLast = D2LANG_GetTblIndex(sgptDataTables->pHirelingTxt[i].szNameLast, &pUnicode);
 
 		if (FOG_IsExpansion())
 		{
-			D2_ASSERT(gpDataTables.pHirelingTxt[i].wNameFirst > 0);
-			D2_ASSERT(gpDataTables.pHirelingTxt[i].wNameLast > gpDataTables.pHirelingTxt[i].wNameFirst);
+			D2_ASSERT(sgptDataTables->pHirelingTxt[i].wNameFirst > 0);
+			D2_ASSERT(sgptDataTables->pHirelingTxt[i].wNameLast > sgptDataTables->pHirelingTxt[i].wNameFirst);
 
 #define MAX_HIRELING_ID 256
-			D2_ASSERT(gpDataTables.pHirelingTxt[i].nId < MAX_HIRELING_ID);
+			D2_ASSERT(sgptDataTables->pHirelingTxt[i].nId < MAX_HIRELING_ID);
 		}
 
-		if (gpDataTables.pHirelingTxt[i].nId < 256)
+		if (sgptDataTables->pHirelingTxt[i].nId < 256)
 		{
-			nId = gpDataTables.pHirelingTxt[i].nId + ((gpDataTables.pHirelingTxt[i].wVersion >= 100) << 8);
-			if (gpDataTables.nClassicHirelingStartRecordIds[nId] < 0)
+			nId = sgptDataTables->pHirelingTxt[i].nId + ((sgptDataTables->pHirelingTxt[i].wVersion >= 100) << 8);
+			if (sgptDataTables->nClassicHirelingStartRecordIds[nId] < 0)
 			{
-				gpDataTables.nClassicHirelingStartRecordIds[nId] = i;
+				sgptDataTables->nClassicHirelingStartRecordIds[nId] = i;
 			}
 		}
 	}
@@ -1681,9 +1681,9 @@ void __fastcall DATATBLS_LoadHirelingTxt(void* pMemPool)
 //D2Common.0x6FD6B1A0
 D2ItemTypesTxt* __fastcall DATATBLS_GetItemTypesTxtRecord(int nItemType)
 {
-	if (nItemType >= 0 && nItemType < gpDataTables.nItemTypesTxtRecordCount)
+	if (nItemType >= 0 && nItemType < sgptDataTables->nItemTypesTxtRecordCount)
 	{
-		return &gpDataTables.pItemTypesTxt[nItemType];
+		return &sgptDataTables->pItemTypesTxt[nItemType];
 	}
 
 	return NULL;
@@ -1708,13 +1708,13 @@ D2HirelingTxt* __stdcall DATATBLS_GetHirelingTxtRecordFromIdAndLevel(BOOL bExpan
 
 	nVersion = bExpansion != 0 ? 100 : 0;
 
-	nStartRecordId = gpDataTables.nClassicHirelingStartRecordIds[nId + ((bExpansion != FALSE) << 8)];
+	nStartRecordId = sgptDataTables->nClassicHirelingStartRecordIds[nId + ((bExpansion != FALSE) << 8)];
 
-	if (nStartRecordId >= 0 && nStartRecordId < gpDataTables.nHirelingTxtRecordCount)
+	if (nStartRecordId >= 0 && nStartRecordId < sgptDataTables->nHirelingTxtRecordCount)
 	{
-		pHirelingTxtRecord = &gpDataTables.pHirelingTxt[nStartRecordId];
+		pHirelingTxtRecord = &sgptDataTables->pHirelingTxt[nStartRecordId];
 
-		while (nStartRecordId < gpDataTables.nHirelingTxtRecordCount)
+		while (nStartRecordId < sgptDataTables->nHirelingTxtRecordCount)
 		{
 			if (pHirelingTxtRecord->nId != nId)
 			{
@@ -1776,12 +1776,12 @@ D2HirelingTxt* __stdcall DATATBLS_GetNextHirelingTxtRecordFromNameId(BOOL bExpan
 
 	if (pOldRecord)
 	{
-		nRecordId = pOldRecord - gpDataTables.pHirelingTxt + 1;
+		nRecordId = pOldRecord - sgptDataTables->pHirelingTxt + 1;
 	}
 
-	while (nRecordId < gpDataTables.nHirelingTxtRecordCount)
+	while (nRecordId < sgptDataTables->nHirelingTxtRecordCount)
 	{
-		pHirelingTxtRecord = &gpDataTables.pHirelingTxt[nRecordId];
+		pHirelingTxtRecord = &sgptDataTables->pHirelingTxt[nRecordId];
 
 		if (nNameId >= pHirelingTxtRecord->wNameFirst && nNameId <= pHirelingTxtRecord->wNameLast && pHirelingTxtRecord->wVersion == nVersion)
 		{
@@ -1805,12 +1805,12 @@ D2HirelingTxt* __stdcall DATATBLS_GetNextHirelingTxtRecordFromClassId(BOOL bExpa
 
 	if (pOldRecord)
 	{
-		nRecordId = pOldRecord - gpDataTables.pHirelingTxt + 1;
+		nRecordId = pOldRecord - sgptDataTables->pHirelingTxt + 1;
 	}
 
-	while (nRecordId < gpDataTables.nHirelingTxtRecordCount)
+	while (nRecordId < sgptDataTables->nHirelingTxtRecordCount)
 	{
-		pHirelingTxtRecord = &gpDataTables.pHirelingTxt[nRecordId];
+		pHirelingTxtRecord = &sgptDataTables->pHirelingTxt[nRecordId];
 
 		if (pHirelingTxtRecord->dwClass == nClass && pHirelingTxtRecord->wVersion == nVersion)
 		{
@@ -1834,12 +1834,12 @@ D2HirelingTxt* __stdcall DATATBLS_GetNextHirelingTxtRecordFromVendorIdAndDifficu
 
 	if (pOldRecord)
 	{
-		nRecordId = pOldRecord - gpDataTables.pHirelingTxt + 1;
+		nRecordId = pOldRecord - sgptDataTables->pHirelingTxt + 1;
 	}
 
-	while (nRecordId < gpDataTables.nHirelingTxtRecordCount)
+	while (nRecordId < sgptDataTables->nHirelingTxtRecordCount)
 	{
-		pHirelingTxtRecord = &gpDataTables.pHirelingTxt[nRecordId];
+		pHirelingTxtRecord = &sgptDataTables->pHirelingTxt[nRecordId];
 
 		if (pHirelingTxtRecord->dwSeller == nVendorId && pHirelingTxtRecord->dwDifficulty == (nDifficulty + 1) && pHirelingTxtRecord->wVersion == nVersion)
 		{
@@ -1865,12 +1865,12 @@ D2HirelingTxt* __stdcall DATATBLS_GetNextHirelingTxtRecordFromActAndDifficulty(B
 	if (pOldRecord)
 	{
 		nLevel = pOldRecord->nHirelingLevel;
-		nRecordId = pOldRecord - gpDataTables.pHirelingTxt + 1;
+		nRecordId = pOldRecord - sgptDataTables->pHirelingTxt + 1;
 	}
 
-	while (nRecordId < gpDataTables.nHirelingTxtRecordCount)
+	while (nRecordId < sgptDataTables->nHirelingTxtRecordCount)
 	{
-		pHirelingTxtRecord = &gpDataTables.pHirelingTxt[nRecordId];
+		pHirelingTxtRecord = &sgptDataTables->pHirelingTxt[nRecordId];
 
 		if (pHirelingTxtRecord->dwAct == (nAct + 1))
 		{
@@ -1891,7 +1891,7 @@ void __fastcall DATATBLS_LoadNpcTxt(void* pMemPool)
 {
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "npc", TXTFIELD_NAMETODWORD, 0, 0, &gpDataTables.pMonStatsLinker },
+		{ "npc", TXTFIELD_NAMETODWORD, 0, 0, &sgptDataTables->pMonStatsLinker },
 		{ "sell mult", TXTFIELD_DWORD, 0, 4, NULL },
 		{ "buy mult", TXTFIELD_DWORD, 0, 8, NULL },
 		{ "rep mult", TXTFIELD_DWORD, 0, 12, NULL },
@@ -1913,17 +1913,17 @@ void __fastcall DATATBLS_LoadNpcTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pNpcTxt = (D2NpcTxt*)DATATBLS_CompileTxt(pMemPool, "npc", pTbl, &gpDataTables.nNpcTxtRecordCount, sizeof(D2NpcTxt));
+	sgptDataTables->pNpcTxt = (D2NpcTxt*)DATATBLS_CompileTxt(pMemPool, "npc", pTbl, &sgptDataTables->nNpcTxtRecordCount, sizeof(D2NpcTxt));
 }
 
 //D2Common.0x6FD6B820 (#10588)
 D2NpcTxt* __stdcall DATATBLS_GetNpcTxtRecord(DWORD dwNpcId)
 {
-	for (int i = 0; i < gpDataTables.nNpcTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nNpcTxtRecordCount; ++i)
 	{
-		if (gpDataTables.pNpcTxt[i].dwNpc == dwNpcId)
+		if (sgptDataTables->pNpcTxt[i].dwNpc == dwNpcId)
 		{
-			return &gpDataTables.pNpcTxt[i];
+			return &sgptDataTables->pNpcTxt[i];
 		}
 	}
 
@@ -1935,59 +1935,59 @@ void __fastcall DATATBLS_LoadMonSoundsTxt(void* pMemPool)
 {
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "Id", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pMonSoundsLinker },
-		{ "Attack1", TXTFIELD_NAMETODWORD, 0, 4, &gpDataTables.pSoundsLinker },
+		{ "Id", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pMonSoundsLinker },
+		{ "Attack1", TXTFIELD_NAMETODWORD, 0, 4, &sgptDataTables->pSoundsLinker },
 		{ "Att1Del", TXTFIELD_DWORD, 0, 8, NULL },
 		{ "Att1Prb", TXTFIELD_DWORD, 0, 12, NULL },
-		{ "Attack2", TXTFIELD_NAMETODWORD, 0, 28, &gpDataTables.pSoundsLinker },
+		{ "Attack2", TXTFIELD_NAMETODWORD, 0, 28, &sgptDataTables->pSoundsLinker },
 		{ "Att2Del", TXTFIELD_DWORD, 0, 32, NULL },
 		{ "Att2Prb", TXTFIELD_DWORD, 0, 36, NULL },
-		{ "Weapon1", TXTFIELD_NAMETODWORD, 0, 16, &gpDataTables.pSoundsLinker },
+		{ "Weapon1", TXTFIELD_NAMETODWORD, 0, 16, &sgptDataTables->pSoundsLinker },
 		{ "Wea1Del", TXTFIELD_DWORD, 0, 20, NULL },
 		{ "Wea1Vol", TXTFIELD_DWORD, 0, 24, NULL },
-		{ "Weapon2", TXTFIELD_NAMETODWORD, 0, 40, &gpDataTables.pSoundsLinker },
+		{ "Weapon2", TXTFIELD_NAMETODWORD, 0, 40, &sgptDataTables->pSoundsLinker },
 		{ "Wea2Del", TXTFIELD_DWORD, 0, 44, NULL },
 		{ "Wea2Vol", TXTFIELD_DWORD, 0, 48, NULL },
-		{ "HitSound", TXTFIELD_NAMETODWORD, 0, 52, &gpDataTables.pSoundsLinker },
+		{ "HitSound", TXTFIELD_NAMETODWORD, 0, 52, &sgptDataTables->pSoundsLinker },
 		{ "HitDelay", TXTFIELD_DWORD, 0, 56, NULL },
-		{ "DeathSound", TXTFIELD_NAMETODWORD, 0, 60, &gpDataTables.pSoundsLinker },
+		{ "DeathSound", TXTFIELD_NAMETODWORD, 0, 60, &sgptDataTables->pSoundsLinker },
 		{ "DeaDelay", TXTFIELD_DWORD, 0, 64, NULL },
-		{ "Skill1", TXTFIELD_NAMETODWORD, 0, 68, &gpDataTables.pSoundsLinker },
-		{ "Skill2", TXTFIELD_NAMETODWORD, 0, 72, &gpDataTables.pSoundsLinker },
-		{ "Skill3", TXTFIELD_NAMETODWORD, 0, 76, &gpDataTables.pSoundsLinker },
-		{ "Skill4", TXTFIELD_NAMETODWORD, 0, 80, &gpDataTables.pSoundsLinker },
-		{ "Footstep", TXTFIELD_NAMETODWORD, 0, 84, &gpDataTables.pSoundsLinker },
-		{ "FootstepLayer", TXTFIELD_NAMETODWORD, 0, 88, &gpDataTables.pSoundsLinker },
+		{ "Skill1", TXTFIELD_NAMETODWORD, 0, 68, &sgptDataTables->pSoundsLinker },
+		{ "Skill2", TXTFIELD_NAMETODWORD, 0, 72, &sgptDataTables->pSoundsLinker },
+		{ "Skill3", TXTFIELD_NAMETODWORD, 0, 76, &sgptDataTables->pSoundsLinker },
+		{ "Skill4", TXTFIELD_NAMETODWORD, 0, 80, &sgptDataTables->pSoundsLinker },
+		{ "Footstep", TXTFIELD_NAMETODWORD, 0, 84, &sgptDataTables->pSoundsLinker },
+		{ "FootstepLayer", TXTFIELD_NAMETODWORD, 0, 88, &sgptDataTables->pSoundsLinker },
 		{ "FsCnt", TXTFIELD_DWORD, 0, 92, NULL },
 		{ "FsOff", TXTFIELD_DWORD, 0, 96, NULL },
 		{ "FsPrb", TXTFIELD_DWORD, 0, 100, NULL },
-		{ "Neutral", TXTFIELD_NAMETODWORD, 0, 104, &gpDataTables.pSoundsLinker },
+		{ "Neutral", TXTFIELD_NAMETODWORD, 0, 104, &sgptDataTables->pSoundsLinker },
 		{ "NeuTime", TXTFIELD_DWORD, 0, 108, NULL },
-		{ "Init", TXTFIELD_NAMETODWORD, 0, 112, &gpDataTables.pSoundsLinker },
-		{ "Taunt", TXTFIELD_NAMETODWORD, 0, 116, &gpDataTables.pSoundsLinker },
-		{ "Flee", TXTFIELD_NAMETODWORD, 0, 120, &gpDataTables.pSoundsLinker },
-		{ "CvtMo1", TXTFIELD_CODETOBYTE, 0, 124, &gpDataTables.pMonModeLinker },
-		{ "CvtMo2", TXTFIELD_CODETOBYTE, 0, 132, &gpDataTables.pMonModeLinker },
-		{ "CvtMo3", TXTFIELD_CODETOBYTE, 0, 140, &gpDataTables.pMonModeLinker },
-		{ "CvtSk1", TXTFIELD_NAMETODWORD, 0, 128, &gpDataTables.pSkillsLinker },
-		{ "CvtSk2", TXTFIELD_NAMETODWORD, 0, 136, &gpDataTables.pSkillsLinker },
-		{ "CvtSk3", TXTFIELD_NAMETODWORD, 0, 144, &gpDataTables.pSkillsLinker },
-		{ "CvtTgt1", TXTFIELD_CODETOBYTE, 0, 125, &gpDataTables.pMonModeLinker },
-		{ "CvtTgt2", TXTFIELD_CODETOBYTE, 0, 133, &gpDataTables.pMonModeLinker },
-		{ "CvtTgt3", TXTFIELD_CODETOBYTE, 0, 141, &gpDataTables.pMonModeLinker },
+		{ "Init", TXTFIELD_NAMETODWORD, 0, 112, &sgptDataTables->pSoundsLinker },
+		{ "Taunt", TXTFIELD_NAMETODWORD, 0, 116, &sgptDataTables->pSoundsLinker },
+		{ "Flee", TXTFIELD_NAMETODWORD, 0, 120, &sgptDataTables->pSoundsLinker },
+		{ "CvtMo1", TXTFIELD_CODETOBYTE, 0, 124, &sgptDataTables->pMonModeLinker },
+		{ "CvtMo2", TXTFIELD_CODETOBYTE, 0, 132, &sgptDataTables->pMonModeLinker },
+		{ "CvtMo3", TXTFIELD_CODETOBYTE, 0, 140, &sgptDataTables->pMonModeLinker },
+		{ "CvtSk1", TXTFIELD_NAMETODWORD, 0, 128, &sgptDataTables->pSkillsLinker },
+		{ "CvtSk2", TXTFIELD_NAMETODWORD, 0, 136, &sgptDataTables->pSkillsLinker },
+		{ "CvtSk3", TXTFIELD_NAMETODWORD, 0, 144, &sgptDataTables->pSkillsLinker },
+		{ "CvtTgt1", TXTFIELD_CODETOBYTE, 0, 125, &sgptDataTables->pMonModeLinker },
+		{ "CvtTgt2", TXTFIELD_CODETOBYTE, 0, 133, &sgptDataTables->pMonModeLinker },
+		{ "CvtTgt3", TXTFIELD_CODETOBYTE, 0, 141, &sgptDataTables->pMonModeLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonSoundsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pMonSoundsTxt = (D2MonSoundsTxt*)DATATBLS_CompileTxt(pMemPool, "monsounds", pTbl, &gpDataTables.nMonSoundsTxtRecordCount, sizeof(D2MonSoundsTxt));
+	sgptDataTables->pMonSoundsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pMonSoundsTxt = (D2MonSoundsTxt*)DATATBLS_CompileTxt(pMemPool, "monsounds", pTbl, &sgptDataTables->nMonSoundsTxtRecordCount, sizeof(D2MonSoundsTxt));
 }
 
 //D2Common.0x6FD6BF50 (#11252)
 D2MonSoundsTxt* __stdcall DATATBLS_GetMonSoundsTxtRecordFromSoundId(int nSoundId)
 {
-	if (gpDataTables.pMonSoundsTxt && nSoundId >= 0 && nSoundId < gpDataTables.nMonSoundsTxtRecordCount)
+	if (sgptDataTables->pMonSoundsTxt && nSoundId >= 0 && nSoundId < sgptDataTables->nMonSoundsTxtRecordCount)
 	{
-		return &gpDataTables.pMonSoundsTxt[nSoundId];
+		return &sgptDataTables->pMonSoundsTxt[nSoundId];
 	}
 
 	return NULL;
@@ -2000,12 +2000,12 @@ D2MonSoundsTxt* __stdcall DATATBLS_GetMonSoundsTxtRecordFromMonsterId(int nMonst
 	int nSoundId = 0;
 
 	pMonStatsTxtRecord = DATATBLS_GetMonStatsTxtRecord(nMonsterId);
-	if (gpDataTables.pMonSoundsTxt && pMonStatsTxtRecord)
+	if (sgptDataTables->pMonSoundsTxt && pMonStatsTxtRecord)
 	{
 		nSoundId = pMonStatsTxtRecord->wMonSound;
-		if (nSoundId >= 0 && nSoundId < gpDataTables.nMonSoundsTxtRecordCount)
+		if (nSoundId >= 0 && nSoundId < sgptDataTables->nMonSoundsTxtRecordCount)
 		{
-			return &gpDataTables.pMonSoundsTxt[nSoundId];
+			return &sgptDataTables->pMonSoundsTxt[nSoundId];
 		}
 	}
 
@@ -2069,7 +2069,7 @@ void __fastcall DATATBLS_MonStats2CompositLinker(char* pSrc, void* pRecord, int 
 				}
 
 
-				pMonStats2TxtRecord->unk0x26[nOffset].nComposit[nCounter] = FOG_GetLinkIndex(gpDataTables.pCompCodeLinker, DATATBLS_StringToCode(pTmp), 1);
+				pMonStats2TxtRecord->unk0x26[nOffset].nComposit[nCounter] = FOG_GetLinkIndex(sgptDataTables->pCompCodeLinker, DATATBLS_StringToCode(pTmp), 1);
 
 				++nCounter;
 
@@ -2107,7 +2107,7 @@ void __fastcall DATATBLS_LoadMonStats2Txt(void* pMemPool)
 {
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "Id", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pMonStats2Linker },
+		{ "Id", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pMonStats2Linker },
 		{ "Height", TXTFIELD_BYTE, 0, 11, NULL },
 		{ "overlayHeight", TXTFIELD_BYTE, 0, 12, NULL },
 		{ "pixHeight", TXTFIELD_BYTE, 0, 13, NULL },
@@ -2230,13 +2230,13 @@ void __fastcall DATATBLS_LoadMonStats2Txt(void* pMemPool)
 		{ "InfernoLen", TXTFIELD_BYTE, 0, 264, NULL },
 		{ "InfernoAnim", TXTFIELD_BYTE, 0, 265, NULL },
 		{ "InfernoRollback", TXTFIELD_BYTE, 0, 266, NULL },
-		{ "ResurrectMode", TXTFIELD_CODETOBYTE, 0, 267, &gpDataTables.pMonModeLinker },
-		{ "ResurrectSkill", TXTFIELD_NAMETOWORD, 0, 268, &gpDataTables.pSkillsLinker },
+		{ "ResurrectMode", TXTFIELD_CODETOBYTE, 0, 267, &sgptDataTables->pMonModeLinker },
+		{ "ResurrectSkill", TXTFIELD_NAMETOWORD, 0, 268, &sgptDataTables->pSkillsLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonStats2Linker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pMonStats2Txt = (D2MonStats2Txt*)DATATBLS_CompileTxt(pMemPool, "monstats2", pTbl, &gpDataTables.nMonStats2TxtRecordCount, sizeof(D2MonStats2Txt));
+	sgptDataTables->pMonStats2Linker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pMonStats2Txt = (D2MonStats2Txt*)DATATBLS_CompileTxt(pMemPool, "monstats2", pTbl, &sgptDataTables->nMonStats2TxtRecordCount, sizeof(D2MonStats2Txt));
 }
 
 //D2Common.0x6FD6D660
@@ -2252,7 +2252,7 @@ int __fastcall DATATBLS_CheckNestedMonsterTypes(int nMonType1, int nMonType2)
 		return 0;
 	}
 
-	if (nMonType1 > 0 && nMonType1 < gpDataTables.nMonTypeTxtRecordCount)
+	if (nMonType1 > 0 && nMonType1 < sgptDataTables->nMonTypeTxtRecordCount)
 	{
 		nParentMonsterTypes[1] = nMonType1;
 		nIndex = 1;
@@ -2264,7 +2264,7 @@ int __fastcall DATATBLS_CheckNestedMonsterTypes(int nMonType1, int nMonType2)
 				return 1;
 			}
 
-			if (nMonsterType >= gpDataTables.nMonTypeTxtRecordCount)
+			if (nMonsterType >= sgptDataTables->nMonTypeTxtRecordCount)
 			{
 				break;
 			}
@@ -2274,7 +2274,7 @@ int __fastcall DATATBLS_CheckNestedMonsterTypes(int nMonType1, int nMonType2)
 				return 0;
 			}
 
-			pMonTypeTxtRecord = &gpDataTables.pMonTypeTxt[nMonsterType];
+			pMonTypeTxtRecord = &sgptDataTables->pMonTypeTxt[nMonsterType];
 
 			if (pMonTypeTxtRecord->nEquiv[0] > 0)
 			{
@@ -2308,27 +2308,27 @@ void __fastcall DATATBLS_LoadMonTypeTxt(void* pMemPool)
 
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "type", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pMonTypeLinker },
-		{ "equiv1", TXTFIELD_NAMETOWORD, 0, 2, &gpDataTables.pMonTypeLinker },
-		{ "equiv2", TXTFIELD_NAMETOWORD, 0, 4, &gpDataTables.pMonTypeLinker },
-		{ "equiv3", TXTFIELD_NAMETOWORD, 0, 6, &gpDataTables.pMonTypeLinker },
+		{ "type", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pMonTypeLinker },
+		{ "equiv1", TXTFIELD_NAMETOWORD, 0, 2, &sgptDataTables->pMonTypeLinker },
+		{ "equiv2", TXTFIELD_NAMETOWORD, 0, 4, &sgptDataTables->pMonTypeLinker },
+		{ "equiv3", TXTFIELD_NAMETOWORD, 0, 6, &sgptDataTables->pMonTypeLinker },
 		{ "strsing", TXTFIELD_KEYTOWORD, 0, 8, DATATBLS_GetStringIdFromReferenceString },
 		{ "strplur", TXTFIELD_KEYTOWORD, 0, 10, DATATBLS_GetStringIdFromReferenceString },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonTypeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pMonTypeTxt = (D2MonTypeTxt*)DATATBLS_CompileTxt(pMemPool, "montype", pTbl, &gpDataTables.nMonTypeTxtRecordCount, sizeof(D2MonTypeTxt));
+	sgptDataTables->pMonTypeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pMonTypeTxt = (D2MonTypeTxt*)DATATBLS_CompileTxt(pMemPool, "montype", pTbl, &sgptDataTables->nMonTypeTxtRecordCount, sizeof(D2MonTypeTxt));
 
-	gpDataTables.nMonTypeIndex = (gpDataTables.nMonTypeTxtRecordCount + 31) / 32;
-	gpDataTables.pMonTypeNest = (DWORD*)FOG_AllocServerMemory(NULL, sizeof(DWORD) * gpDataTables.nMonTypeTxtRecordCount * gpDataTables.nMonTypeIndex, __FILE__, __LINE__, 0);
-	memset(gpDataTables.pMonTypeNest, 0x00, sizeof(DWORD) * gpDataTables.nMonTypeTxtRecordCount * gpDataTables.nMonTypeIndex);
+	sgptDataTables->nMonTypeIndex = (sgptDataTables->nMonTypeTxtRecordCount + 31) / 32;
+	sgptDataTables->pMonTypeNest = (DWORD*)FOG_AllocServerMemory(NULL, sizeof(DWORD) * sgptDataTables->nMonTypeTxtRecordCount * sgptDataTables->nMonTypeIndex, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->pMonTypeNest, 0x00, sizeof(DWORD) * sgptDataTables->nMonTypeTxtRecordCount * sgptDataTables->nMonTypeIndex);
 
-	for (int i = 0; i < gpDataTables.nMonTypeTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nMonTypeTxtRecordCount; ++i)
 	{
-		pMonTypeNest = &gpDataTables.pMonTypeNest[gpDataTables.nMonTypeIndex * i];
+		pMonTypeNest = &sgptDataTables->pMonTypeNest[sgptDataTables->nMonTypeIndex * i];
 
-		for (int j = 0; j < gpDataTables.nMonTypeTxtRecordCount; ++j)
+		for (int j = 0; j < sgptDataTables->nMonTypeTxtRecordCount; ++j)
 		{
 			if (DATATBLS_CheckNestedMonsterTypes(i, j))
 			{
@@ -2341,13 +2341,13 @@ void __fastcall DATATBLS_LoadMonTypeTxt(void* pMemPool)
 //D2Common.0x6FD6D910
 void __fastcall DATATBLS_UnloadMonTypeTxt()
 {
-	if (gpDataTables.pMonTypeTxt)
+	if (sgptDataTables->pMonTypeTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pMonTypeTxt);
-		FOG_FreeLinker(gpDataTables.pMonTypeLinker);
-		FOG_FreeServerMemory(NULL, gpDataTables.pMonTypeNest, __FILE__, __LINE__, 0);
-		gpDataTables.pMonTypeTxt = NULL;
-		gpDataTables.pMonTypeLinker = NULL;
+		DATATBLS_UnloadBin(sgptDataTables->pMonTypeTxt);
+		FOG_FreeLinker(sgptDataTables->pMonTypeLinker);
+		FOG_FreeServerMemory(NULL, sgptDataTables->pMonTypeNest, __FILE__, __LINE__, 0);
+		sgptDataTables->pMonTypeTxt = NULL;
+		sgptDataTables->pMonTypeLinker = NULL;
 	}
 }
 
@@ -2356,93 +2356,93 @@ void __fastcall DATATBLS_LoadMonPropTxt(void* pMemPool)
 {
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "Id", TXTFIELD_NAMETOINDEX2, 0, 0, &gpDataTables.pMonPropLinker },
-		{ "prop1", TXTFIELD_NAMETODWORD, 0, 4, &gpDataTables.pPropertiesLinker },
+		{ "Id", TXTFIELD_NAMETOINDEX2, 0, 0, &sgptDataTables->pMonPropLinker },
+		{ "prop1", TXTFIELD_NAMETODWORD, 0, 4, &sgptDataTables->pPropertiesLinker },
 		{ "par1", TXTFIELD_DWORD, 0, 8, NULL },
 		{ "chance1", TXTFIELD_BYTE, 0, 292, NULL },
 		{ "min1", TXTFIELD_DWORD, 0, 12, NULL },
 		{ "max1", TXTFIELD_DWORD, 0, 16, NULL },
-		{ "prop2", TXTFIELD_NAMETODWORD, 0, 20, &gpDataTables.pPropertiesLinker },
+		{ "prop2", TXTFIELD_NAMETODWORD, 0, 20, &sgptDataTables->pPropertiesLinker },
 		{ "chance2", TXTFIELD_BYTE, 0, 293, NULL },
 		{ "par2", TXTFIELD_DWORD, 0, 24, NULL },
 		{ "min2", TXTFIELD_DWORD, 0, 28, NULL },
 		{ "max2", TXTFIELD_DWORD, 0, 32, NULL },
-		{ "prop3", TXTFIELD_NAMETODWORD, 0, 36, &gpDataTables.pPropertiesLinker },
+		{ "prop3", TXTFIELD_NAMETODWORD, 0, 36, &sgptDataTables->pPropertiesLinker },
 		{ "chance3", TXTFIELD_BYTE, 0, 294, NULL },
 		{ "par3", TXTFIELD_DWORD, 0, 40, NULL },
 		{ "min3", TXTFIELD_DWORD, 0, 44, NULL },
 		{ "max3", TXTFIELD_DWORD, 0, 48, NULL },
-		{ "prop4", TXTFIELD_NAMETODWORD, 0, 52, &gpDataTables.pPropertiesLinker },
+		{ "prop4", TXTFIELD_NAMETODWORD, 0, 52, &sgptDataTables->pPropertiesLinker },
 		{ "chance4", TXTFIELD_BYTE, 0, 295, NULL },
 		{ "par4", TXTFIELD_DWORD, 0, 56, NULL },
 		{ "min4", TXTFIELD_DWORD, 0, 60, NULL },
 		{ "max4", TXTFIELD_DWORD, 0, 64, NULL },
-		{ "prop5", TXTFIELD_NAMETODWORD, 0, 68, &gpDataTables.pPropertiesLinker },
+		{ "prop5", TXTFIELD_NAMETODWORD, 0, 68, &sgptDataTables->pPropertiesLinker },
 		{ "chance5", TXTFIELD_BYTE, 0, 296, NULL },
 		{ "par5", TXTFIELD_DWORD, 0, 72, NULL },
 		{ "min5", TXTFIELD_DWORD, 0, 76, NULL },
 		{ "max5", TXTFIELD_DWORD, 0, 80, NULL },
-		{ "prop6", TXTFIELD_NAMETODWORD, 0, 84, &gpDataTables.pPropertiesLinker },
+		{ "prop6", TXTFIELD_NAMETODWORD, 0, 84, &sgptDataTables->pPropertiesLinker },
 		{ "chance6", TXTFIELD_BYTE, 0, 297, NULL },
 		{ "par6", TXTFIELD_DWORD, 0, 88, NULL },
 		{ "min6", TXTFIELD_DWORD, 0, 92, NULL },
 		{ "max6", TXTFIELD_DWORD, 0, 96, NULL },
-		{ "prop1 (N)", TXTFIELD_NAMETODWORD, 0, 100, &gpDataTables.pPropertiesLinker },
+		{ "prop1 (N)", TXTFIELD_NAMETODWORD, 0, 100, &sgptDataTables->pPropertiesLinker },
 		{ "chance1 (N)", TXTFIELD_BYTE, 0, 298, NULL },
 		{ "par1 (N)", TXTFIELD_DWORD, 0, 104, NULL },
 		{ "min1 (N)", TXTFIELD_DWORD, 0, 108, NULL },
 		{ "max1 (N)", TXTFIELD_DWORD, 0, 112, NULL },
-		{ "prop2 (N)", TXTFIELD_NAMETODWORD, 0, 116, &gpDataTables.pPropertiesLinker },
+		{ "prop2 (N)", TXTFIELD_NAMETODWORD, 0, 116, &sgptDataTables->pPropertiesLinker },
 		{ "chance2 (N)", TXTFIELD_BYTE, 0, 299, NULL },
 		{ "par2 (N)", TXTFIELD_DWORD, 0, 120, NULL },
 		{ "min2 (N)", TXTFIELD_DWORD, 0, 124, NULL },
 		{ "max2 (N)", TXTFIELD_DWORD, 0, 128, NULL },
-		{ "prop3 (N)", TXTFIELD_NAMETODWORD, 0, 132, &gpDataTables.pPropertiesLinker },
+		{ "prop3 (N)", TXTFIELD_NAMETODWORD, 0, 132, &sgptDataTables->pPropertiesLinker },
 		{ "chance3 (N)", TXTFIELD_BYTE, 0, 300, NULL },
 		{ "par3 (N)", TXTFIELD_DWORD, 0, 136, NULL },
 		{ "min3 (N)", TXTFIELD_DWORD, 0, 140, NULL },
 		{ "max3 (N)", TXTFIELD_DWORD, 0, 144, NULL },
-		{ "prop4 (N)", TXTFIELD_NAMETODWORD, 0, 148, &gpDataTables.pPropertiesLinker },
+		{ "prop4 (N)", TXTFIELD_NAMETODWORD, 0, 148, &sgptDataTables->pPropertiesLinker },
 		{ "chance4 (N)", TXTFIELD_BYTE, 0, 301, NULL },
 		{ "par4 (N)", TXTFIELD_DWORD, 0, 152, NULL },
 		{ "min4 (N)", TXTFIELD_DWORD, 0, 156, NULL },
 		{ "max4 (N)", TXTFIELD_DWORD, 0, 160, NULL },
-		{ "prop5 (N)", TXTFIELD_NAMETODWORD, 0, 164, &gpDataTables.pPropertiesLinker },
+		{ "prop5 (N)", TXTFIELD_NAMETODWORD, 0, 164, &sgptDataTables->pPropertiesLinker },
 		{ "chance5 (N)", TXTFIELD_BYTE, 0, 302, NULL },
 		{ "par5 (N)", TXTFIELD_DWORD, 0, 168, NULL },
 		{ "min5 (N)", TXTFIELD_DWORD, 0, 172, NULL },
 		{ "max5 (N)", TXTFIELD_DWORD, 0, 176, NULL },
-		{ "prop6 (N)", TXTFIELD_NAMETODWORD, 0, 180, &gpDataTables.pPropertiesLinker },
+		{ "prop6 (N)", TXTFIELD_NAMETODWORD, 0, 180, &sgptDataTables->pPropertiesLinker },
 		{ "chance6 (N)", TXTFIELD_BYTE, 0, 303, NULL },
 		{ "par6 (N)", TXTFIELD_DWORD, 0, 184, NULL },
 		{ "min6 (N)", TXTFIELD_DWORD, 0, 188, NULL },
 		{ "max6 (N)", TXTFIELD_DWORD, 0, 192, NULL },
-		{ "prop1 (H)", TXTFIELD_NAMETODWORD, 0, 196, &gpDataTables.pPropertiesLinker },
+		{ "prop1 (H)", TXTFIELD_NAMETODWORD, 0, 196, &sgptDataTables->pPropertiesLinker },
 		{ "chance1 (H)", TXTFIELD_BYTE, 0, 304, NULL },
 		{ "par1 (H)", TXTFIELD_DWORD, 0, 200, NULL },
 		{ "min1 (H)", TXTFIELD_DWORD, 0, 204, NULL },
 		{ "max1 (H)", TXTFIELD_DWORD, 0, 208, NULL },
-		{ "prop2 (H)", TXTFIELD_NAMETODWORD, 0, 212, &gpDataTables.pPropertiesLinker },
+		{ "prop2 (H)", TXTFIELD_NAMETODWORD, 0, 212, &sgptDataTables->pPropertiesLinker },
 		{ "chance2 (H)", TXTFIELD_BYTE, 0, 305, NULL },
 		{ "par2 (H)", TXTFIELD_DWORD, 0, 216, NULL },
 		{ "min2 (H)", TXTFIELD_DWORD, 0, 220, NULL },
 		{ "max2 (H)", TXTFIELD_DWORD, 0, 224, NULL },
-		{ "prop3 (H)", TXTFIELD_NAMETODWORD, 0, 228, &gpDataTables.pPropertiesLinker },
+		{ "prop3 (H)", TXTFIELD_NAMETODWORD, 0, 228, &sgptDataTables->pPropertiesLinker },
 		{ "chance3 (H)", TXTFIELD_BYTE, 0, 306, NULL },
 		{ "par3 (H)", TXTFIELD_DWORD, 0, 232, NULL },
 		{ "min3 (H)", TXTFIELD_DWORD, 0, 236, NULL },
 		{ "max3 (H)", TXTFIELD_DWORD, 0, 240, NULL },
-		{ "prop4 (H)", TXTFIELD_NAMETODWORD, 0, 244, &gpDataTables.pPropertiesLinker },
+		{ "prop4 (H)", TXTFIELD_NAMETODWORD, 0, 244, &sgptDataTables->pPropertiesLinker },
 		{ "chance4 (H)", TXTFIELD_BYTE, 0, 307, NULL },
 		{ "par4 (H)", TXTFIELD_DWORD, 0, 248, NULL },
 		{ "min4 (H)", TXTFIELD_DWORD, 0, 252, NULL },
 		{ "max4 (H)", TXTFIELD_DWORD, 0, 256, NULL },
-		{ "prop5 (H)", TXTFIELD_NAMETODWORD, 0, 260, &gpDataTables.pPropertiesLinker },
+		{ "prop5 (H)", TXTFIELD_NAMETODWORD, 0, 260, &sgptDataTables->pPropertiesLinker },
 		{ "chance5 (H)", TXTFIELD_BYTE, 0, 308, NULL },
 		{ "par5 (H)", TXTFIELD_DWORD, 0, 264, NULL },
 		{ "min5 (H)", TXTFIELD_DWORD, 0, 268, NULL },
 		{ "max5 (H)", TXTFIELD_DWORD, 0, 272, NULL },
-		{ "prop6 (H)", TXTFIELD_NAMETODWORD, 0, 276, &gpDataTables.pPropertiesLinker },
+		{ "prop6 (H)", TXTFIELD_NAMETODWORD, 0, 276, &sgptDataTables->pPropertiesLinker },
 		{ "chance6 (H)", TXTFIELD_BYTE, 0, 309, NULL },
 		{ "par6 (H)", TXTFIELD_DWORD, 0, 280, NULL },
 		{ "min6 (H)", TXTFIELD_DWORD, 0, 284, NULL },
@@ -2450,8 +2450,8 @@ void __fastcall DATATBLS_LoadMonPropTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonPropLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pMonPropTxt = (D2MonPropTxt*)DATATBLS_CompileTxt(pMemPool, "monprop", pTbl, &gpDataTables.nMonPropTxtRecordCount, sizeof(D2MonPropTxt));
+	sgptDataTables->pMonPropLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pMonPropTxt = (D2MonPropTxt*)DATATBLS_CompileTxt(pMemPool, "monprop", pTbl, &sgptDataTables->nMonPropTxtRecordCount, sizeof(D2MonPropTxt));
 }
 
 //D2Common.0x6FD6E8E0
@@ -2492,7 +2492,7 @@ void __fastcall DATATBLS_LoadMonLvlTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonLvlTxt = (D2MonLvlTxt*)DATATBLS_CompileTxt(pMemPool, "monlvl", pTbl, &gpDataTables.nMonLvlTxtRecordCount, sizeof(D2MonLvlTxt));
+	sgptDataTables->pMonLvlTxt = (D2MonLvlTxt*)DATATBLS_CompileTxt(pMemPool, "monlvl", pTbl, &sgptDataTables->nMonLvlTxtRecordCount, sizeof(D2MonLvlTxt));
 }
 
 //D2Common.0x6FD6EDE0
@@ -2507,13 +2507,13 @@ void __fastcall DATATBLS_MonPresetPlaceLinker(char* pSrc, void* pRecord, int nOf
 
 		if (pSrc && *pSrc)
 		{
-			nRow = FOG_GetRowFromTxt(gpDataTables.pSuperUniquesLinker, pSrc, 0);
+			nRow = FOG_GetRowFromTxt(sgptDataTables->pSuperUniquesLinker, pSrc, 0);
 			if (nRow < 0)
 			{
-				nRow = FOG_GetRowFromTxt(gpDataTables.pMonStatsLinker, pSrc, 0);
+				nRow = FOG_GetRowFromTxt(sgptDataTables->pMonStatsLinker, pSrc, 0);
 				if (nRow < 0)
 				{
-					nRow = FOG_GetRowFromTxt(gpDataTables.pMonPlaceLinker, pSrc, 1);
+					nRow = FOG_GetRowFromTxt(sgptDataTables->pMonPlaceLinker, pSrc, 1);
 					if (nRow >= 0)
 					{
 						*((BYTE*)pRecord + 1) = 0;
@@ -2552,23 +2552,23 @@ void __fastcall DATATBLS_LoadMonPresetTxt(void* pMemPool)
 
 	pMonPresetTxt = (D2MonPresetTxt*)DATATBLS_CompileTxt(pMemPool, "monpreset", pTbl, &nRecordCount, sizeof(D2MonPresetTxt));
 
-	gpDataTables.pMonPresetTxt = pMonPresetTxt;
-	gpDataTables.pMonPresetTxtActSections[0] = pMonPresetTxt;
+	sgptDataTables->pMonPresetTxt = pMonPresetTxt;
+	sgptDataTables->pMonPresetTxtActSections[0] = pMonPresetTxt;
 
 	for (int i = 0; i < nRecordCount; ++i)
 	{
 		for (int j = nAct + 1; j < pMonPresetTxt[i].nAct; ++j)
 		{
-			gpDataTables.nMonPresetTxtActRecordCounts[nAct] = nActRecords;
+			sgptDataTables->nMonPresetTxtActRecordCounts[nAct] = nActRecords;
 			++nAct;
 			nActRecords = 0;
-			gpDataTables.pMonPresetTxtActSections[nAct] = &pMonPresetTxt[i];
+			sgptDataTables->pMonPresetTxtActSections[nAct] = &pMonPresetTxt[i];
 		}
 
 		++nActRecords;
 	}
 
-	gpDataTables.nMonPresetTxtActRecordCounts[nAct] = nActRecords;
+	sgptDataTables->nMonPresetTxtActRecordCounts[nAct] = nActRecords;
 }
 
 //D2Common.0x6FD6EF30 (#11256)
@@ -2576,10 +2576,10 @@ D2MonPresetTxt* __stdcall DATATBLS_GetMonPresetTxtActSection(int nAct, int* pRec
 {
 	if (pRecordCount)
 	{
-		if (nAct >= 0 && nAct < 5 && gpDataTables.pMonPresetTxt)
+		if (nAct >= 0 && nAct < 5 && sgptDataTables->pMonPresetTxt)
 		{
-			*pRecordCount = gpDataTables.nMonPresetTxtActRecordCounts[nAct];
-			return gpDataTables.pMonPresetTxtActSections[nAct];
+			*pRecordCount = sgptDataTables->nMonPresetTxtActRecordCounts[nAct];
+			return sgptDataTables->pMonPresetTxtActSections[nAct];
 		}
 		
 		*pRecordCount = 0;
@@ -2594,10 +2594,10 @@ int __stdcall DATATBLS_MapSuperUniqueId(int nType, int nSuperUnique)
 	switch (nType)
 	{
 	case 0:
-		return nSuperUnique + gpDataTables.nSuperUniquesTxtRecordCount + gpDataTables.nMonStatsTxtRecordCount;
+		return nSuperUnique + sgptDataTables->nSuperUniquesTxtRecordCount + sgptDataTables->nMonStatsTxtRecordCount;
 
 	case 2:
-		return nSuperUnique + gpDataTables.nMonStatsTxtRecordCount;
+		return nSuperUnique + sgptDataTables->nMonStatsTxtRecordCount;
 
 	default:
 		return nSuperUnique;
@@ -2610,27 +2610,27 @@ void __fastcall DATATBLS_LoadSoundsTxt(void* pMemPool)
 {
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "Sound", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pSoundsLinker },
+		{ "Sound", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pSoundsLinker },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	if (gpDataTables.bCompileTxt)
+	if (sgptDataTables->bCompileTxt)
 	{
-		gpDataTables.pSoundsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		gpDataTables.pSoundsTxtCodes = (D2SoundsTxtStub*)DATATBLS_CompileTxt(pMemPool, "sounds", pTbl, &gpDataTables.nSoundsTxtCodes, sizeof(D2SoundsTxtStub));
+		sgptDataTables->pSoundsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+		sgptDataTables->pSoundsTxtCodes = (D2SoundsTxtStub*)DATATBLS_CompileTxt(pMemPool, "sounds", pTbl, &sgptDataTables->nSoundsTxtCodes, sizeof(D2SoundsTxtStub));
 	}
 }
 
 //D2Common.0x6FD6F020
 void __fastcall DATATBLS_UnloadSoundsTxt()
 {
-	if (gpDataTables.pSoundsTxtCodes)
+	if (sgptDataTables->pSoundsTxtCodes)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pSoundsTxtCodes);
-		gpDataTables.pSoundsTxtCodes = NULL;
-		FOG_FreeLinker(gpDataTables.pSoundsLinker);
-		gpDataTables.pSoundsLinker = NULL;
-		gpDataTables.nSoundsTxtCodes = 0;
+		DATATBLS_UnloadBin(sgptDataTables->pSoundsTxtCodes);
+		sgptDataTables->pSoundsTxtCodes = NULL;
+		FOG_FreeLinker(sgptDataTables->pSoundsLinker);
+		sgptDataTables->pSoundsLinker = NULL;
+		sgptDataTables->nSoundsTxtCodes = 0;
 	}
 }
 
@@ -2641,33 +2641,33 @@ void __fastcall DATATBLS_LoadMonSeqTxt(void* pMemPool)
 
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "sequence", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pMonSeqLinker },
-		{ "mode", TXTFIELD_CODETOBYTE, 0, 2, &gpDataTables.pMonModeLinker },
+		{ "sequence", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pMonSeqLinker },
+		{ "mode", TXTFIELD_CODETOBYTE, 0, 2, &sgptDataTables->pMonModeLinker },
 		{ "frame", TXTFIELD_BYTE, 0, 3, NULL },
 		{ "dir", TXTFIELD_BYTE, 0, 4, NULL },
 		{ "event", TXTFIELD_BYTE, 0, 5, NULL },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonSeqLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pMonSeqTxt = (D2MonSeqTxt*)DATATBLS_CompileTxt(pMemPool, "monseq", pTbl, &gpDataTables.nMonSeqTxtRecordCount, sizeof(D2MonSeqTxt));
+	sgptDataTables->pMonSeqLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pMonSeqTxt = (D2MonSeqTxt*)DATATBLS_CompileTxt(pMemPool, "monseq", pTbl, &sgptDataTables->nMonSeqTxtRecordCount, sizeof(D2MonSeqTxt));
 
-	if (gpDataTables.nMonSeqTxtRecordCount > 0)
+	if (sgptDataTables->nMonSeqTxtRecordCount > 0)
 	{
-		gpDataTables.nMonSeqTableRecordCount = gpDataTables.pMonSeqTxt[gpDataTables.nMonSeqTxtRecordCount - 1].wSequence + 1;
-		gpDataTables.pMonSeqTable = (D2SeqRecordStrc*)FOG_AllocServerMemory(NULL, sizeof(D2SeqRecordStrc) * gpDataTables.nMonSeqTableRecordCount, __FILE__, __LINE__, 0);
-		memset(gpDataTables.pMonSeqTable, 0x00, sizeof(D2SeqRecordStrc) * gpDataTables.nMonSeqTableRecordCount);
+		sgptDataTables->nMonSeqTableRecordCount = sgptDataTables->pMonSeqTxt[sgptDataTables->nMonSeqTxtRecordCount - 1].wSequence + 1;
+		sgptDataTables->pMonSeqTable = (D2SeqRecordStrc*)FOG_AllocServerMemory(NULL, sizeof(D2SeqRecordStrc) * sgptDataTables->nMonSeqTableRecordCount, __FILE__, __LINE__, 0);
+		memset(sgptDataTables->pMonSeqTable, 0x00, sizeof(D2SeqRecordStrc) * sgptDataTables->nMonSeqTableRecordCount);
 
-		for (int i = 0; i < gpDataTables.nMonSeqTxtRecordCount; ++i)
+		for (int i = 0; i < sgptDataTables->nMonSeqTxtRecordCount; ++i)
 		{
-			nSequence = gpDataTables.pMonSeqTxt[i].wSequence;
-			if (!gpDataTables.pMonSeqTable[nSequence].pMonSeqTxtRecord)
+			nSequence = sgptDataTables->pMonSeqTxt[i].wSequence;
+			if (!sgptDataTables->pMonSeqTable[nSequence].pMonSeqTxtRecord)
 			{
-				gpDataTables.pMonSeqTable[nSequence].pMonSeqTxtRecord = &gpDataTables.pMonSeqTxt[i];
+				sgptDataTables->pMonSeqTable[nSequence].pMonSeqTxtRecord = &sgptDataTables->pMonSeqTxt[i];
 			}
 
-			++gpDataTables.pMonSeqTable[nSequence].unk0x04;
-			++gpDataTables.pMonSeqTable[nSequence].unk0x08;
+			++sgptDataTables->pMonSeqTable[nSequence].unk0x04;
+			++sgptDataTables->pMonSeqTable[nSequence].unk0x08;
 		}
 	}
 }
@@ -2675,9 +2675,9 @@ void __fastcall DATATBLS_LoadMonSeqTxt(void* pMemPool)
 //D2Common.0x6FD6F200 (#11262)
 D2SeqRecordStrc* __stdcall DATATBLS_GetMonSeqTableRecord(int nSequence)
 {
-	if (nSequence >= 0 && nSequence < gpDataTables.nMonSeqTableRecordCount)
+	if (nSequence >= 0 && nSequence < sgptDataTables->nMonSeqTableRecordCount)
 	{
-		return &gpDataTables.pMonSeqTable[nSequence];
+		return &sgptDataTables->pMonSeqTable[nSequence];
 	}
 
 	return NULL;
@@ -2691,36 +2691,36 @@ void __fastcall DATATBLS_LoadMonEquipTxt(void* pMemPool)
 
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "monster", TXTFIELD_NAMETOWORD, 0, 0, &gpDataTables.pMonStatsLinker },
+		{ "monster", TXTFIELD_NAMETOWORD, 0, 0, &sgptDataTables->pMonStatsLinker },
 		{ "level", TXTFIELD_WORD, 0, 2, NULL },
 		{ "oninit", TXTFIELD_BYTE, 0, 4, NULL },
-		{ "item1", TXTFIELD_RAW, 0, 8, &gpDataTables.pItemsLinker },
-		{ "loc1", TXTFIELD_CODETOBYTE, 0, 20, &gpDataTables.pBodyLocsLinker },
+		{ "item1", TXTFIELD_RAW, 0, 8, &sgptDataTables->pItemsLinker },
+		{ "loc1", TXTFIELD_CODETOBYTE, 0, 20, &sgptDataTables->pBodyLocsLinker },
 		{ "mod1", TXTFIELD_BYTE, 0, 23, NULL },
-		{ "item2", TXTFIELD_RAW, 0, 12, &gpDataTables.pItemsLinker },
-		{ "loc2", TXTFIELD_CODETOBYTE, 0, 21, &gpDataTables.pBodyLocsLinker },
+		{ "item2", TXTFIELD_RAW, 0, 12, &sgptDataTables->pItemsLinker },
+		{ "loc2", TXTFIELD_CODETOBYTE, 0, 21, &sgptDataTables->pBodyLocsLinker },
 		{ "mod2", TXTFIELD_BYTE, 0, 24, NULL },
-		{ "item3", TXTFIELD_RAW, 0, 16, &gpDataTables.pItemsLinker },
-		{ "loc3", TXTFIELD_CODETOBYTE, 0, 22, &gpDataTables.pBodyLocsLinker },
+		{ "item3", TXTFIELD_RAW, 0, 16, &sgptDataTables->pItemsLinker },
+		{ "loc3", TXTFIELD_CODETOBYTE, 0, 22, &sgptDataTables->pBodyLocsLinker },
 		{ "mod3", TXTFIELD_BYTE, 0, 25, NULL },
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonEquipTxt = (D2MonEquipTxt*)DATATBLS_CompileTxt(pMemPool, "monequip", pTbl, &gpDataTables.nMonEquipTxtRecordCount, sizeof(D2MonEquipTxt));
+	sgptDataTables->pMonEquipTxt = (D2MonEquipTxt*)DATATBLS_CompileTxt(pMemPool, "monequip", pTbl, &sgptDataTables->nMonEquipTxtRecordCount, sizeof(D2MonEquipTxt));
 
-	if (gpDataTables.nMonEquipTxtRecordCount >= 32767)
+	if (sgptDataTables->nMonEquipTxtRecordCount >= 32767)
 	{
 		FOG_10025("Monequip.txt exceeded maximum number of allowable rows", __FILE__, __LINE__);
 	}
 
-	for (int i = 0; i < gpDataTables.nMonStatsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nMonStatsTxtRecordCount; ++i)
 	{
-		gpDataTables.pMonStatsTxt[i].nMonEquipTxtRecordId = -1;
+		sgptDataTables->pMonStatsTxt[i].nMonEquipTxtRecordId = -1;
 	}
 
-	for (int i = 0; i < gpDataTables.nMonEquipTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nMonEquipTxtRecordCount; ++i)
 	{
-		pMonEquipTxtRecord = &gpDataTables.pMonEquipTxt[i];
+		pMonEquipTxtRecord = &sgptDataTables->pMonEquipTxt[i];
 		pMonStatsTxtRecord = DATATBLS_GetMonStatsTxtRecord(pMonEquipTxtRecord->nMonster);
 		if (pMonStatsTxtRecord)
 		{
@@ -2732,7 +2732,7 @@ void __fastcall DATATBLS_LoadMonEquipTxt(void* pMemPool)
 			for (int j = 0; j < 3; ++j)
 			{
 				if (pMonEquipTxtRecord->nLoc[j] <= BODYLOC_NONE || pMonEquipTxtRecord->nLoc[j] >= BODYLOC_SWRARM
-					|| pMonEquipTxtRecord->dwItem[j] != '    ' && FOG_GetLinkIndex(gpDataTables.pItemsLinker, pMonEquipTxtRecord->dwItem[j], 1) < 0)
+					|| pMonEquipTxtRecord->dwItem[j] != '    ' && FOG_GetLinkIndex(sgptDataTables->pItemsLinker, pMonEquipTxtRecord->dwItem[j], 1) < 0)
 				{
 					pMonEquipTxtRecord->nLoc[j] = BODYLOC_NONE;
 				}
@@ -2758,19 +2758,19 @@ void __fastcall DATATBLS_LoadSomeMonsterTxts(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pUniqueTitleTxt = (D2UniqueTitleTxt*)DATATBLS_CompileTxt(pMemPool, "uniquetitle", pTbl, &gpDataTables.nUniqueTitleTxtRecordCount, sizeof(D2UniqueTitleTxt));
-	gpDataTables.pUniquePrefixTxt = (D2UniquePrefixTxt*)DATATBLS_CompileTxt(pMemPool, "uniqueprefix", pTbl, &gpDataTables.nUniquePrefixTxtRecordCount, sizeof(D2UniquePrefixTxt));
-	gpDataTables.pUniqueSuffixTxt = (D2UniqueSuffixTxt*)DATATBLS_CompileTxt(pMemPool, "uniquesuffix", pTbl, &gpDataTables.nUniqueSuffixTxtRecordCount, sizeof(D2UniqueSuffixTxt));
-	gpDataTables.pUniqueAppellationTxt = (D2UniqueAppellationTxt*)DATATBLS_CompileTxt(pMemPool, "uniqueappellation", pTbl, &gpDataTables.nUniqueAppellationTxtRecordCount, sizeof(D2UniqueAppellationTxt));
+	sgptDataTables->pUniqueTitleTxt = (D2UniqueTitleTxt*)DATATBLS_CompileTxt(pMemPool, "uniquetitle", pTbl, &sgptDataTables->nUniqueTitleTxtRecordCount, sizeof(D2UniqueTitleTxt));
+	sgptDataTables->pUniquePrefixTxt = (D2UniquePrefixTxt*)DATATBLS_CompileTxt(pMemPool, "uniqueprefix", pTbl, &sgptDataTables->nUniquePrefixTxtRecordCount, sizeof(D2UniquePrefixTxt));
+	sgptDataTables->pUniqueSuffixTxt = (D2UniqueSuffixTxt*)DATATBLS_CompileTxt(pMemPool, "uniquesuffix", pTbl, &sgptDataTables->nUniqueSuffixTxtRecordCount, sizeof(D2UniqueSuffixTxt));
+	sgptDataTables->pUniqueAppellationTxt = (D2UniqueAppellationTxt*)DATATBLS_CompileTxt(pMemPool, "uniqueappellation", pTbl, &sgptDataTables->nUniqueAppellationTxtRecordCount, sizeof(D2UniqueAppellationTxt));
 
 	DATATBLS_LoadMonLvlTxt(pMemPool);
 
-	gpDataTables.pTreasureClassExLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pTreasureClassExLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
 
 	DATATBLS_CreateItemTypeTreasureClasses();
 	DATATBLS_LoadTreasureClassExTxt(pMemPool);
 
-	ppTCEx = gpDataTables.pChestTreasureClasses;
+	ppTCEx = sgptDataTables->pChestTreasureClasses;
 	for (int i = 0; i < 3; ++i)
 	{
 		for (int j = 0; j < 5; ++j)
@@ -2779,10 +2779,10 @@ void __fastcall DATATBLS_LoadSomeMonsterTxts(void* pMemPool)
 			{
 				wsprintfA(szChest, "Act %d%s Chest %s", j + 1, szDifficulties[i], szTreasureClassVariants[k]);
 
-				nTxtRow = FOG_GetRowFromTxt(gpDataTables.pTreasureClassExLinker, szChest, 0);
+				nTxtRow = FOG_GetRowFromTxt(sgptDataTables->pTreasureClassExLinker, szChest, 0);
 				if (nTxtRow >= 0)
 				{
-					*ppTCEx = &gpDataTables.pTreasureClassEx[nTxtRow];
+					*ppTCEx = &sgptDataTables->pTreasureClassEx[nTxtRow];
 				}
 				else
 				{
@@ -2794,7 +2794,7 @@ void __fastcall DATATBLS_LoadSomeMonsterTxts(void* pMemPool)
 		}
 	}
 
-	D2_ASSERT(gpDataTables.nTreasureClassEx < USHRT_MAX);
+	D2_ASSERT(sgptDataTables->nTreasureClassEx < USHRT_MAX);
 
 	DATATBLS_LoadMonStats2Txt(pMemPool);
 	DATATBLS_LoadMonPropTxt(pMemPool);
@@ -2823,41 +2823,41 @@ void __fastcall DATATBLS_CreateItemTypeTreasureClasses()
 	char v37[8] = {};
 	char dest[32] = {};
 
-	FOG_10216_AddRecordToLinkingTable(gpDataTables.pTreasureClassExLinker, &gpDataTables.szDefaultString);
+	FOG_10216_AddRecordToLinkingTable(sgptDataTables->pTreasureClassExLinker, &sgptDataTables->szDefaultString);
 
-	if (!(gpDataTables.nTreasureClassEx % 16))
+	if (!(sgptDataTables->nTreasureClassEx % 16))
 	{
-		gpDataTables.pTreasureClassEx = (D2TCExShortStrc*)FOG_ReallocServerMemory(NULL, gpDataTables.pTreasureClassEx, sizeof(D2TCExShortStrc) * (gpDataTables.nTreasureClassEx + 16), __FILE__, __LINE__, 0);
+		sgptDataTables->pTreasureClassEx = (D2TCExShortStrc*)FOG_ReallocServerMemory(NULL, sgptDataTables->pTreasureClassEx, sizeof(D2TCExShortStrc) * (sgptDataTables->nTreasureClassEx + 16), __FILE__, __LINE__, 0);
 	}
-	memset(&gpDataTables.pTreasureClassEx[gpDataTables.nTreasureClassEx], 0x00, sizeof(gpDataTables.pTreasureClassEx[gpDataTables.nTreasureClassEx]));
-	++gpDataTables.nTreasureClassEx;
+	memset(&sgptDataTables->pTreasureClassEx[sgptDataTables->nTreasureClassEx], 0x00, sizeof(sgptDataTables->pTreasureClassEx[sgptDataTables->nTreasureClassEx]));
+	++sgptDataTables->nTreasureClassEx;
 
-	for (int i = 0; i < gpDataTables.nItemTypesTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nItemTypesTxtRecordCount; ++i)
 	{
-		if (!&gpDataTables.pItemTypesTxt[i])
+		if (!&sgptDataTables->pItemTypesTxt[i])
 		{
 			break;
 		}
 
-		if (gpDataTables.pItemTypesTxt[i].nTreasureClass)
+		if (sgptDataTables->pItemTypesTxt[i].nTreasureClass)
 		{
-			++gpDataTables.nTreasureClassItemTypes;
+			++sgptDataTables->nTreasureClassItemTypes;
 
 			nLevel = 3;
 			do
 			{
-				if (FOG_GetStringFromLinkIndex(gpDataTables.pItemTypesLinker, i, v37))
+				if (FOG_GetStringFromLinkIndex(sgptDataTables->pItemTypesLinker, i, v37))
 				{
 					wsprintfA(dest, "%s%d", v37, nLevel);
-					FOG_10216_AddRecordToLinkingTable(gpDataTables.pTreasureClassExLinker, dest);
+					FOG_10216_AddRecordToLinkingTable(sgptDataTables->pTreasureClassExLinker, dest);
 
-					if (!(gpDataTables.nTreasureClassEx % 16))
+					if (!(sgptDataTables->nTreasureClassEx % 16))
 					{
-						gpDataTables.pTreasureClassEx = (D2TCExShortStrc*)FOG_ReallocServerMemory(NULL, gpDataTables.pTreasureClassEx, sizeof(D2TCExShortStrc) * (gpDataTables.nTreasureClassEx + 16), __FILE__, __LINE__, 0);
+						sgptDataTables->pTreasureClassEx = (D2TCExShortStrc*)FOG_ReallocServerMemory(NULL, sgptDataTables->pTreasureClassEx, sizeof(D2TCExShortStrc) * (sgptDataTables->nTreasureClassEx + 16), __FILE__, __LINE__, 0);
 					}
-					memset(&gpDataTables.pTreasureClassEx[gpDataTables.nTreasureClassEx], 0x00, sizeof(gpDataTables.pTreasureClassEx[gpDataTables.nTreasureClassEx]));
+					memset(&sgptDataTables->pTreasureClassEx[sgptDataTables->nTreasureClassEx], 0x00, sizeof(sgptDataTables->pTreasureClassEx[sgptDataTables->nTreasureClassEx]));
 
-					pTCExTxtRecord = &gpDataTables.pTreasureClassEx[gpDataTables.nTreasureClassEx++];
+					pTCExTxtRecord = &sgptDataTables->pTreasureClassEx[sgptDataTables->nTreasureClassEx++];
 
 					if (pTCExTxtRecord)
 					{
@@ -2865,7 +2865,7 @@ void __fastcall DATATBLS_CreateItemTypeTreasureClasses()
 						pTCExTxtRecord->nGroup = 0;
 						pTCExTxtRecord->nLevel = nLevel - 3;
 
-						for (int j = 0; j < gpDataTables.pItemDataTables.nItemsTxtRecordCount; ++j)
+						for (int j = 0; j < sgptDataTables->pItemDataTables.nItemsTxtRecordCount; ++j)
 						{
 							pItemsTxtRecord = DATATBLS_GetItemsTxtRecord(j);
 							if (pItemsTxtRecord && !pItemsTxtRecord->nQuest && pItemsTxtRecord->nSpawnable && ITEMS_CheckItemTypeIdByItemId(j, i) && (i == ITEMTYPE_MISSILE_POTION || !ITEMS_CheckItemTypeIdByItemId(j, ITEMTYPE_MISSILE_POTION)))
@@ -2873,9 +2873,9 @@ void __fastcall DATATBLS_CreateItemTypeTreasureClasses()
 								if (pItemsTxtRecord->nLevel > nLevel - 3 && pItemsTxtRecord->nLevel <= nLevel)
 								{
 									nItemType = pItemsTxtRecord->wType[0];
-									if (nItemType >= 0 && nItemType < gpDataTables.nItemTypesTxtRecordCount)
+									if (nItemType >= 0 && nItemType < sgptDataTables->nItemTypesTxtRecordCount)
 									{
-										pItemTypesTxtRecord = &gpDataTables.pItemTypesTxt[nItemType];
+										pItemTypesTxtRecord = &sgptDataTables->pItemTypesTxt[nItemType];
 										if (pItemTypesTxtRecord)
 										{
 											nProbability = pItemTypesTxtRecord->nRarity;
@@ -2914,147 +2914,147 @@ void __fastcall DATATBLS_CreateItemTypeTreasureClasses()
 //D2Common.0x6FD6FBB0
 void __fastcall DATATBLS_UnloadSomeMonsterTxts()
 {
-	if (gpDataTables.pMonEquipTxt)
+	if (sgptDataTables->pMonEquipTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pMonEquipTxt);
-		gpDataTables.nMonEquipTxtRecordCount = 0;
+		DATATBLS_UnloadBin(sgptDataTables->pMonEquipTxt);
+		sgptDataTables->nMonEquipTxtRecordCount = 0;
 	}
 
-	DATATBLS_UnloadBin(gpDataTables.pNpcTxt);
+	DATATBLS_UnloadBin(sgptDataTables->pNpcTxt);
 
-	DATATBLS_UnloadBin(gpDataTables.pHirelingTxt);
-	gpDataTables.nHirelingTxtRecordCount = 0;
+	DATATBLS_UnloadBin(sgptDataTables->pHirelingTxt);
+	sgptDataTables->nHirelingTxtRecordCount = 0;
 	for (int i = 0; i < 256; ++i)
 	{
-		gpDataTables.nClassicHirelingStartRecordIds[i] = -1;
-		gpDataTables.nExpansionHirelingStartRecordIds[i] = -1;
+		sgptDataTables->nClassicHirelingStartRecordIds[i] = -1;
+		sgptDataTables->nExpansionHirelingStartRecordIds[i] = -1;
 	}
 
-	if (gpDataTables.pMonPresetTxt)
+	if (sgptDataTables->pMonPresetTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pMonPresetTxt);
+		DATATBLS_UnloadBin(sgptDataTables->pMonPresetTxt);
 	}
 	for (int i = 0; i < 5; ++i)
 	{
-		gpDataTables.pMonPresetTxtActSections[i] = NULL;
-		gpDataTables.nMonPresetTxtActRecordCounts[i] = 0;
+		sgptDataTables->pMonPresetTxtActSections[i] = NULL;
+		sgptDataTables->nMonPresetTxtActRecordCounts[i] = 0;
 	}
 
-	if (gpDataTables.pSuperUniquesLinker)
+	if (sgptDataTables->pSuperUniquesLinker)
 	{
-		FOG_FreeLinker(gpDataTables.pSuperUniquesLinker);
+		FOG_FreeLinker(sgptDataTables->pSuperUniquesLinker);
 	}
-	if (gpDataTables.pSuperUniquesTxt)
+	if (sgptDataTables->pSuperUniquesTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pSuperUniquesTxt);
-		gpDataTables.pSuperUniquesTxt = NULL;
+		DATATBLS_UnloadBin(sgptDataTables->pSuperUniquesTxt);
+		sgptDataTables->pSuperUniquesTxt = NULL;
 	}
-	gpDataTables.nSuperUniquesTxtRecordCount = 0;
+	sgptDataTables->nSuperUniquesTxtRecordCount = 0;
 
-	if (gpDataTables.pMonUModLinker)
+	if (sgptDataTables->pMonUModLinker)
 	{
-		FOG_FreeLinker(gpDataTables.pMonUModLinker);
-		gpDataTables.pMonUModLinker = NULL;
+		FOG_FreeLinker(sgptDataTables->pMonUModLinker);
+		sgptDataTables->pMonUModLinker = NULL;
 	}
-	if (gpDataTables.pMonUModTxt)
+	if (sgptDataTables->pMonUModTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pMonUModTxt);
-		gpDataTables.pMonUModTxt = NULL;
+		DATATBLS_UnloadBin(sgptDataTables->pMonUModTxt);
+		sgptDataTables->pMonUModTxt = NULL;
 	}
-	gpDataTables.nMonUModTxtRecordCount = 0;
+	sgptDataTables->nMonUModTxtRecordCount = 0;
 
-	if (gpDataTables.pMonStatsTxt)
+	if (sgptDataTables->pMonStatsTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pMonStatsTxt);
-		FOG_FreeLinker(gpDataTables.pMonStatsLinker);
+		DATATBLS_UnloadBin(sgptDataTables->pMonStatsTxt);
+		FOG_FreeLinker(sgptDataTables->pMonStatsLinker);
 	}
-	gpDataTables.pMonStatsTxt = NULL;
+	sgptDataTables->pMonStatsTxt = NULL;
 
-	if (gpDataTables.pMonStats2Txt)
+	if (sgptDataTables->pMonStats2Txt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pMonStats2Txt);
-		FOG_FreeLinker(gpDataTables.pMonStats2Linker);
-	}
-
-	if (gpDataTables.pMonPropTxt)
-	{
-		DATATBLS_UnloadBin(gpDataTables.pMonPropTxt);
-		FOG_FreeLinker(gpDataTables.pMonPropLinker);
-	}
-	gpDataTables.nMonPropTxtRecordCount = 0;
-
-	if (gpDataTables.pMonSoundsTxt)
-	{
-		DATATBLS_UnloadBin(gpDataTables.pMonSoundsTxt);
-		FOG_FreeLinker(gpDataTables.pMonSoundsLinker);
-		gpDataTables.nMonSoundsTxtRecordCount = 0;
+		DATATBLS_UnloadBin(sgptDataTables->pMonStats2Txt);
+		FOG_FreeLinker(sgptDataTables->pMonStats2Linker);
 	}
 
-	if (gpDataTables.pMonSeqTxt)
+	if (sgptDataTables->pMonPropTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pMonSeqTxt);
-		FOG_FreeLinker(gpDataTables.pMonSeqLinker);
-		gpDataTables.nMonSeqTxtRecordCount = 0;
+		DATATBLS_UnloadBin(sgptDataTables->pMonPropTxt);
+		FOG_FreeLinker(sgptDataTables->pMonPropLinker);
 	}
-	if (gpDataTables.pMonSeqTable)
+	sgptDataTables->nMonPropTxtRecordCount = 0;
+
+	if (sgptDataTables->pMonSoundsTxt)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pMonSeqTable, __FILE__, __LINE__, 0);
-		gpDataTables.nMonSeqTableRecordCount = 0;
+		DATATBLS_UnloadBin(sgptDataTables->pMonSoundsTxt);
+		FOG_FreeLinker(sgptDataTables->pMonSoundsLinker);
+		sgptDataTables->nMonSoundsTxtRecordCount = 0;
 	}
 
-	FOG_FreeLinker(gpDataTables.pTreasureClassExLinker);
-	for (int i = 0; i < gpDataTables.nTreasureClassEx; ++i)
+	if (sgptDataTables->pMonSeqTxt)
 	{
-		if (gpDataTables.pTreasureClassEx[i].pInfo)
+		DATATBLS_UnloadBin(sgptDataTables->pMonSeqTxt);
+		FOG_FreeLinker(sgptDataTables->pMonSeqLinker);
+		sgptDataTables->nMonSeqTxtRecordCount = 0;
+	}
+	if (sgptDataTables->pMonSeqTable)
+	{
+		FOG_FreeServerMemory(NULL, sgptDataTables->pMonSeqTable, __FILE__, __LINE__, 0);
+		sgptDataTables->nMonSeqTableRecordCount = 0;
+	}
+
+	FOG_FreeLinker(sgptDataTables->pTreasureClassExLinker);
+	for (int i = 0; i < sgptDataTables->nTreasureClassEx; ++i)
+	{
+		if (sgptDataTables->pTreasureClassEx[i].pInfo)
 		{
-			FOG_FreeServerMemory(NULL, gpDataTables.pTreasureClassEx[i].pInfo, __FILE__, __LINE__, 0);
+			FOG_FreeServerMemory(NULL, sgptDataTables->pTreasureClassEx[i].pInfo, __FILE__, __LINE__, 0);
 		}
 	}
-	FOG_FreeServerMemory(NULL, gpDataTables.pTreasureClassEx, __FILE__, __LINE__, 0);
-	gpDataTables.pTreasureClassEx = NULL;
-	gpDataTables.nTreasureClassEx = 0;
+	FOG_FreeServerMemory(NULL, sgptDataTables->pTreasureClassEx, __FILE__, __LINE__, 0);
+	sgptDataTables->pTreasureClassEx = NULL;
+	sgptDataTables->nTreasureClassEx = 0;
 
-	if (gpDataTables.pMonLvlTxt)
+	if (sgptDataTables->pMonLvlTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pMonLvlTxt);
-		gpDataTables.nMonLvlTxtRecordCount = 0;
+		DATATBLS_UnloadBin(sgptDataTables->pMonLvlTxt);
+		sgptDataTables->nMonLvlTxtRecordCount = 0;
 	}
 
-	if (gpDataTables.pUniqueTitleTxt)
+	if (sgptDataTables->pUniqueTitleTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pUniqueTitleTxt);
-		gpDataTables.pUniqueTitleTxt = NULL;
-		gpDataTables.nUniqueTitleTxtRecordCount = 0;
+		DATATBLS_UnloadBin(sgptDataTables->pUniqueTitleTxt);
+		sgptDataTables->pUniqueTitleTxt = NULL;
+		sgptDataTables->nUniqueTitleTxtRecordCount = 0;
 	}
 
-	if (gpDataTables.pUniquePrefixTxt)
+	if (sgptDataTables->pUniquePrefixTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pUniquePrefixTxt);
-		gpDataTables.pUniquePrefixTxt = NULL;
-		gpDataTables.nUniquePrefixTxtRecordCount = 0;
+		DATATBLS_UnloadBin(sgptDataTables->pUniquePrefixTxt);
+		sgptDataTables->pUniquePrefixTxt = NULL;
+		sgptDataTables->nUniquePrefixTxtRecordCount = 0;
 	}
 
-	if (gpDataTables.pUniqueSuffixTxt)
+	if (sgptDataTables->pUniqueSuffixTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pUniqueSuffixTxt);
-		gpDataTables.pUniqueSuffixTxt = NULL;
-		gpDataTables.nUniqueSuffixTxtRecordCount = 0;
+		DATATBLS_UnloadBin(sgptDataTables->pUniqueSuffixTxt);
+		sgptDataTables->pUniqueSuffixTxt = NULL;
+		sgptDataTables->nUniqueSuffixTxtRecordCount = 0;
 	}
 
-	if (gpDataTables.pUniqueAppellationTxt)
+	if (sgptDataTables->pUniqueAppellationTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pUniqueAppellationTxt);
-		gpDataTables.pUniqueAppellationTxt = NULL;
-		gpDataTables.nUniqueAppellationTxtRecordCount = 0;
+		DATATBLS_UnloadBin(sgptDataTables->pUniqueAppellationTxt);
+		sgptDataTables->pUniqueAppellationTxt = NULL;
+		sgptDataTables->nUniqueAppellationTxtRecordCount = 0;
 	}
 }
 
 //Inlined at various places
 D2MonStatsTxt* __fastcall DATATBLS_GetMonStatsTxtRecord(int nMonsterId)
 {
-	if (nMonsterId >= 0 && nMonsterId < gpDataTables.nMonStatsTxtRecordCount)
+	if (nMonsterId >= 0 && nMonsterId < sgptDataTables->nMonStatsTxtRecordCount)
 	{
-		return &gpDataTables.pMonStatsTxt[nMonsterId];
+		return &sgptDataTables->pMonStatsTxt[nMonsterId];
 	}
 
 	return NULL;

--- a/source/D2Common/src/DataTbls/ObjectsTbls.cpp
+++ b/source/D2Common/src/DataTbls/ObjectsTbls.cpp
@@ -166,16 +166,16 @@ void __fastcall DATATBLS_LoadObjectsTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 	
-	gpDataTables.pObjectsTxt = (D2ObjectsTxt*)DATATBLS_CompileTxt(pMemPool, "objects", pTbl, &gpDataTables.nObjectsTxtRecordCount, sizeof(D2ObjectsTxt));
+	sgptDataTables->pObjectsTxt = (D2ObjectsTxt*)DATATBLS_CompileTxt(pMemPool, "objects", pTbl, &sgptDataTables->nObjectsTxtRecordCount, sizeof(D2ObjectsTxt));
 
-	for (int i = 0; i < gpDataTables.nObjectsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nObjectsTxtRecordCount; ++i)
 	{
-		memset(gpDataTables.pObjectsTxt[i].wszName, 0x00, sizeof(gpDataTables.pObjectsTxt[i].wszName));
-		wcsncpy_s(gpDataTables.pObjectsTxt[i].wszName, D2LANG_GetStringByReferenceString(gpDataTables.pObjectsTxt[i].szName), sizeof(gpDataTables.pObjectsTxt[i].szName));
+		memset(sgptDataTables->pObjectsTxt[i].wszName, 0x00, sizeof(sgptDataTables->pObjectsTxt[i].wszName));
+		wcsncpy_s(sgptDataTables->pObjectsTxt[i].wszName, D2LANG_GetStringByReferenceString(sgptDataTables->pObjectsTxt[i].szName), sizeof(sgptDataTables->pObjectsTxt[i].szName));
 
 		for (int j = 0; j < 8; ++j)
 		{
-			gpDataTables.pObjectsTxt[i].dwFrameCnt[j] <<= 8;
+			sgptDataTables->pObjectsTxt[i].dwFrameCnt[j] <<= 8;
 		}
 	}
 }
@@ -183,25 +183,25 @@ void __fastcall DATATBLS_LoadObjectsTxt(void* pMemPool)
 //D2Common.0x6FD718F0 (#10626)
 D2ObjectsTxt* __stdcall DATATBLS_GetObjectsTxtRecord(int nObjectId)
 {
-	D2_ASSERT(nObjectId < gpDataTables.nObjectsTxtRecordCount);
+	D2_ASSERT(nObjectId < sgptDataTables->nObjectsTxtRecordCount);
 	D2_ASSERT(nObjectId >= 0);
-	return &gpDataTables.pObjectsTxt[nObjectId];
+	return &sgptDataTables->pObjectsTxt[nObjectId];
 }
 
 //D2Common.0x6FD71960
 void __fastcall DATATBLS_UnloadObjectsTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pObjectsTxt);
-	gpDataTables.pObjectsTxt = NULL;
-	gpDataTables.nObjectsTxtRecordCount = 0;
+	DATATBLS_UnloadBin(sgptDataTables->pObjectsTxt);
+	sgptDataTables->pObjectsTxt = NULL;
+	sgptDataTables->nObjectsTxtRecordCount = 0;
 }
 
 //D2Common.0x6FD71980
 void __fastcall DATATBLS_UnloadObjGroupTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pObjGroupTxt);
-	gpDataTables.pObjGroupTxt = NULL;
-	gpDataTables.nObjGroupTxtRecordCount = 0;
+	DATATBLS_UnloadBin(sgptDataTables->pObjGroupTxt);
+	sgptDataTables->pObjGroupTxt = NULL;
+	sgptDataTables->nObjGroupTxtRecordCount = 0;
 }
 
 //D2Common.0x6FD719A0
@@ -238,15 +238,15 @@ void __fastcall DATATBLS_LoadObjGroupTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pObjGroupTxt = (D2ObjGroupTxt*)DATATBLS_CompileTxt(pMemPool, "objgroup", pTbl, &gpDataTables.nObjGroupTxtRecordCount, sizeof(D2ObjGroupTxt));
+	sgptDataTables->pObjGroupTxt = (D2ObjGroupTxt*)DATATBLS_CompileTxt(pMemPool, "objgroup", pTbl, &sgptDataTables->nObjGroupTxtRecordCount, sizeof(D2ObjGroupTxt));
 }
 
 //D2Common.0x6FD71E00 (#10627)
 D2ObjGroupTxt* __stdcall DATATBLS_GetObjGroupTxtRecord(int nId)
 {
-	if (nId < gpDataTables.nObjGroupTxtRecordCount)
+	if (nId < sgptDataTables->nObjGroupTxtRecordCount)
 	{
-		return &gpDataTables.pObjGroupTxt[nId];
+		return &sgptDataTables->pObjGroupTxt[nId];
 	}
 
 	return NULL;
@@ -270,27 +270,27 @@ void __fastcall DATATBLS_LoadShrinesTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pShrinesTxt = (D2ShrinesTxt*)DATATBLS_CompileTxt(pMemPool, "shrines", pTbl, &gpDataTables.nShrinesTxtRecordCount, sizeof(D2ShrinesTxt));
+	sgptDataTables->pShrinesTxt = (D2ShrinesTxt*)DATATBLS_CompileTxt(pMemPool, "shrines", pTbl, &sgptDataTables->nShrinesTxtRecordCount, sizeof(D2ShrinesTxt));
 }
 
 //D2Common.0x6FD72000 (#10624)
 D2ShrinesTxt* __stdcall DATATBLS_GetShrinesTxtRecord(int nShrineId)
 {
-	D2_ASSERT(nShrineId < gpDataTables.nShrinesTxtRecordCount);
+	D2_ASSERT(nShrineId < sgptDataTables->nShrinesTxtRecordCount);
 	D2_ASSERT(nShrineId >= 0);
-	return &gpDataTables.pShrinesTxt[nShrineId];
+	return &sgptDataTables->pShrinesTxt[nShrineId];
 }
 
 //D2Common.0x6FD72070 (#10625)
 int __stdcall DATATBLS_GetShrinesTxtRecordCount()
 {
-	return gpDataTables.nShrinesTxtRecordCount;
+	return sgptDataTables->nShrinesTxtRecordCount;
 }
 
 //D2Common.0x6FD72080
 void __fastcall DATATBLS_UnloadShrinesTxt()
 {
-	DATATBLS_UnloadBin(gpDataTables.pShrinesTxt);
-	gpDataTables.pShrinesTxt = NULL;
-	gpDataTables.nShrinesTxtRecordCount = 0;
+	DATATBLS_UnloadBin(sgptDataTables->pShrinesTxt);
+	sgptDataTables->pShrinesTxt = NULL;
+	sgptDataTables->nShrinesTxtRecordCount = 0;
 }

--- a/source/D2Common/src/DataTbls/OverlayTbls.cpp
+++ b/source/D2Common/src/DataTbls/OverlayTbls.cpp
@@ -6,7 +6,7 @@ void __fastcall DATATBLS_LoadOverlayTxt(void* pMemPool)
 {
 	D2BinFieldStrc pTbl[] =
 	{
-		{ "overlay", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pOverlayLinker },
+		{ "overlay", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pOverlayLinker },
 		{ "Filename", TXTFIELD_ASCII, 64, TXTFIELD_DWORD, NULL },
 		{ "version", TXTFIELD_WORD, 0, 66, NULL },
 		{ "Frames", TXTFIELD_DWORD, 0, 68, NULL },
@@ -34,18 +34,18 @@ void __fastcall DATATBLS_LoadOverlayTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pOverlayLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pOverlayLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
 
-	gpDataTables.pOverlayTxt = (D2OverlayTxt*)DATATBLS_CompileTxt(pMemPool, "overlay", pTbl, &gpDataTables.nOverlayTxtRecordCount, sizeof(D2OverlayTxt));
+	sgptDataTables->pOverlayTxt = (D2OverlayTxt*)DATATBLS_CompileTxt(pMemPool, "overlay", pTbl, &sgptDataTables->nOverlayTxtRecordCount, sizeof(D2OverlayTxt));
 }
 
 //D2Common.0x6FD72500
 void __fastcall DATATBLS_UnloadOverlayTxt()
 {
-	FOG_FreeLinker(gpDataTables.pOverlayLinker);
-	DATATBLS_UnloadBin(gpDataTables.pOverlayTxt);
-	gpDataTables.pOverlayTxt = NULL;
-	gpDataTables.nOverlayTxtRecordCount = 0;
+	FOG_FreeLinker(sgptDataTables->pOverlayLinker);
+	DATATBLS_UnloadBin(sgptDataTables->pOverlayTxt);
+	sgptDataTables->pOverlayTxt = NULL;
+	sgptDataTables->nOverlayTxtRecordCount = 0;
 }
 
 //D2Common.0x6FD72530 (#10674)
@@ -166,9 +166,9 @@ int __stdcall DATATBLS_GetDirFromOverlayTxt(int nOverlayId)
 //Inlined at various places
 D2OverlayTxt* __fastcall DATATBLS_GetOverlayTxtRecord(int nOverlay)
 {
-	if (nOverlay >= 0 && nOverlay < gpDataTables.nOverlayTxtRecordCount)
+	if (nOverlay >= 0 && nOverlay < sgptDataTables->nOverlayTxtRecordCount)
 	{
-		return &gpDataTables.pOverlayTxt[nOverlay];
+		return &sgptDataTables->pOverlayTxt[nOverlay];
 	}
 
 	return NULL;

--- a/source/D2Common/src/DataTbls/SkillsTbls.cpp
+++ b/source/D2Common/src/DataTbls/SkillsTbls.cpp
@@ -49,7 +49,7 @@ int __fastcall sub_6FD49980(int nValue)
 //TODO: Find a name
 int __fastcall sub_6FD49990(char* szText, int* a2, int a3, int nKeywordNumber)
 {
-	D2TxtLinkStrc* pLinker = gpDataTables.pSkillCalcLinker;
+	D2TxtLinkStrc* pLinker = sgptDataTables->pSkillCalcLinker;
 	char szCode[4] = {};
 	int nRow = 0;
 
@@ -59,9 +59,9 @@ int __fastcall sub_6FD49990(char* szText, int* a2, int a3, int nKeywordNumber)
 		{
 		case 3:
 		{
-			if (gpDataTables.pSkillsLinker)
+			if (sgptDataTables->pSkillsLinker)
 			{
-				nRow = FOG_GetRowFromTxt(gpDataTables.pSkillsLinker, szText, 0);
+				nRow = FOG_GetRowFromTxt(sgptDataTables->pSkillsLinker, szText, 0);
 				if (nRow >= 0)
 				{
 					*a2 = 1;
@@ -69,14 +69,14 @@ int __fastcall sub_6FD49990(char* szText, int* a2, int a3, int nKeywordNumber)
 				}
 			}
 
-			pLinker = gpDataTables.pSkillCalcLinker;
+			pLinker = sgptDataTables->pSkillCalcLinker;
 			break;
 		}
 		case 4:
 		{
-			if (gpDataTables.pMissilesLinker)
+			if (sgptDataTables->pMissilesLinker)
 			{
-				nRow = FOG_GetRowFromTxt(gpDataTables.pMissilesLinker, szText, 0);
+				nRow = FOG_GetRowFromTxt(sgptDataTables->pMissilesLinker, szText, 0);
 				if (nRow >= 0)
 				{
 					*a2 = 1;
@@ -84,14 +84,14 @@ int __fastcall sub_6FD49990(char* szText, int* a2, int a3, int nKeywordNumber)
 				}
 			}
 
-			pLinker = gpDataTables.pMissileCalcLinker;
+			pLinker = sgptDataTables->pMissileCalcLinker;
 			break;
 		}
 		case 5:
 		{
-			if (gpDataTables.pItemStatCostLinker)
+			if (sgptDataTables->pItemStatCostLinker)
 			{
-				nRow = FOG_GetRowFromTxt(gpDataTables.pItemStatCostLinker, szText, 0);
+				nRow = FOG_GetRowFromTxt(sgptDataTables->pItemStatCostLinker, szText, 0);
 				if (nRow >= 0)
 				{
 					*a2 = 1;
@@ -121,9 +121,9 @@ int __fastcall sub_6FD49990(char* szText, int* a2, int a3, int nKeywordNumber)
 		}
 		case 6:
 		{
-			if (gpDataTables.pSkillsLinker)
+			if (sgptDataTables->pSkillsLinker)
 			{
-				nRow = FOG_GetRowFromTxt(gpDataTables.pSkillsLinker, szText, 0);
+				nRow = FOG_GetRowFromTxt(sgptDataTables->pSkillsLinker, szText, 0);
 				if (nRow >= 0)
 				{
 					*a2 = 1;
@@ -131,7 +131,7 @@ int __fastcall sub_6FD49990(char* szText, int* a2, int a3, int nKeywordNumber)
 				}
 			}
 
-			pLinker = gpDataTables.pSkillCalcLinker;
+			pLinker = sgptDataTables->pSkillCalcLinker;
 			break;
 		}
 		default:
@@ -201,14 +201,14 @@ void __fastcall DATATBLS_SkillCalcLinker(char* pSrc, void* pRecord, int nOffset,
 			nBufferSize = FOG_10254(pSrc, pBuffer, sizeof(pBuffer), DATATBLS_MapSkillsTxtKeywordToNumber, sub_6FD49980, sub_6FD49990);
 			if (nBufferSize > 0)
 			{
-				nSize = gpDataTables.nSkillsCodeSize;
-				nSizeEx = gpDataTables.nSkillsCodeSizeEx;
-				pCode = gpDataTables.pSkillsCode;
+				nSize = sgptDataTables->nSkillsCodeSize;
+				nSizeEx = sgptDataTables->nSkillsCodeSizeEx;
+				pCode = sgptDataTables->pSkillsCode;
 
-				if (gpDataTables.nSkillsCodeSize + nBufferSize < gpDataTables.nSkillsCodeSizeEx)
+				if (sgptDataTables->nSkillsCodeSize + nBufferSize < sgptDataTables->nSkillsCodeSizeEx)
 				{
 					memcpy(&pCode[nSize], pBuffer, nBufferSize);
-					gpDataTables.nSkillsCodeSize += nBufferSize;
+					sgptDataTables->nSkillsCodeSize += nBufferSize;
 					*(int*)((char*)pRecord + nOffset) = nSize;
 				}
 				else
@@ -216,21 +216,21 @@ void __fastcall DATATBLS_SkillCalcLinker(char* pSrc, void* pRecord, int nOffset,
 					while (1)
 					{
 						nNewSize = nSizeEx + 1024;
-						gpDataTables.nSkillsCodeSizeEx = nNewSize;
+						sgptDataTables->nSkillsCodeSizeEx = nNewSize;
 						if (nNewSize >= 0x7FFFFFFF)
 						{
 							break;
 						}
 
 						pCode = (char*)FOG_ReallocServerMemory(NULL, pCode, nNewSize, __FILE__, __LINE__, 0);
-						nSize = gpDataTables.nSkillsCodeSize;
-						nSizeEx = gpDataTables.nSkillsCodeSizeEx;
-						gpDataTables.pSkillsCode = pCode;
+						nSize = sgptDataTables->nSkillsCodeSize;
+						nSizeEx = sgptDataTables->nSkillsCodeSizeEx;
+						sgptDataTables->pSkillsCode = pCode;
 
-						if (gpDataTables.nSkillsCodeSize + nBufferSize < gpDataTables.nSkillsCodeSizeEx)
+						if (sgptDataTables->nSkillsCodeSize + nBufferSize < sgptDataTables->nSkillsCodeSizeEx)
 						{
 							memcpy(&pCode[nSize], pBuffer, nBufferSize);
-							gpDataTables.nSkillsCodeSize += nBufferSize;
+							sgptDataTables->nSkillsCodeSize += nBufferSize;
 							*(int*)((char*)pRecord + nOffset) = nSize;
 							return;
 						}
@@ -267,14 +267,14 @@ void __fastcall DATATBLS_SkillDescCalcLinker(char* pSrc, void* pRecord, int nOff
 			nBufferSize = FOG_10254(pSrc, pBuffer, sizeof(pBuffer), DATATBLS_MapSkillsTxtKeywordToNumber, sub_6FD49980, sub_6FD49990);
 			if (nBufferSize > 0)
 			{
-				nSize = gpDataTables.nSkillDescCodeSize;
-				nSizeEx = gpDataTables.nSkillDescCodeSizeEx;
-				pCode = gpDataTables.pSkillDescCode;
+				nSize = sgptDataTables->nSkillDescCodeSize;
+				nSizeEx = sgptDataTables->nSkillDescCodeSizeEx;
+				pCode = sgptDataTables->pSkillDescCode;
 
-				if (gpDataTables.nSkillDescCodeSize + nBufferSize < gpDataTables.nSkillDescCodeSizeEx)
+				if (sgptDataTables->nSkillDescCodeSize + nBufferSize < sgptDataTables->nSkillDescCodeSizeEx)
 				{
 					memcpy(&pCode[nSize], pBuffer, nBufferSize);
-					gpDataTables.nSkillDescCodeSize += nBufferSize;
+					sgptDataTables->nSkillDescCodeSize += nBufferSize;
 					*(int*)((char*)pRecord + nOffset) = nSize;
 				}
 				else
@@ -282,21 +282,21 @@ void __fastcall DATATBLS_SkillDescCalcLinker(char* pSrc, void* pRecord, int nOff
 					while (1)
 					{
 						nNewSize = nSizeEx + 1024;
-						gpDataTables.nSkillDescCodeSizeEx = nNewSize;
+						sgptDataTables->nSkillDescCodeSizeEx = nNewSize;
 						if (nNewSize >= 0x7FFFFFFF)
 						{
 							break;
 						}
 
 						pCode = (char*)FOG_ReallocServerMemory(NULL, pCode, nNewSize, __FILE__, __LINE__, 0);
-						nSize = gpDataTables.nSkillDescCodeSize;
-						nSizeEx = gpDataTables.nSkillDescCodeSizeEx;
-						gpDataTables.pSkillDescCode = pCode;
+						nSize = sgptDataTables->nSkillDescCodeSize;
+						nSizeEx = sgptDataTables->nSkillDescCodeSizeEx;
+						sgptDataTables->pSkillDescCode = pCode;
 
-						if (gpDataTables.nSkillDescCodeSize + nBufferSize < gpDataTables.nSkillDescCodeSizeEx)
+						if (sgptDataTables->nSkillDescCodeSize + nBufferSize < sgptDataTables->nSkillDescCodeSizeEx)
 						{
 							memcpy(&pCode[nSize], pBuffer, nBufferSize);
-							gpDataTables.nSkillDescCodeSize += nBufferSize;
+							sgptDataTables->nSkillDescCodeSize += nBufferSize;
 							*(int*)((char*)pRecord + nOffset) = nSize;
 							return;
 						}
@@ -347,8 +347,8 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 
 	D2BinFieldStrc pSkillTbl[] =
 	{
-		{ "skill", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pSkillsLinker },
-		{ "charclass", TXTFIELD_CODETOBYTE, 0, 12, &gpDataTables.pPlayerClassLinker },
+		{ "skill", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pSkillsLinker },
+		{ "charclass", TXTFIELD_CODETOBYTE, 0, 12, &sgptDataTables->pPlayerClassLinker },
 		{ "skilldesc", TXTFIELD_NAMETOWORD, 0, 404, &pSkillDescLinker },
 		{ "srvstfunc", TXTFIELD_WORD, 0, 44, NULL },
 		{ "srvdofunc", TXTFIELD_WORD, 0, 46, NULL },
@@ -359,115 +359,115 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 		{ "prgcalc2", TXTFIELD_CALCTODWORD, 0, 60, DATATBLS_SkillCalcLinker },
 		{ "prgcalc3", TXTFIELD_CALCTODWORD, 0, 64, DATATBLS_SkillCalcLinker },
 		{ "prgdam", TXTFIELD_BYTE, 0, 68, NULL },
-		{ "srvmissile", TXTFIELD_NAMETOWORD, 0, 70, &gpDataTables.pMissilesLinker },
-		{ "srvmissilea", TXTFIELD_NAMETOWORD, 0, 72, &gpDataTables.pMissilesLinker },
-		{ "srvmissileb", TXTFIELD_NAMETOWORD, 0, 74, &gpDataTables.pMissilesLinker },
-		{ "srvmissilec", TXTFIELD_NAMETOWORD, 0, 76, &gpDataTables.pMissilesLinker },
-		{ "srvoverlay", TXTFIELD_NAMETOWORD, 0, 78, &gpDataTables.pOverlayLinker },
+		{ "srvmissile", TXTFIELD_NAMETOWORD, 0, 70, &sgptDataTables->pMissilesLinker },
+		{ "srvmissilea", TXTFIELD_NAMETOWORD, 0, 72, &sgptDataTables->pMissilesLinker },
+		{ "srvmissileb", TXTFIELD_NAMETOWORD, 0, 74, &sgptDataTables->pMissilesLinker },
+		{ "srvmissilec", TXTFIELD_NAMETOWORD, 0, 76, &sgptDataTables->pMissilesLinker },
+		{ "srvoverlay", TXTFIELD_NAMETOWORD, 0, 78, &sgptDataTables->pOverlayLinker },
 		{ "lob", TXTFIELD_BIT, 1, 4, NULL },
 		{ "decquant", TXTFIELD_BIT, 0, 4, NULL },
 		{ "immediate", TXTFIELD_BIT, 15, 4, NULL },
 		{ "aurafilter", TXTFIELD_DWORD, 0, 80, NULL },
-		{ "aurastate", TXTFIELD_NAMETOWORD, 0, 128, &gpDataTables.pStatesLinker },
-		{ "auratargetstate", TXTFIELD_NAMETOWORD, 0, 130, &gpDataTables.pStatesLinker },
+		{ "aurastate", TXTFIELD_NAMETOWORD, 0, 128, &sgptDataTables->pStatesLinker },
+		{ "auratargetstate", TXTFIELD_NAMETOWORD, 0, 130, &sgptDataTables->pStatesLinker },
 		{ "auralencalc", TXTFIELD_CALCTODWORD, 0, 96, DATATBLS_SkillCalcLinker },
 		{ "aurarangecalc", TXTFIELD_CALCTODWORD, 0, 100, DATATBLS_SkillCalcLinker },
-		{ "aurastat1", TXTFIELD_NAMETOWORD, 0, 84, &gpDataTables.pItemStatCostLinker },
+		{ "aurastat1", TXTFIELD_NAMETOWORD, 0, 84, &sgptDataTables->pItemStatCostLinker },
 		{ "aurastatcalc1", TXTFIELD_CALCTODWORD, 0, 104, DATATBLS_SkillCalcLinker },
-		{ "aurastat2", TXTFIELD_NAMETOWORD, 0, 86, &gpDataTables.pItemStatCostLinker },
+		{ "aurastat2", TXTFIELD_NAMETOWORD, 0, 86, &sgptDataTables->pItemStatCostLinker },
 		{ "aurastatcalc2", TXTFIELD_CALCTODWORD, 0, 108, DATATBLS_SkillCalcLinker },
-		{ "aurastat3", TXTFIELD_NAMETOWORD, 0, 88, &gpDataTables.pItemStatCostLinker },
+		{ "aurastat3", TXTFIELD_NAMETOWORD, 0, 88, &sgptDataTables->pItemStatCostLinker },
 		{ "aurastatcalc3", TXTFIELD_CALCTODWORD, 0, 112, DATATBLS_SkillCalcLinker },
-		{ "aurastat4", TXTFIELD_NAMETOWORD, 0, 90, &gpDataTables.pItemStatCostLinker },
+		{ "aurastat4", TXTFIELD_NAMETOWORD, 0, 90, &sgptDataTables->pItemStatCostLinker },
 		{ "aurastatcalc4", TXTFIELD_CALCTODWORD, 0, 116, DATATBLS_SkillCalcLinker },
-		{ "aurastat5", TXTFIELD_NAMETOWORD, 0, 92, &gpDataTables.pItemStatCostLinker },
+		{ "aurastat5", TXTFIELD_NAMETOWORD, 0, 92, &sgptDataTables->pItemStatCostLinker },
 		{ "aurastatcalc5", TXTFIELD_CALCTODWORD, 0, 120, DATATBLS_SkillCalcLinker },
-		{ "aurastat6", TXTFIELD_NAMETOWORD, 0, 94, &gpDataTables.pItemStatCostLinker },
+		{ "aurastat6", TXTFIELD_NAMETOWORD, 0, 94, &sgptDataTables->pItemStatCostLinker },
 		{ "aurastatcalc6", TXTFIELD_CALCTODWORD, 0, 124, DATATBLS_SkillCalcLinker },
-		{ "auraevent1", TXTFIELD_NAMETOWORD, 0, 132, &gpDataTables.pEventsLinker },
+		{ "auraevent1", TXTFIELD_NAMETOWORD, 0, 132, &sgptDataTables->pEventsLinker },
 		{ "auraeventfunc1", TXTFIELD_WORD, 0, 138, NULL },
-		{ "auraevent2", TXTFIELD_NAMETOWORD, 0, 134, &gpDataTables.pEventsLinker },
+		{ "auraevent2", TXTFIELD_NAMETOWORD, 0, 134, &sgptDataTables->pEventsLinker },
 		{ "auraeventfunc2", TXTFIELD_WORD, 0, 140, NULL },
-		{ "auraevent3", TXTFIELD_NAMETOWORD, 0, 136, &gpDataTables.pEventsLinker },
+		{ "auraevent3", TXTFIELD_NAMETOWORD, 0, 136, &sgptDataTables->pEventsLinker },
 		{ "auraeventfunc3", TXTFIELD_WORD, 0, 142, NULL },
-		{ "auratgtevent", TXTFIELD_NAMETOWORD, 0, 144, &gpDataTables.pEventsLinker },
+		{ "auratgtevent", TXTFIELD_NAMETOWORD, 0, 144, &sgptDataTables->pEventsLinker },
 		{ "auratgteventfunc", TXTFIELD_WORD, 0, 146, NULL },
-		{ "passivestate", TXTFIELD_NAMETOWORD, 0, 148, &gpDataTables.pStatesLinker },
-		{ "passiveitype", TXTFIELD_CODETOWORD, 0, 150, &gpDataTables.pItemTypesLinker },
-		{ "passivestat1", TXTFIELD_NAMETOWORD, 0, 152, &gpDataTables.pItemStatCostLinker },
+		{ "passivestate", TXTFIELD_NAMETOWORD, 0, 148, &sgptDataTables->pStatesLinker },
+		{ "passiveitype", TXTFIELD_CODETOWORD, 0, 150, &sgptDataTables->pItemTypesLinker },
+		{ "passivestat1", TXTFIELD_NAMETOWORD, 0, 152, &sgptDataTables->pItemStatCostLinker },
 		{ "passivecalc1", TXTFIELD_CALCTODWORD, 0, 164, DATATBLS_SkillCalcLinker },
-		{ "passivestat2", TXTFIELD_NAMETOWORD, 0, 154, &gpDataTables.pItemStatCostLinker },
+		{ "passivestat2", TXTFIELD_NAMETOWORD, 0, 154, &sgptDataTables->pItemStatCostLinker },
 		{ "passivecalc2", TXTFIELD_CALCTODWORD, 0, 168, DATATBLS_SkillCalcLinker },
-		{ "passivestat3", TXTFIELD_NAMETOWORD, 0, 156, &gpDataTables.pItemStatCostLinker },
+		{ "passivestat3", TXTFIELD_NAMETOWORD, 0, 156, &sgptDataTables->pItemStatCostLinker },
 		{ "passivecalc3", TXTFIELD_CALCTODWORD, 0, 172, DATATBLS_SkillCalcLinker },
-		{ "passivestat4", TXTFIELD_NAMETOWORD, 0, 158, &gpDataTables.pItemStatCostLinker },
+		{ "passivestat4", TXTFIELD_NAMETOWORD, 0, 158, &sgptDataTables->pItemStatCostLinker },
 		{ "passivecalc4", TXTFIELD_CALCTODWORD, 0, 176, DATATBLS_SkillCalcLinker },
-		{ "passivestat5", TXTFIELD_NAMETOWORD, 0, 160, &gpDataTables.pItemStatCostLinker },
+		{ "passivestat5", TXTFIELD_NAMETOWORD, 0, 160, &sgptDataTables->pItemStatCostLinker },
 		{ "passivecalc5", TXTFIELD_CALCTODWORD, 0, 180, DATATBLS_SkillCalcLinker },
-		{ "passiveevent", TXTFIELD_NAMETOWORD, 0, 184, &gpDataTables.pEventsLinker },
+		{ "passiveevent", TXTFIELD_NAMETOWORD, 0, 184, &sgptDataTables->pEventsLinker },
 		{ "passiveeventfunc", TXTFIELD_WORD, 0, 186, NULL },
 		{ "summon", TXTFIELD_NAMETOWORD, 0, 188, &pMonStatsLinker },
-		{ "pettype", TXTFIELD_NAMETOWORD2, 0, 190, &gpDataTables.pPetTypeLinker },
-		{ "summode", TXTFIELD_CODETOBYTE, 0, 191, &gpDataTables.pMonModeLinker },
+		{ "pettype", TXTFIELD_NAMETOWORD2, 0, 190, &sgptDataTables->pPetTypeLinker },
+		{ "summode", TXTFIELD_CODETOBYTE, 0, 191, &sgptDataTables->pMonModeLinker },
 		{ "petmax", TXTFIELD_CALCTODWORD, 0, 192, DATATBLS_SkillCalcLinker },
-		{ "sumskill1", TXTFIELD_NAMETOWORD, 0, 196, &gpDataTables.pSkillsLinker },
+		{ "sumskill1", TXTFIELD_NAMETOWORD, 0, 196, &sgptDataTables->pSkillsLinker },
 		{ "sumsk1calc", TXTFIELD_CALCTODWORD, 0, 208, DATATBLS_SkillCalcLinker },
-		{ "sumskill2", TXTFIELD_NAMETOWORD, 0, 198, &gpDataTables.pSkillsLinker },
+		{ "sumskill2", TXTFIELD_NAMETOWORD, 0, 198, &sgptDataTables->pSkillsLinker },
 		{ "sumsk2calc", TXTFIELD_CALCTODWORD, 0, 212, DATATBLS_SkillCalcLinker },
-		{ "sumskill3", TXTFIELD_NAMETOWORD, 0, 200, &gpDataTables.pSkillsLinker },
+		{ "sumskill3", TXTFIELD_NAMETOWORD, 0, 200, &sgptDataTables->pSkillsLinker },
 		{ "sumsk3calc", TXTFIELD_CALCTODWORD, 0, 216, DATATBLS_SkillCalcLinker },
-		{ "sumskill4", TXTFIELD_NAMETOWORD, 0, 202, &gpDataTables.pSkillsLinker },
+		{ "sumskill4", TXTFIELD_NAMETOWORD, 0, 202, &sgptDataTables->pSkillsLinker },
 		{ "sumsk4calc", TXTFIELD_CALCTODWORD, 0, 220, DATATBLS_SkillCalcLinker },
-		{ "sumskill5", TXTFIELD_NAMETOWORD, 0, 204, &gpDataTables.pSkillsLinker },
+		{ "sumskill5", TXTFIELD_NAMETOWORD, 0, 204, &sgptDataTables->pSkillsLinker },
 		{ "sumsk5calc", TXTFIELD_CALCTODWORD, 0, 224, DATATBLS_SkillCalcLinker },
 		{ "sumumod", TXTFIELD_WORD, 0, 228, NULL },
-		{ "sumoverlay", TXTFIELD_NAMETOWORD, 0, 230, &gpDataTables.pOverlayLinker },
-		{ "cltmissile", TXTFIELD_NAMETOWORD, 0, 232, &gpDataTables.pMissilesLinker },
-		{ "cltmissilea", TXTFIELD_NAMETOWORD, 0, 234, &gpDataTables.pMissilesLinker },
-		{ "cltmissileb", TXTFIELD_NAMETOWORD, 0, 236, &gpDataTables.pMissilesLinker },
-		{ "cltmissilec", TXTFIELD_NAMETOWORD, 0, 238, &gpDataTables.pMissilesLinker },
-		{ "cltmissiled", TXTFIELD_NAMETOWORD, 0, 240, &gpDataTables.pMissilesLinker },
+		{ "sumoverlay", TXTFIELD_NAMETOWORD, 0, 230, &sgptDataTables->pOverlayLinker },
+		{ "cltmissile", TXTFIELD_NAMETOWORD, 0, 232, &sgptDataTables->pMissilesLinker },
+		{ "cltmissilea", TXTFIELD_NAMETOWORD, 0, 234, &sgptDataTables->pMissilesLinker },
+		{ "cltmissileb", TXTFIELD_NAMETOWORD, 0, 236, &sgptDataTables->pMissilesLinker },
+		{ "cltmissilec", TXTFIELD_NAMETOWORD, 0, 238, &sgptDataTables->pMissilesLinker },
+		{ "cltmissiled", TXTFIELD_NAMETOWORD, 0, 240, &sgptDataTables->pMissilesLinker },
 		{ "cltstfunc", TXTFIELD_WORD, 0, 242, NULL },
 		{ "cltdofunc", TXTFIELD_WORD, 0, 244, NULL },
 		{ "cltprgfunc1", TXTFIELD_WORD, 0, 246, NULL },
 		{ "cltprgfunc2", TXTFIELD_WORD, 0, 248, NULL },
 		{ "cltprgfunc3", TXTFIELD_WORD, 0, 250, NULL },
 		{ "stsuccessonly", TXTFIELD_BIT, 12, 4, NULL },
-		{ "stsound", TXTFIELD_NAMETOWORD, 0, 252, &gpDataTables.pSoundsLinker },
-		{ "stsoundclass", TXTFIELD_NAMETOWORD, 0, 254, &gpDataTables.pSoundsLinker },
+		{ "stsound", TXTFIELD_NAMETOWORD, 0, 252, &sgptDataTables->pSoundsLinker },
+		{ "stsoundclass", TXTFIELD_NAMETOWORD, 0, 254, &sgptDataTables->pSoundsLinker },
 		{ "stsounddelay", TXTFIELD_BIT, 13, 4, NULL },
 		{ "weaponsnd", TXTFIELD_BIT, 14, 4, NULL },
-		{ "dosound", TXTFIELD_NAMETOWORD, 0, 256, &gpDataTables.pSoundsLinker },
-		{ "dosound a", TXTFIELD_NAMETOWORD, 0, 258, &gpDataTables.pSoundsLinker },
-		{ "dosound b", TXTFIELD_NAMETOWORD, 0, 260, &gpDataTables.pSoundsLinker },
-		{ "tgtsound", TXTFIELD_NAMETOWORD, 0, 266, &gpDataTables.pSoundsLinker },
-		{ "tgtoverlay", TXTFIELD_NAMETOWORD, 0, 264, &gpDataTables.pOverlayLinker },
-		{ "castoverlay", TXTFIELD_NAMETOWORD, 0, 262, &gpDataTables.pOverlayLinker },
-		{ "cltoverlaya", TXTFIELD_NAMETOWORD, 0, 272, &gpDataTables.pOverlayLinker },
-		{ "cltoverlayb", TXTFIELD_NAMETOWORD, 0, 274, &gpDataTables.pOverlayLinker },
-		{ "prgsound", TXTFIELD_NAMETOWORD, 0, 270, &gpDataTables.pSoundsLinker },
-		{ "prgoverlay", TXTFIELD_NAMETOWORD, 0, 268, &gpDataTables.pOverlayLinker },
+		{ "dosound", TXTFIELD_NAMETOWORD, 0, 256, &sgptDataTables->pSoundsLinker },
+		{ "dosound a", TXTFIELD_NAMETOWORD, 0, 258, &sgptDataTables->pSoundsLinker },
+		{ "dosound b", TXTFIELD_NAMETOWORD, 0, 260, &sgptDataTables->pSoundsLinker },
+		{ "tgtsound", TXTFIELD_NAMETOWORD, 0, 266, &sgptDataTables->pSoundsLinker },
+		{ "tgtoverlay", TXTFIELD_NAMETOWORD, 0, 264, &sgptDataTables->pOverlayLinker },
+		{ "castoverlay", TXTFIELD_NAMETOWORD, 0, 262, &sgptDataTables->pOverlayLinker },
+		{ "cltoverlaya", TXTFIELD_NAMETOWORD, 0, 272, &sgptDataTables->pOverlayLinker },
+		{ "cltoverlayb", TXTFIELD_NAMETOWORD, 0, 274, &sgptDataTables->pOverlayLinker },
+		{ "prgsound", TXTFIELD_NAMETOWORD, 0, 270, &sgptDataTables->pSoundsLinker },
+		{ "prgoverlay", TXTFIELD_NAMETOWORD, 0, 268, &sgptDataTables->pOverlayLinker },
 		{ "cltcalc1", TXTFIELD_CALCTODWORD, 0, 276, DATATBLS_SkillCalcLinker },
 		{ "cltcalc2", TXTFIELD_CALCTODWORD, 0, 280, DATATBLS_SkillCalcLinker },
 		{ "cltcalc3", TXTFIELD_CALCTODWORD, 0, 284, DATATBLS_SkillCalcLinker },
 		{ "warp", TXTFIELD_BIT, 38, 4, NULL },
-		{ "anim", TXTFIELD_CODETOBYTE, 0, 16, &gpDataTables.pPlrModeLinker },
-		{ "seqtrans", TXTFIELD_CODETOBYTE, 0, 18, &gpDataTables.pPlrModeLinker },
-		{ "monanim", TXTFIELD_CODETOBYTE, 0, 17, &gpDataTables.pMonModeLinker },
+		{ "anim", TXTFIELD_CODETOBYTE, 0, 16, &sgptDataTables->pPlrModeLinker },
+		{ "seqtrans", TXTFIELD_CODETOBYTE, 0, 18, &sgptDataTables->pPlrModeLinker },
+		{ "monanim", TXTFIELD_CODETOBYTE, 0, 17, &sgptDataTables->pMonModeLinker },
 		{ "seqnum", TXTFIELD_BYTE, 0, 19, NULL },
 		{ "seqinput", TXTFIELD_BYTE, 0, 22, NULL },
 		{ "range", TXTFIELD_CODETOBYTE, 0, TXTFIELD_NAMETOWORD, &pRangeLinker },
 		{ "weapsel", TXTFIELD_BYTE, 0, 360, NULL },
-		{ "itypea1", TXTFIELD_CODETOWORD, 0, 24, &gpDataTables.pItemTypesLinker },
-		{ "itypea2", TXTFIELD_CODETOWORD, 0, 26, &gpDataTables.pItemTypesLinker },
-		{ "itypea3", TXTFIELD_CODETOWORD, 0, 28, &gpDataTables.pItemTypesLinker },
-		{ "etypea1", TXTFIELD_CODETOWORD, 0, 36, &gpDataTables.pItemTypesLinker },
-		{ "etypea2", TXTFIELD_CODETOWORD, 0, 38, &gpDataTables.pItemTypesLinker },
-		{ "itypeb1", TXTFIELD_CODETOWORD, 0, 30, &gpDataTables.pItemTypesLinker },
-		{ "itypeb2", TXTFIELD_CODETOWORD, 0, 32, &gpDataTables.pItemTypesLinker },
-		{ "itypeb3", TXTFIELD_CODETOWORD, 0, 34, &gpDataTables.pItemTypesLinker },
-		{ "etypeb1", TXTFIELD_CODETOWORD, 0, 40, &gpDataTables.pItemTypesLinker },
-		{ "etypeb2", TXTFIELD_CODETOWORD, 0, 42, &gpDataTables.pItemTypesLinker },
+		{ "itypea1", TXTFIELD_CODETOWORD, 0, 24, &sgptDataTables->pItemTypesLinker },
+		{ "itypea2", TXTFIELD_CODETOWORD, 0, 26, &sgptDataTables->pItemTypesLinker },
+		{ "itypea3", TXTFIELD_CODETOWORD, 0, 28, &sgptDataTables->pItemTypesLinker },
+		{ "etypea1", TXTFIELD_CODETOWORD, 0, 36, &sgptDataTables->pItemTypesLinker },
+		{ "etypea2", TXTFIELD_CODETOWORD, 0, 38, &sgptDataTables->pItemTypesLinker },
+		{ "itypeb1", TXTFIELD_CODETOWORD, 0, 30, &sgptDataTables->pItemTypesLinker },
+		{ "itypeb2", TXTFIELD_CODETOWORD, 0, 32, &sgptDataTables->pItemTypesLinker },
+		{ "itypeb3", TXTFIELD_CODETOWORD, 0, 34, &sgptDataTables->pItemTypesLinker },
+		{ "etypeb1", TXTFIELD_CODETOWORD, 0, 40, &sgptDataTables->pItemTypesLinker },
+		{ "etypeb2", TXTFIELD_CODETOWORD, 0, 42, &sgptDataTables->pItemTypesLinker },
 		{ "maxlvl", TXTFIELD_WORD, 0, 300, NULL },
 		{ "progressive", TXTFIELD_BIT, 2, 4, NULL },
 		{ "finishing", TXTFIELD_BIT, 3, 4, NULL },
@@ -489,8 +489,8 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 		{ "ItemCheckStart", TXTFIELD_BIT, 33, 4, NULL },
 		{ "ItemCltCheckStart", TXTFIELD_BIT, 34, 4, NULL },
 		{ "ItemTarget", TXTFIELD_BYTE, 0, 288, NULL },
-		{ "ItemCastSound", TXTFIELD_NAMETOWORD, 0, 290, &gpDataTables.pSoundsLinker },
-		{ "ItemCastOverlay", TXTFIELD_NAMETOWORD, 0, 292, &gpDataTables.pOverlayLinker },
+		{ "ItemCastSound", TXTFIELD_NAMETOWORD, 0, 290, &sgptDataTables->pSoundsLinker },
+		{ "ItemCastOverlay", TXTFIELD_NAMETOWORD, 0, 292, &sgptDataTables->pOverlayLinker },
 		{ "InGame", TXTFIELD_BIT, 10, 4, NULL },
 		{ "lineofsight", TXTFIELD_BYTE, 0, 399, NULL },
 		{ "attackrank", TXTFIELD_BYTE, 0, 398, NULL },
@@ -518,9 +518,9 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 		{ "reqdex", TXTFIELD_WORD, 0, 376, NULL },
 		{ "reqint", TXTFIELD_WORD, 0, 378, NULL },
 		{ "reqvit", TXTFIELD_WORD, 0, 380, NULL },
-		{ "reqskill1", TXTFIELD_NAMETOWORD, 0, 382, &gpDataTables.pSkillsLinker },
-		{ "reqskill2", TXTFIELD_NAMETOWORD, 0, 384, &gpDataTables.pSkillsLinker },
-		{ "reqskill3", TXTFIELD_NAMETOWORD, 0, 386, &gpDataTables.pSkillsLinker },
+		{ "reqskill1", TXTFIELD_NAMETOWORD, 0, 382, &sgptDataTables->pSkillsLinker },
+		{ "reqskill2", TXTFIELD_NAMETOWORD, 0, 384, &sgptDataTables->pSkillsLinker },
+		{ "reqskill3", TXTFIELD_NAMETOWORD, 0, 386, &sgptDataTables->pSkillsLinker },
 		{ "delay", TXTFIELD_CALCTODWORD, 0, 400, DATATBLS_SkillCalcLinker },
 		{ "usemanaondo", TXTFIELD_BIT, 37, 4, NULL },
 		{ "startmana", TXTFIELD_WORD, 0, 388, NULL },
@@ -558,7 +558,7 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 		{ "MaxLevDam4", TXTFIELD_DWORD, 0, 464, NULL },
 		{ "MaxLevDam5", TXTFIELD_DWORD, 0, 468, NULL },
 		{ "DmgSymPerCalc", TXTFIELD_CALCTODWORD, 0, 472, DATATBLS_SkillCalcLinker },
-		{ "EType", TXTFIELD_CODETOBYTE, 0, 476, &gpDataTables.pElemTypesLinker },
+		{ "EType", TXTFIELD_CODETOBYTE, 0, 476, &sgptDataTables->pElemTypesLinker },
 		{ "EMin", TXTFIELD_DWORD, 0, 480, NULL },
 		{ "EMinLev1", TXTFIELD_DWORD, 0, 488, NULL },
 		{ "EMinLev2", TXTFIELD_DWORD, 0, 492, NULL },
@@ -578,9 +578,9 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 		{ "ELevLen3", TXTFIELD_DWORD, 0, 544, NULL },
 		{ "ELenSymPerCalc", TXTFIELD_CALCTODWORD, 0, 548, DATATBLS_SkillCalcLinker },
 		{ "restrict", TXTFIELD_BYTE, 0, 552, NULL },
-		{ "state1", TXTFIELD_NAMETOWORD, 0, 554, &gpDataTables.pStatesLinker },
-		{ "state2", TXTFIELD_NAMETOWORD, 0, 556, &gpDataTables.pStatesLinker },
-		{ "state3", TXTFIELD_NAMETOWORD, 0, 558, &gpDataTables.pStatesLinker },
+		{ "state1", TXTFIELD_NAMETOWORD, 0, 554, &sgptDataTables->pStatesLinker },
+		{ "state2", TXTFIELD_NAMETOWORD, 0, 556, &sgptDataTables->pStatesLinker },
+		{ "state3", TXTFIELD_NAMETOWORD, 0, 558, &sgptDataTables->pStatesLinker },
 		{ "aitype", TXTFIELD_BYTE, 0, 560, NULL },
 		{ "aibonus", TXTFIELD_WORD, 0, 562, NULL },
 		{ "cost mult", TXTFIELD_DWORD, 0, 564, NULL },
@@ -590,7 +590,7 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 
 	D2BinFieldStrc pSkillDescTbl[] =
 	{
-		{ "skilldesc", TXTFIELD_NAMETOINDEX, 0, 0, &gpDataTables.pSkillDescLinker },
+		{ "skilldesc", TXTFIELD_NAMETOINDEX, 0, 0, &sgptDataTables->pSkillDescLinker },
 		{ "skillpage", TXTFIELD_BYTE, 0, 2, NULL },
 		{ "skillrow", TXTFIELD_BYTE, 0, TXTFIELD_WORD, NULL },
 		{ "skillcolumn", TXTFIELD_BYTE, 0, 4, NULL },
@@ -606,18 +606,18 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 		{ "descatt", TXTFIELD_WORD, 0, TXTFIELD_NAMETOWORD, NULL },
 		{ "ddam calc1", TXTFIELD_CALCTODWORD, 0, 24, DATATBLS_SkillDescCalcLinker },
 		{ "ddam calc2", TXTFIELD_CALCTODWORD, 0, 28, DATATBLS_SkillDescCalcLinker },
-		{ "p1dmelem", TXTFIELD_CODETOBYTE, 0, 32, &gpDataTables.pElemTypesLinker },
+		{ "p1dmelem", TXTFIELD_CODETOBYTE, 0, 32, &sgptDataTables->pElemTypesLinker },
 		{ "p1dmmin", TXTFIELD_CALCTODWORD, 0, 36, DATATBLS_SkillDescCalcLinker },
 		{ "p1dmmax", TXTFIELD_CALCTODWORD, 0, 48, DATATBLS_SkillDescCalcLinker },
-		{ "p2dmelem", TXTFIELD_CODETOBYTE, 0, 33, &gpDataTables.pElemTypesLinker },
+		{ "p2dmelem", TXTFIELD_CODETOBYTE, 0, 33, &sgptDataTables->pElemTypesLinker },
 		{ "p2dmmin", TXTFIELD_CALCTODWORD, 0, 40, DATATBLS_SkillDescCalcLinker },
 		{ "p2dmmax", TXTFIELD_CALCTODWORD, 0, 52, DATATBLS_SkillDescCalcLinker },
-		{ "p3dmelem", TXTFIELD_CODETOBYTE, 0, 34, &gpDataTables.pElemTypesLinker },
+		{ "p3dmelem", TXTFIELD_CODETOBYTE, 0, 34, &sgptDataTables->pElemTypesLinker },
 		{ "p3dmmin", TXTFIELD_CALCTODWORD, 0, 44, DATATBLS_SkillDescCalcLinker },
 		{ "p3dmmax", TXTFIELD_CALCTODWORD, 0, 56, DATATBLS_SkillDescCalcLinker },
-		{ "descmissile1", TXTFIELD_NAMETOWORD, 0, 60, &gpDataTables.pMissilesLinker },
-		{ "descmissile2", TXTFIELD_NAMETOWORD, 0, 62, &gpDataTables.pMissilesLinker },
-		{ "descmissile3", TXTFIELD_NAMETOWORD, 0, 64, &gpDataTables.pMissilesLinker },
+		{ "descmissile1", TXTFIELD_NAMETOWORD, 0, 60, &sgptDataTables->pMissilesLinker },
+		{ "descmissile2", TXTFIELD_NAMETOWORD, 0, 62, &sgptDataTables->pMissilesLinker },
+		{ "descmissile3", TXTFIELD_NAMETOWORD, 0, 64, &sgptDataTables->pMissilesLinker },
 		{ "descline1", TXTFIELD_BYTE, 0, 66, NULL },
 		{ "desctexta1", TXTFIELD_KEYTOWORD, 0, 84, DATATBLS_GetStringIdFromReferenceString },
 		{ "desctextb1", TXTFIELD_KEYTOWORD, 0, 118, DATATBLS_GetStringIdFromReferenceString },
@@ -706,7 +706,7 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	if (gpDataTables.bCompileTxt)
+	if (sgptDataTables->bCompileTxt)
 	{
 		pRangeLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
 
@@ -723,23 +723,23 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 		pTmpSkillDescTxt = DATATBLS_CompileTxt(pMemPool, "skilldesc", pTmpSkillDescTbl, &nSize, 2);
 	}
 
-	gpDataTables.pSkillsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pSkillsTxt = (D2SkillsTxt*)DATATBLS_CompileTxt(pMemPool, "skills", pSkillTbl, &gpDataTables.nSkillsTxtRecordCount, sizeof(D2SkillsTxt));
-	if (gpDataTables.nSkillsTxtRecordCount >= 32767)
+	sgptDataTables->pSkillsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pSkillsTxt = (D2SkillsTxt*)DATATBLS_CompileTxt(pMemPool, "skills", pSkillTbl, &sgptDataTables->nSkillsTxtRecordCount, sizeof(D2SkillsTxt));
+	if (sgptDataTables->nSkillsTxtRecordCount >= 32767)
 	{
 		FOG_10025("Skills table exceeded maximum number of entries.", __FILE__, __LINE__);
 	}
 
-	gpDataTables.nPassiveSkills = 0;
+	sgptDataTables->nPassiveSkills = 0;
 
-	gpDataTables.pSkillDescLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-	gpDataTables.pSkillDescTxt = (D2SkillDescTxt*)DATATBLS_CompileTxt(pMemPool, "skilldesc", pSkillDescTbl, &gpDataTables.nSkillDescTxtRecordCount, sizeof(D2SkillDescTxt));
-	if (gpDataTables.nSkillDescTxtRecordCount >= 32767)
+	sgptDataTables->pSkillDescLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
+	sgptDataTables->pSkillDescTxt = (D2SkillDescTxt*)DATATBLS_CompileTxt(pMemPool, "skilldesc", pSkillDescTbl, &sgptDataTables->nSkillDescTxtRecordCount, sizeof(D2SkillDescTxt));
+	if (sgptDataTables->nSkillDescTxtRecordCount >= 32767)
 	{
 		FOG_10025("SkillDesc table exceeded maximum number of entries.", __FILE__, __LINE__);
 	}
 
-	if (gpDataTables.bCompileTxt)
+	if (sgptDataTables->bCompileTxt)
 	{
 		FOG_FreeLinker(pRangeLinker);
 		FOG_FreeLinker(pMonStatsLinker);
@@ -771,97 +771,97 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 			}
 		}
 
-		if (gpDataTables.bCompileTxt && gpDataTables.pSkillsCode)
+		if (sgptDataTables->bCompileTxt && sgptDataTables->pSkillsCode)
 		{
 			wsprintfA(szFileName, "%s\\%s.bin", "DATA\\GLOBAL\\EXCEL", "skillscode");
 			fopen_s(&pSkillsCodeBin, szFileName, "wb");
 			if (pSkillsCodeBin)
 			{
-				DATATBLS_LockAndWriteToFile(gpDataTables.pSkillsCode, gpDataTables.nSkillsCodeSize, 1u, pSkillsCodeBin);
+				DATATBLS_LockAndWriteToFile(sgptDataTables->pSkillsCode, sgptDataTables->nSkillsCodeSize, 1u, pSkillsCodeBin);
 				fclose(pSkillsCodeBin);
 			}
-			FOG_FreeServerMemory(NULL, gpDataTables.pSkillsCode, __FILE__, __LINE__, 0);
+			FOG_FreeServerMemory(NULL, sgptDataTables->pSkillsCode, __FILE__, __LINE__, 0);
 		}
 	}
 
 	wsprintfA(szFileName, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", "skillscode", ".bin");
-	gpDataTables.pSkillsCode = (char*)DATATBLS_GetBinaryData(pMemPool, szFileName, &nSize, __FILE__, __LINE__);
-	gpDataTables.nSkillsCodeSizeEx = nSize;
-	gpDataTables.nSkillsCodeSize = nSize;
+	sgptDataTables->pSkillsCode = (char*)DATATBLS_GetBinaryData(pMemPool, szFileName, &nSize, __FILE__, __LINE__);
+	sgptDataTables->nSkillsCodeSizeEx = nSize;
+	sgptDataTables->nSkillsCodeSize = nSize;
 
-	if (gpDataTables.bCompileTxt && gpDataTables.pSkillDescCode)
+	if (sgptDataTables->bCompileTxt && sgptDataTables->pSkillDescCode)
 	{
 		wsprintfA(szFileName, "%s\\%s.bin", "DATA\\GLOBAL\\EXCEL", "skilldesccode");
 		fopen_s(&pSkillDescCodeBin, szFileName, "wb");
 		if (pSkillDescCodeBin)
 		{
-			DATATBLS_LockAndWriteToFile(gpDataTables.pSkillDescCode, gpDataTables.nSkillDescCodeSize, 1, pSkillDescCodeBin);
+			DATATBLS_LockAndWriteToFile(sgptDataTables->pSkillDescCode, sgptDataTables->nSkillDescCodeSize, 1, pSkillDescCodeBin);
 			fclose(pSkillDescCodeBin);
 		}
-		FOG_FreeServerMemory(NULL, gpDataTables.pSkillDescCode, __FILE__, __LINE__, 0);
+		FOG_FreeServerMemory(NULL, sgptDataTables->pSkillDescCode, __FILE__, __LINE__, 0);
 	}
 
 	wsprintfA(szFileName, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", "skilldesccode", ".bin");
-	gpDataTables.pSkillDescCode = (char*)DATATBLS_GetBinaryData(pMemPool, szFileName, &nSize, __FILE__, __LINE__);
-	gpDataTables.nSkillDescCodeSizeEx = nSize;
-	gpDataTables.nSkillDescCodeSize = nSize;
+	sgptDataTables->pSkillDescCode = (char*)DATATBLS_GetBinaryData(pMemPool, szFileName, &nSize, __FILE__, __LINE__);
+	sgptDataTables->nSkillDescCodeSizeEx = nSize;
+	sgptDataTables->nSkillDescCodeSize = nSize;
 
-	gpDataTables.nClassSkillCount = (int*)FOG_AllocServerMemory(NULL, 7 * sizeof(int), __FILE__, __LINE__, 0);
-	memset(gpDataTables.nClassSkillCount, 0x00, 7 * sizeof(int));
+	sgptDataTables->nClassSkillCount = (int*)FOG_AllocServerMemory(NULL, 7 * sizeof(int), __FILE__, __LINE__, 0);
+	memset(sgptDataTables->nClassSkillCount, 0x00, 7 * sizeof(int));
 
-	for (int i = 0; i < gpDataTables.nSkillsTxtRecordCount; ++i)
+	for (int i = 0; i < sgptDataTables->nSkillsTxtRecordCount; ++i)
 	{
-		nClass = gpDataTables.pSkillsTxt[i].nCharClass;
+		nClass = sgptDataTables->pSkillsTxt[i].nCharClass;
 		if (nClass >= 0 && nClass < 7)
 		{
-			++gpDataTables.nClassSkillCount[nClass];
+			++sgptDataTables->nClassSkillCount[nClass];
 		}
 
-		if (gpDataTables.pSkillsTxt[i].nPassiveState >= 0)
+		if (sgptDataTables->pSkillsTxt[i].nPassiveState >= 0)
 		{
-			++gpDataTables.nPassiveSkills;
+			++sgptDataTables->nPassiveSkills;
 		}
 	}
 
 	nHighestClassSkillCount = 0;
-	gpDataTables.nHighestClassSkillCount = 0;
+	sgptDataTables->nHighestClassSkillCount = 0;
 
 	for (int i = 0; i < 7; ++i)
 	{
-		if (gpDataTables.nClassSkillCount[i] > nHighestClassSkillCount)
+		if (sgptDataTables->nClassSkillCount[i] > nHighestClassSkillCount)
 		{
-			nHighestClassSkillCount = gpDataTables.nClassSkillCount[i];
-			gpDataTables.nHighestClassSkillCount = gpDataTables.nClassSkillCount[i];
+			nHighestClassSkillCount = sgptDataTables->nClassSkillCount[i];
+			sgptDataTables->nHighestClassSkillCount = sgptDataTables->nClassSkillCount[i];
 		}
 	}
 
-	gpDataTables.nClassSkillList = (short*)FOG_AllocServerMemory(NULL, 7 * sizeof(short) * nHighestClassSkillCount, __FILE__, __LINE__, 0);
-	memset(gpDataTables.nClassSkillList, 0x00, 7 * sizeof(short) * nHighestClassSkillCount);
-	memset(gpDataTables.nClassSkillCount, 0x00, 7 * sizeof(int));
+	sgptDataTables->nClassSkillList = (short*)FOG_AllocServerMemory(NULL, 7 * sizeof(short) * nHighestClassSkillCount, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->nClassSkillList, 0x00, 7 * sizeof(short) * nHighestClassSkillCount);
+	memset(sgptDataTables->nClassSkillCount, 0x00, 7 * sizeof(int));
 
-	gpDataTables.pPassiveSkills = (WORD*)FOG_AllocServerMemory(NULL, sizeof(WORD) * gpDataTables.nPassiveSkills, __FILE__, __LINE__, 0);
-	memset(gpDataTables.pPassiveSkills, 0x00, sizeof(WORD) * gpDataTables.nPassiveSkills);
+	sgptDataTables->pPassiveSkills = (WORD*)FOG_AllocServerMemory(NULL, sizeof(WORD) * sgptDataTables->nPassiveSkills, __FILE__, __LINE__, 0);
+	memset(sgptDataTables->pPassiveSkills, 0x00, sizeof(WORD) * sgptDataTables->nPassiveSkills);
 
-	gpDataTables.nPassiveSkills = 0;
-	for (int i = 0; i < gpDataTables.nSkillsTxtRecordCount; ++i)
+	sgptDataTables->nPassiveSkills = 0;
+	for (int i = 0; i < sgptDataTables->nSkillsTxtRecordCount; ++i)
 	{
-		nClass = gpDataTables.pSkillsTxt[i].nCharClass;
+		nClass = sgptDataTables->pSkillsTxt[i].nCharClass;
 		if (nClass >= 0 && nClass < 7)
 		{
-			gpDataTables.nClassSkillList[gpDataTables.nClassSkillCount[nClass] + gpDataTables.nHighestClassSkillCount * nClass] = i;
-			++gpDataTables.nClassSkillCount[nClass];
+			sgptDataTables->nClassSkillList[sgptDataTables->nClassSkillCount[nClass] + sgptDataTables->nHighestClassSkillCount * nClass] = i;
+			++sgptDataTables->nClassSkillCount[nClass];
 		}
 
-		if (gpDataTables.pSkillsTxt[i].nPassiveState >= 0)
+		if (sgptDataTables->pSkillsTxt[i].nPassiveState >= 0)
 		{
-			gpDataTables.pPassiveSkills[gpDataTables.nPassiveSkills] = i;
-			++gpDataTables.nPassiveSkills;
+			sgptDataTables->pPassiveSkills[sgptDataTables->nPassiveSkills] = i;
+			++sgptDataTables->nPassiveSkills;
 		}
 
-		nPetType = gpDataTables.pSkillsTxt[i].nPetType;
-		if (nPetType >= 0 && nPetType < gpDataTables.nPetTypeTxtRecordCount)
+		nPetType = sgptDataTables->pSkillsTxt[i].nPetType;
+		if (nPetType >= 0 && nPetType < sgptDataTables->nPetTypeTxtRecordCount)
 		{
-			pPetTypeTxtRecord = &gpDataTables.pPetTypeTxt[nPetType];
+			pPetTypeTxtRecord = &sgptDataTables->pPetTypeTxt[nPetType];
 			if (pPetTypeTxtRecord->nSkillCount < ARRAY_SIZE(pPetTypeTxtRecord->wSkillIds))
 			{
 				pPetTypeTxtRecord->wSkillIds[pPetTypeTxtRecord->nSkillCount] = i;
@@ -874,61 +874,61 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 //D2Common.0x6FD4E350
 void __fastcall DATATBLS_UnloadSkills_SkillDescTxt()
 {
-	if (gpDataTables.nClassSkillCount)
+	if (sgptDataTables->nClassSkillCount)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.nClassSkillCount, __FILE__, __LINE__, 0);
-		gpDataTables.nClassSkillCount = 0;
+		FOG_FreeServerMemory(NULL, sgptDataTables->nClassSkillCount, __FILE__, __LINE__, 0);
+		sgptDataTables->nClassSkillCount = 0;
 	}
 
-	if (gpDataTables.nClassSkillList)
+	if (sgptDataTables->nClassSkillList)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.nClassSkillList, __FILE__, __LINE__, 0);
-		gpDataTables.nClassSkillList = 0;
+		FOG_FreeServerMemory(NULL, sgptDataTables->nClassSkillList, __FILE__, __LINE__, 0);
+		sgptDataTables->nClassSkillList = 0;
 	}
-	gpDataTables.nHighestClassSkillCount = 0;
+	sgptDataTables->nHighestClassSkillCount = 0;
 
-	if (gpDataTables.pPassiveSkills)
+	if (sgptDataTables->pPassiveSkills)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pPassiveSkills, __FILE__, __LINE__, 0);
-		gpDataTables.pPassiveSkills = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pPassiveSkills, __FILE__, __LINE__, 0);
+		sgptDataTables->pPassiveSkills = NULL;
 	}
-	gpDataTables.nPassiveSkills = 0;
+	sgptDataTables->nPassiveSkills = 0;
 
-	if (gpDataTables.pSkillsCode)
+	if (sgptDataTables->pSkillsCode)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pSkillsCode, __FILE__, __LINE__, 0);
-		gpDataTables.pSkillsCode = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pSkillsCode, __FILE__, __LINE__, 0);
+		sgptDataTables->pSkillsCode = NULL;
 	}
-	gpDataTables.nSkillsCodeSize = 0;
-	gpDataTables.nSkillsCodeSizeEx = 0;
+	sgptDataTables->nSkillsCodeSize = 0;
+	sgptDataTables->nSkillsCodeSizeEx = 0;
 
-	if (gpDataTables.pSkillDescCode)
+	if (sgptDataTables->pSkillDescCode)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pSkillDescCode, __FILE__, __LINE__, 0);
-		gpDataTables.pSkillDescCode = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pSkillDescCode, __FILE__, __LINE__, 0);
+		sgptDataTables->pSkillDescCode = NULL;
 	}
-	gpDataTables.nSkillDescCodeSize = 0;
-	gpDataTables.nSkillDescCodeSizeEx = 0;
+	sgptDataTables->nSkillDescCodeSize = 0;
+	sgptDataTables->nSkillDescCodeSizeEx = 0;
 
-	DATATBLS_UnloadBin(gpDataTables.pSkillsTxt);
-	gpDataTables.pSkillsTxt = NULL;
-	FOG_FreeLinker(gpDataTables.pSkillsLinker);
-	gpDataTables.pSkillsLinker = NULL;
-	gpDataTables.nSkillsTxtRecordCount = 0;
+	DATATBLS_UnloadBin(sgptDataTables->pSkillsTxt);
+	sgptDataTables->pSkillsTxt = NULL;
+	FOG_FreeLinker(sgptDataTables->pSkillsLinker);
+	sgptDataTables->pSkillsLinker = NULL;
+	sgptDataTables->nSkillsTxtRecordCount = 0;
 
-	DATATBLS_UnloadBin(gpDataTables.pSkillDescTxt);
-	gpDataTables.pSkillDescTxt = NULL;
-	FOG_FreeLinker(gpDataTables.pSkillDescLinker);
-	gpDataTables.pSkillDescLinker = NULL;
-	gpDataTables.nSkillDescTxtRecordCount = 0;
+	DATATBLS_UnloadBin(sgptDataTables->pSkillDescTxt);
+	sgptDataTables->pSkillDescTxt = NULL;
+	FOG_FreeLinker(sgptDataTables->pSkillDescLinker);
+	sgptDataTables->pSkillDescLinker = NULL;
+	sgptDataTables->nSkillDescTxtRecordCount = 0;
 }
 
 //Inlined at various places
 D2SkillsTxt* __fastcall DATATBLS_GetSkillsTxtRecord(int nSkillId)
 {
-	if (nSkillId >= 0 && nSkillId < gpDataTables.nSkillsTxtRecordCount)
+	if (nSkillId >= 0 && nSkillId < sgptDataTables->nSkillsTxtRecordCount)
 	{
-		return &gpDataTables.pSkillsTxt[nSkillId];
+		return &sgptDataTables->pSkillsTxt[nSkillId];
 	}
 
 	return NULL;
@@ -937,9 +937,9 @@ D2SkillsTxt* __fastcall DATATBLS_GetSkillsTxtRecord(int nSkillId)
 //Inlined at various places
 D2SkillDescTxt* __fastcall DATATBLS_GetSkillDescTxtRecord(int nSkillDesc)
 {
-	if (nSkillDesc >= 0 && nSkillDesc < gpDataTables.nSkillDescTxtRecordCount)
+	if (nSkillDesc >= 0 && nSkillDesc < sgptDataTables->nSkillDescTxtRecordCount)
 	{
-		return &gpDataTables.pSkillDescTxt[nSkillDesc];
+		return &sgptDataTables->pSkillDescTxt[nSkillDesc];
 	}
 
 	return NULL;

--- a/source/D2Common/src/DataTbls/TokenTbls.cpp
+++ b/source/D2Common/src/DataTbls/TokenTbls.cpp
@@ -1330,17 +1330,17 @@ void __fastcall DATATBLS_LoadPlrType_ModeTxt(void* pMemPool)
 	pPlrType = (D2PlrModeTypeTxt*)DATATBLS_CompileTxt(pMemPool, "plrtype", pTbl, &nTypeRecords, sizeof(D2PlrModeTypeTxt));
 	pPlrMode = (D2PlrModeTypeTxt*)DATATBLS_CompileTxt(pMemPool, "plrmode", pTbl, &nModeRecords, sizeof(D2PlrModeTypeTxt));
 
-	gpDataTables.pPlrModeDataTables.nPlrModeTypeTxtRecordCount = nModeRecords + nTypeRecords;
+	sgptDataTables->pPlrModeDataTables.nPlrModeTypeTxtRecordCount = nModeRecords + nTypeRecords;
 
 	pPlrModeTypeTxt = (D2PlrModeTypeTxt*)FOG_AllocServerMemory(NULL, sizeof(D2PlrModeTypeTxt) * (nModeRecords + nTypeRecords), __FILE__, __LINE__, 0);
 	D2_ASSERT(pPlrModeTypeTxt);
 
-	gpDataTables.pPlrModeDataTables.pPlrModeTypeTxt = pPlrModeTypeTxt;
-	gpDataTables.pPlrModeDataTables.pPlayerType = pPlrModeTypeTxt;
-	gpDataTables.pPlrModeDataTables.pPlayerMode = pPlrModeTypeTxt + nTypeRecords;
+	sgptDataTables->pPlrModeDataTables.pPlrModeTypeTxt = pPlrModeTypeTxt;
+	sgptDataTables->pPlrModeDataTables.pPlayerType = pPlrModeTypeTxt;
+	sgptDataTables->pPlrModeDataTables.pPlayerMode = pPlrModeTypeTxt + nTypeRecords;
 
-	memcpy(gpDataTables.pPlrModeDataTables.pPlayerType, pPlrType, sizeof(D2PlrModeTypeTxt) * nTypeRecords);
-	memcpy(gpDataTables.pPlrModeDataTables.pPlayerMode, pPlrMode, sizeof(D2PlrModeTypeTxt) * nModeRecords);
+	memcpy(sgptDataTables->pPlrModeDataTables.pPlayerType, pPlrType, sizeof(D2PlrModeTypeTxt) * nTypeRecords);
+	memcpy(sgptDataTables->pPlrModeDataTables.pPlayerMode, pPlrMode, sizeof(D2PlrModeTypeTxt) * nModeRecords);
 
 	DATATBLS_UnloadBin(pPlrType);
 	DATATBLS_UnloadBin(pPlrMode);
@@ -1372,10 +1372,10 @@ void __fastcall DATATBLS_LoadMonModeTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL },
 	};
 
-	gpDataTables.pMonModeDataTables.pMonModeTxt = (D2MonModeTxt*)DATATBLS_CompileTxt(pMemPool, "monmode", pTbl, &gpDataTables.pMonModeDataTables.nMonModeTxtRecordCount, sizeof(D2MonModeTxt));
+	sgptDataTables->pMonModeDataTables.pMonModeTxt = (D2MonModeTxt*)DATATBLS_CompileTxt(pMemPool, "monmode", pTbl, &sgptDataTables->pMonModeDataTables.nMonModeTxtRecordCount, sizeof(D2MonModeTxt));
 
-	gpDataTables.pMonModeDataTables.pMonMode[0] = gpDataTables.pMonModeDataTables.pMonModeTxt;
-	gpDataTables.pMonModeDataTables.pMonMode[1] = gpDataTables.pMonModeDataTables.pMonModeTxt;
+	sgptDataTables->pMonModeDataTables.pMonMode[0] = sgptDataTables->pMonModeDataTables.pMonModeTxt;
+	sgptDataTables->pMonModeDataTables.pMonMode[1] = sgptDataTables->pMonModeDataTables.pMonModeTxt;
 }
 
 //D2Common.0x6FD72E50
@@ -1398,17 +1398,17 @@ void __fastcall DATATBLS_LoadObjType_ModeTxt(void* pMemPool)
 	pObjType = (D2ObjModeTypeTxt*)DATATBLS_CompileTxt(pMemPool, "objtype", pTbl, &nTypeRecords, sizeof(D2ObjModeTypeTxt));
 	pObjMode = (D2ObjModeTypeTxt*)DATATBLS_CompileTxt(pMemPool, "objmode", pTbl, &nModeRecords, sizeof(D2ObjModeTypeTxt));
 
-	gpDataTables.pObjModeDataTables.nObjModeTypeTxtRecordCount = nModeRecords + nTypeRecords;
+	sgptDataTables->pObjModeDataTables.nObjModeTypeTxtRecordCount = nModeRecords + nTypeRecords;
 
 	pObjModeTypeTxt = (D2ObjModeTypeTxt*)FOG_AllocServerMemory(NULL, sizeof(D2ObjModeTypeTxt) * (nModeRecords + nTypeRecords), __FILE__, __LINE__, 0);
 	D2_ASSERT(pObjModeTypeTxt);
 
-	gpDataTables.pObjModeDataTables.pObjModeTypeTxt = pObjModeTypeTxt;
-	gpDataTables.pObjModeDataTables.pObjType = pObjModeTypeTxt;
-	gpDataTables.pObjModeDataTables.pObjMode = (D2ObjModeTypeTxt*)((char*)pObjModeTypeTxt + sizeof(D2ObjModeTypeTxt) * nTypeRecords);
+	sgptDataTables->pObjModeDataTables.pObjModeTypeTxt = pObjModeTypeTxt;
+	sgptDataTables->pObjModeDataTables.pObjType = pObjModeTypeTxt;
+	sgptDataTables->pObjModeDataTables.pObjMode = (D2ObjModeTypeTxt*)((char*)pObjModeTypeTxt + sizeof(D2ObjModeTypeTxt) * nTypeRecords);
 
-	memcpy(gpDataTables.pObjModeDataTables.pObjType, pObjType, sizeof(D2ObjModeTypeTxt) * nTypeRecords);
-	memcpy(gpDataTables.pObjModeDataTables.pObjMode, pObjMode, sizeof(D2ObjModeTypeTxt) * nModeRecords);
+	memcpy(sgptDataTables->pObjModeDataTables.pObjType, pObjType, sizeof(D2ObjModeTypeTxt) * nTypeRecords);
+	memcpy(sgptDataTables->pObjModeDataTables.pObjMode, pObjMode, sizeof(D2ObjModeTypeTxt) * nModeRecords);
 	DATATBLS_UnloadBin(pObjType);
 	DATATBLS_UnloadBin(pObjMode);
 }
@@ -1423,7 +1423,7 @@ void __fastcall DATATBLS_LoadCompositTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL }
 	};
 
-	gpDataTables.pCompositTxt = (D2CompositTxt*)DATATBLS_CompileTxt(pMemPool, "composit", pTbl, NULL, sizeof(D2CompositTxt));
+	sgptDataTables->pCompositTxt = (D2CompositTxt*)DATATBLS_CompileTxt(pMemPool, "composit", pTbl, NULL, sizeof(D2CompositTxt));
 }
 
 //D2Common.0x6FD73040
@@ -1436,90 +1436,90 @@ void __fastcall DATATBLS_LoadArmTypeTxt(void* pMemPool)
 		{ "end", 0, 0, 0, NULL }
 	};
 
-	gpDataTables.pArmTypeTxt = (D2ArmTypeTxt*)DATATBLS_CompileTxt(pMemPool, "armtype", pTbl, NULL, sizeof(D2ArmTypeTxt));
+	sgptDataTables->pArmTypeTxt = (D2ArmTypeTxt*)DATATBLS_CompileTxt(pMemPool, "armtype", pTbl, NULL, sizeof(D2ArmTypeTxt));
 }
 
 //D2Common.0x6FD730C0
 void __fastcall DATATBLS_UnloadPlrMode_Type_MonMode_ObjMode_Type_Composit_ArmtypeTxt()
 {
-	if (gpDataTables.pPlrModeDataTables.pPlrModeTypeTxt)
+	if (sgptDataTables->pPlrModeDataTables.pPlrModeTypeTxt)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pPlrModeDataTables.pPlrModeTypeTxt, __FILE__, __LINE__, 0);
-		gpDataTables.pPlrModeDataTables.pPlrModeTypeTxt = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pPlrModeDataTables.pPlrModeTypeTxt, __FILE__, __LINE__, 0);
+		sgptDataTables->pPlrModeDataTables.pPlrModeTypeTxt = NULL;
 	}
 
-	if (gpDataTables.pMonModeDataTables.pMonModeTxt)
+	if (sgptDataTables->pMonModeDataTables.pMonModeTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pMonModeDataTables.pMonModeTxt);
-		gpDataTables.pMonModeDataTables.pMonModeTxt = NULL;
+		DATATBLS_UnloadBin(sgptDataTables->pMonModeDataTables.pMonModeTxt);
+		sgptDataTables->pMonModeDataTables.pMonModeTxt = NULL;
 	}
 
-	if (gpDataTables.pObjModeDataTables.pObjModeTypeTxt)
+	if (sgptDataTables->pObjModeDataTables.pObjModeTypeTxt)
 	{
-		FOG_FreeServerMemory(NULL, gpDataTables.pObjModeDataTables.pObjModeTypeTxt, __FILE__, __LINE__, 0);
-		gpDataTables.pObjModeDataTables.pObjModeTypeTxt = NULL;
+		FOG_FreeServerMemory(NULL, sgptDataTables->pObjModeDataTables.pObjModeTypeTxt, __FILE__, __LINE__, 0);
+		sgptDataTables->pObjModeDataTables.pObjModeTypeTxt = NULL;
 	}
 
-	if (gpDataTables.pCompositTxt)
+	if (sgptDataTables->pCompositTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pCompositTxt);
-		gpDataTables.pCompositTxt = NULL;
+		DATATBLS_UnloadBin(sgptDataTables->pCompositTxt);
+		sgptDataTables->pCompositTxt = NULL;
 	}
 
-	if (gpDataTables.pArmTypeTxt)
+	if (sgptDataTables->pArmTypeTxt)
 	{
-		DATATBLS_UnloadBin(gpDataTables.pArmTypeTxt);
-		gpDataTables.pArmTypeTxt = NULL;
+		DATATBLS_UnloadBin(sgptDataTables->pArmTypeTxt);
+		sgptDataTables->pArmTypeTxt = NULL;
 	}
 }
 
 //D2Common.0x6FD73150 (#10643)
 D2PlrModeDataTbl* __fastcall DATATBLS_GetPlrMode_TypeDataTables()
 {
-	return &gpDataTables.pPlrModeDataTables;
+	return &sgptDataTables->pPlrModeDataTables;
 }
 
 //D2Common.0x6FD73160 (#10644)
 D2MonModeDataTbl* __fastcall DATATBLS_GetMonModeDataTables()
 {
-	return &gpDataTables.pMonModeDataTables;
+	return &sgptDataTables->pMonModeDataTables;
 }
 
 //D2Common.0x6FD73170 (#10645)
 D2ObjModeDataTbl* __fastcall DATATBLS_GetObjMode_TypeDataTables()
 {
-	return &gpDataTables.pObjModeDataTables;
+	return &sgptDataTables->pObjModeDataTables;
 }
 
 //D2Common.0x6FD73180 (#10646)
 D2PlrModeTypeTxt* __stdcall DATATBLS_GetPlrModeTypeTxtRecord(int nIndex, int bGetMode)
 {
-	if (nIndex >= gpDataTables.pPlrModeDataTables.nPlrModeTypeTxtRecordCount)
+	if (nIndex >= sgptDataTables->pPlrModeDataTables.nPlrModeTypeTxtRecordCount)
 	{
 		return NULL;
 	}
 
-	D2_ASSERT(gpDataTables.pPlrModeDataTables.pPlrModeTypeTxt);
+	D2_ASSERT(sgptDataTables->pPlrModeDataTables.pPlrModeTypeTxt);
 
 	if (bGetMode)
 	{
 		if (bGetMode == 1)
 		{
-			D2_ASSERT(&gpDataTables.pPlrModeDataTables.pPlayerMode[nIndex]);
-			return &gpDataTables.pPlrModeDataTables.pPlayerMode[nIndex];
+			D2_ASSERT(&sgptDataTables->pPlrModeDataTables.pPlayerMode[nIndex]);
+			return &sgptDataTables->pPlrModeDataTables.pPlayerMode[nIndex];
 		}
 		return NULL;
 	}
 
-	D2_ASSERT(&gpDataTables.pPlrModeDataTables.pPlayerType[nIndex]);
+	D2_ASSERT(&sgptDataTables->pPlrModeDataTables.pPlayerType[nIndex]);
 
-	return &gpDataTables.pPlrModeDataTables.pPlayerType[nIndex];
+	return &sgptDataTables->pPlrModeDataTables.pPlayerType[nIndex];
 }
 
 //D2Common.0x6FD73230 (#10647)
 D2MonModeTxt* __stdcall DATATBLS_GetMonModeTxtRecord(int nIndex, int bGetMode)
 {
-	if (nIndex >= gpDataTables.pMonModeDataTables.nMonModeTxtRecordCount)
+	if (nIndex >= sgptDataTables->pMonModeDataTables.nMonModeTxtRecordCount)
 	{
 		return NULL;
 	}
@@ -1528,21 +1528,21 @@ D2MonModeTxt* __stdcall DATATBLS_GetMonModeTxtRecord(int nIndex, int bGetMode)
 	{
 		if (bGetMode == 1)
 		{
-			D2_ASSERT(&gpDataTables.pMonModeDataTables.pMonMode[1][nIndex]);
-			return &gpDataTables.pMonModeDataTables.pMonMode[1][nIndex];
+			D2_ASSERT(&sgptDataTables->pMonModeDataTables.pMonMode[1][nIndex]);
+			return &sgptDataTables->pMonModeDataTables.pMonMode[1][nIndex];
 		}
 		return NULL;
 	}
 
-	D2_ASSERT(&gpDataTables.pMonModeDataTables.pMonMode[0][nIndex]);
+	D2_ASSERT(&sgptDataTables->pMonModeDataTables.pMonMode[0][nIndex]);
 
-	return &gpDataTables.pMonModeDataTables.pMonMode[0][nIndex];
+	return &sgptDataTables->pMonModeDataTables.pMonMode[0][nIndex];
 }
 
 //D2Common.0x6FD732B0 (#10648)
 D2ObjModeTypeTxt* __stdcall DATATBLS_GetObjModeTypeTxtRecord(int nIndex, int bGetMode)
 {
-	if (nIndex >= gpDataTables.pObjModeDataTables.nObjModeTypeTxtRecordCount)
+	if (nIndex >= sgptDataTables->pObjModeDataTables.nObjModeTypeTxtRecordCount)
 	{
 		return NULL;
 	}
@@ -1551,29 +1551,29 @@ D2ObjModeTypeTxt* __stdcall DATATBLS_GetObjModeTypeTxtRecord(int nIndex, int bGe
 	{
 		if (bGetMode == 1)
 		{
-			D2_ASSERT(&gpDataTables.pObjModeDataTables.pObjMode[nIndex]);
-			return &gpDataTables.pObjModeDataTables.pObjMode[nIndex];
+			D2_ASSERT(&sgptDataTables->pObjModeDataTables.pObjMode[nIndex]);
+			return &sgptDataTables->pObjModeDataTables.pObjMode[nIndex];
 		}
 		return NULL;
 	}
 
-	D2_ASSERT(&gpDataTables.pObjModeDataTables.pObjType[nIndex]);
-	return &gpDataTables.pObjModeDataTables.pObjType[nIndex];
+	D2_ASSERT(&sgptDataTables->pObjModeDataTables.pObjType[nIndex]);
+	return &sgptDataTables->pObjModeDataTables.pObjType[nIndex];
 }
 
 //D2Common.0x6FD73330 (#10649)
 D2CompositTxt* __stdcall DATATBLS_GetCompositTxtRecord(int nComposit)
 {
-	D2_ASSERT(&gpDataTables.pCompositTxt[nComposit]);
+	D2_ASSERT(&sgptDataTables->pCompositTxt[nComposit]);
 
-	return &gpDataTables.pCompositTxt[nComposit];
+	return &sgptDataTables->pCompositTxt[nComposit];
 }
 
 //D2Common.0x6FD73370 (#10650)
 D2ArmTypeTxt* __stdcall DATATBLS_GetArmTypeTxtRecord(int nId)
 {
-	D2_ASSERT(&gpDataTables.pArmTypeTxt[nId]);
-	return &gpDataTables.pArmTypeTxt[nId];
+	D2_ASSERT(&sgptDataTables->pArmTypeTxt[nId]);
+	return &sgptDataTables->pArmTypeTxt[nId];
 }
 
 //D2Common.0x6FD733B0 (#10667)

--- a/source/D2Common/src/Drlg/DrlgDrlg.cpp
+++ b/source/D2Common/src/Drlg/DrlgDrlg.cpp
@@ -40,7 +40,7 @@ D2DrlgStrc* __fastcall DRLG_AllocDrlg(D2DrlgActStrc* pAct, BYTE nActNo, void* a3
 	pDrlg->pfAutomap = pfAutoMap;
 	pDrlg->pfTownAutomap = pfTownAutoMap;
 
-	szPath[0] = gpDataTables.szDefaultString;
+	szPath[0] = sgptDataTables->szDefaultString;
 
 	switch (nActNo)
 	{

--- a/source/D2Common/src/Drlg/DrlgDrlgAnim.cpp
+++ b/source/D2Common/src/Drlg/DrlgDrlgAnim.cpp
@@ -201,7 +201,7 @@ void __fastcall DRLGANIM_AllocAnimationTileGrid(D2RoomExStrc* pRoomEx, int nAnim
 				}
 
 				memset(szBuffer, 0x00, sizeof(szBuffer));
-				szBuffer[0] = gpDataTables.szDefaultString;
+				szBuffer[0] = sgptDataTables->szDefaultString;
 
 				if (nIndex >= nFrames)
 				{

--- a/source/D2Common/src/Drlg/DrlgPreset.cpp
+++ b/source/D2Common/src/Drlg/DrlgPreset.cpp
@@ -254,14 +254,14 @@ void __fastcall DRLGPRESET_ParseDS1File(D2DrlgFileStrc* pDrlgFile, void* pMemPoo
 						{
 						case 0:
 							nUnitId += DATATBLS_GetSuperUniquesTxtRecordCount();
-							nUnitId += gpDataTables.nMonStatsTxtRecordCount;
+							nUnitId += sgptDataTables->nMonStatsTxtRecordCount;
 							break;
 
 						case 1:
 							break;
 
 						case 2:
-							nUnitId += gpDataTables.nMonStatsTxtRecordCount;
+							nUnitId += sgptDataTables->nMonStatsTxtRecordCount;
 							break;
 
 						default:
@@ -695,9 +695,9 @@ void __fastcall DRLGPRESET_AddPresetUnitToDrlgMap(void* pMemPool, D2DrlgMapStrc*
 		if (pPresetUnit->nUnitType == UNIT_MONSTER)
 		{
 			nIndex = pPresetUnit->nIndex;
-			if (nIndex < gpDataTables.nMonStatsTxtRecordCount)
+			if (nIndex < sgptDataTables->nMonStatsTxtRecordCount)
 			{
-				if (nIndex < 0 || nIndex >= gpDataTables.nMonStatsTxtRecordCount)
+				if (nIndex < 0 || nIndex >= sgptDataTables->nMonStatsTxtRecordCount)
 				{
 					nIndex = -1;
 				}
@@ -720,23 +720,23 @@ void __fastcall DRLGPRESET_AddPresetUnitToDrlgMap(void* pMemPool, D2DrlgMapStrc*
 			}
 			else
 			{
-				if (pPresetUnit->nIndex - gpDataTables.nMonStatsTxtRecordCount >= DATATBLS_GetSuperUniquesTxtRecordCount())
+				if (pPresetUnit->nIndex - sgptDataTables->nMonStatsTxtRecordCount >= DATATBLS_GetSuperUniquesTxtRecordCount())
 				{
-					if (pPresetUnit->nIndex - gpDataTables.nMonStatsTxtRecordCount - DATATBLS_GetSuperUniquesTxtRecordCount() == SUPERUNIQUE_THE_TORMENTOR)
+					if (pPresetUnit->nIndex - sgptDataTables->nMonStatsTxtRecordCount - DATATBLS_GetSuperUniquesTxtRecordCount() == SUPERUNIQUE_THE_TORMENTOR)
 					{
 						if (!(SEED_RollRandomNumber(pSeed) & 3))
 						{
 							continue;
 						}
 					}
-					else if (pPresetUnit->nIndex - gpDataTables.nMonStatsTxtRecordCount - DATATBLS_GetSuperUniquesTxtRecordCount() == SUPERUNIQUE_TAINTBREEDER)
+					else if (pPresetUnit->nIndex - sgptDataTables->nMonStatsTxtRecordCount - DATATBLS_GetSuperUniquesTxtRecordCount() == SUPERUNIQUE_TAINTBREEDER)
 					{
 						if (!(SEED_RollRandomNumber(pSeed) & 1))
 						{
 							continue;
 						}
 					}
-					else if (pPresetUnit->nIndex - gpDataTables.nMonStatsTxtRecordCount - DATATBLS_GetSuperUniquesTxtRecordCount() == SUPERUNIQUE_RIFTWRAITH_THE_CANNIBAL)
+					else if (pPresetUnit->nIndex - sgptDataTables->nMonStatsTxtRecordCount - DATATBLS_GetSuperUniquesTxtRecordCount() == SUPERUNIQUE_RIFTWRAITH_THE_CANNIBAL)
 					{
 						if (SEED_RollRandomNumber(pSeed) & 3)
 						{

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -1438,7 +1438,7 @@ void __fastcall DRLGROOMTILE_LoadDT1FilesForRoom(D2RoomExStrc* pRoomEx)
 		++nCounter;
 	}
 
-	szPath[0] = gpDataTables.szDefaultString;
+	szPath[0] = sgptDataTables->szDefaultString;
 
 	wsprintfA(szPath, "%s\\Tiles\\Act1\\Outdoors\\Blank.dt1", "DATA\\GLOBAL");
 	D2CMP_10087_LoadTileLibrarySlot(pRoomEx->pTiles, szPath);

--- a/source/D2Common/src/Items/ItemMods.cpp
+++ b/source/D2Common/src/Items/ItemMods.cpp
@@ -542,7 +542,7 @@ BOOL __stdcall ITEMMODS_GetItemCharges(D2UnitStrc* pItem, int nSkillId, int nSki
 	{
 		do
 		{
-			nValue = STATLIST_GetStatValue(pStatList, STAT_ITEM_CHARGED_SKILL, (nSkillLevel & gpDataTables.nShiftedStuff) + (nSkillId << gpDataTables.nStuff));
+			nValue = STATLIST_GetStatValue(pStatList, STAT_ITEM_CHARGED_SKILL, (nSkillLevel & sgptDataTables->nShiftedStuff) + (nSkillId << sgptDataTables->nStuff));
 			if (nValue)
 			{
 				break;
@@ -594,7 +594,7 @@ BOOL __stdcall ITEMMODS_UpdateItemWithSkillCharges(D2UnitStrc* pItem, int nSkill
 
 	if (pItem && pItem->dwUnitType == UNIT_ITEM)
 	{
-		nLayer = (nSkillLevel & gpDataTables.nShiftedStuff) + (nSkillId << gpDataTables.nStuff);
+		nLayer = (nSkillLevel & sgptDataTables->nShiftedStuff) + (nSkillId << sgptDataTables->nStuff);
 
 		pStatList = STATLIST_GetStatListFromUnitAndFlag(pItem, 0x40);
 		while (pStatList)
@@ -1643,7 +1643,7 @@ BOOL __fastcall sub_6FD94190(int nType, D2UnitStrc* pUnit, D2UnitStrc* pItem, D2
 	{
 		nTemp = (ITEMS_GetItemLevel(pItem) - SKILLS_GetRequiredLevel(nSkillId)) / 4 + 1;
 
-		nMaxLevel = gpDataTables.pSkillsTxt[nSkillId].wMaxLvl;
+		nMaxLevel = sgptDataTables->pSkillsTxt[nSkillId].wMaxLvl;
 		if (nMaxLevel <= 0)
 		{
 			nMaxLevel = 20;
@@ -1722,7 +1722,7 @@ BOOL __fastcall sub_6FD94190(int nType, D2UnitStrc* pUnit, D2UnitStrc* pItem, D2
 	nRand = SEED_RollLimitedRandomNumber(ITEMS_GetItemSeed(pItem), nTemp - nTemp / 8);
 
 	pStatList = ITEMMODS_GetOrCreateStatList(pUnit, pItem, nState, fStatList);
-	STATLIST_SetStatIfListIsValid(pStatList, nStatId, (nTemp << 8) + ((nRand + nTemp / 8 + 1) & 0xFF), (nLevel & ((WORD)gpDataTables.nShiftedStuff)) + (nSkillId << gpDataTables.nStuff));
+	STATLIST_SetStatIfListIsValid(pStatList, nStatId, (nTemp << 8) + ((nRand + nTemp / 8 + 1) & 0xFF), (nLevel & ((WORD)sgptDataTables->nShiftedStuff)) + (nSkillId << sgptDataTables->nStuff));
 
 	return 1;
 }
@@ -2339,9 +2339,9 @@ void __stdcall ITEMMODS_AssignProperty(int nType, D2UnitStrc* a2, D2UnitStrc* pI
 	{
 		nFileIndex = ITEMS_GetFileIndex(pItem);
 
-		if (nFileIndex >= 0 && nFileIndex < gpDataTables.nUniqueItemsTxtRecordCount)
+		if (nFileIndex >= 0 && nFileIndex < sgptDataTables->nUniqueItemsTxtRecordCount)
 		{
-			pUniqueItemsTxtRecord = &gpDataTables.pUniqueItemsTxt[nFileIndex];
+			pUniqueItemsTxtRecord = &sgptDataTables->pUniqueItemsTxt[nFileIndex];
 			if (pUniqueItemsTxtRecord)
 			{
 				for (int i = 0; i < ARRAY_SIZE(pUniqueItemsTxtRecord->pProperties); ++i)
@@ -2357,9 +2357,9 @@ void __stdcall ITEMMODS_AssignProperty(int nType, D2UnitStrc* a2, D2UnitStrc* pI
 	case PROPMODE_SET:
 	{
 		nFileIndex = ITEMS_GetFileIndex(pItem);
-		if (nFileIndex >= 0 && nFileIndex < gpDataTables.nSetItemsTxtRecordCount)
+		if (nFileIndex >= 0 && nFileIndex < sgptDataTables->nSetItemsTxtRecordCount)
 		{
-			pSetItemsTxtRecord = &gpDataTables.pSetItemsTxt[nFileIndex];
+			pSetItemsTxtRecord = &sgptDataTables->pSetItemsTxt[nFileIndex];
 			if (pSetItemsTxtRecord)
 			{
 				if (ITEMS_GetItemFormat(pItem))
@@ -2473,7 +2473,7 @@ void __fastcall sub_6FD95810(int nType, D2UnitStrc* pUnit, D2UnitStrc* pItem, vo
 	{
 		D2_ASSERT(pProperty);
 
-		if (pProperty->nProperty >= 0 && pProperty->nProperty < gpDataTables.nPropertiesTxtRecordCount)
+		if (pProperty->nProperty >= 0 && pProperty->nProperty < sgptDataTables->nPropertiesTxtRecordCount)
 		{
 			if (stru_6FDE3160[pProperty->nProperty].pfAssign)
 			{
@@ -2557,12 +2557,12 @@ void __fastcall ITEMMODS_UpdateFullSetBoni(D2UnitStrc* pUnit, D2UnitStrc* pItem,
 	if (nState && pItem && pItem->dwUnitType == UNIT_ITEM && ITEMS_GetItemQuality(pItem) == ITEMQUAL_SET)
 	{
 		nFileIndex = ITEMS_GetFileIndex(pItem);
-		if (nFileIndex >= 0 && nFileIndex < gpDataTables.nSetItemsTxtRecordCount)
+		if (nFileIndex >= 0 && nFileIndex < sgptDataTables->nSetItemsTxtRecordCount)
 		{
-			pSetItemsTxtRecord = &gpDataTables.pSetItemsTxt[nFileIndex];
-			if (pSetItemsTxtRecord && pSetItemsTxtRecord->nSetId >= 0 && pSetItemsTxtRecord->nSetId < gpDataTables.nSetsTxtRecordCount)
+			pSetItemsTxtRecord = &sgptDataTables->pSetItemsTxt[nFileIndex];
+			if (pSetItemsTxtRecord && pSetItemsTxtRecord->nSetId >= 0 && pSetItemsTxtRecord->nSetId < sgptDataTables->nSetsTxtRecordCount)
 			{
-				pSetsTxtRecord = &gpDataTables.pSetsTxt[pSetItemsTxtRecord->nSetId];
+				pSetsTxtRecord = &sgptDataTables->pSetsTxt[pSetItemsTxtRecord->nSetId];
 				if (pSetsTxtRecord)
 				{
 					nSetItemsMask = ITEMS_GetSetItemsMask(pUnit, pItem, 1);
@@ -2617,9 +2617,9 @@ BOOL __stdcall ITEMMODS_CanItemHaveMagicAffix(D2UnitStrc* pItem, D2MagicAffixTxt
 
 	if (ITEMS_GetItemFormat(pItem) >= 100 || !ITEMS_CheckIfStackable(pItem) && !ITEMS_CheckIfThrowable(pItem))
 	{
-		if (ITEMS_CheckIfSocketable(pItem) && ITEMS_GetMaxSockets(pItem) || pMagicAffixTxtRecord->pProperties[0].nProperty < 0 || pMagicAffixTxtRecord->pProperties[0].nProperty < gpDataTables.nPropertiesTxtRecordCount)
+		if (ITEMS_CheckIfSocketable(pItem) && ITEMS_GetMaxSockets(pItem) || pMagicAffixTxtRecord->pProperties[0].nProperty < 0 || pMagicAffixTxtRecord->pProperties[0].nProperty < sgptDataTables->nPropertiesTxtRecordCount)
 		{
-			pPropertiesTxtRecord = &gpDataTables.pPropertiesTxt[pMagicAffixTxtRecord->pProperties[0].nProperty];
+			pPropertiesTxtRecord = &sgptDataTables->pPropertiesTxt[pMagicAffixTxtRecord->pProperties[0].nProperty];
 			if (pPropertiesTxtRecord && pPropertiesTxtRecord->wStat[0] != STAT_ITEM_NUMSOCKETS)
 			{
 				for (int i = 0; i < ARRAY_SIZE(pMagicAffixTxtRecord->wEType); ++i)
@@ -3611,7 +3611,7 @@ int __fastcall ITEMMODS_PropertyFunc11(int nType, D2UnitStrc* pUnit, D2UnitStrc*
 		{
 			nLevel = (ITEMS_GetItemLevel(pItem) - SKILLS_GetRequiredLevel(pProperty->nLayer)) / 4 + 1;
 
-			nMaxLevel = gpDataTables.pSkillsTxt[pProperty->nLayer].wMaxLvl;
+			nMaxLevel = sgptDataTables->pSkillsTxt[pProperty->nLayer].wMaxLvl;
 			if (nMaxLevel <= 0)
 			{
 				nMaxLevel = 20;
@@ -3745,7 +3745,7 @@ int __fastcall ITEMMODS_PropertyFunc19(int nType, D2UnitStrc* pUnit, D2UnitStrc*
 	{
 		nTemp = (ITEMS_GetItemLevel(pItem) - SKILLS_GetRequiredLevel(nSkillId)) / 4 + 1;
 
-		nMaxLevel = gpDataTables.pSkillsTxt[nSkillId].wMaxLvl;
+		nMaxLevel = sgptDataTables->pSkillsTxt[nSkillId].wMaxLvl;
 		if (nMaxLevel <= 0)
 		{
 			nMaxLevel = 20;
@@ -3824,7 +3824,7 @@ int __fastcall ITEMMODS_PropertyFunc19(int nType, D2UnitStrc* pUnit, D2UnitStrc*
 	nRand = SEED_RollLimitedRandomNumber(ITEMS_GetItemSeed(pItem), nTemp - nTemp / 8);
 
 	pStatList = ITEMMODS_GetOrCreateStatList(pUnit, pItem, nState, fStatList);
-	STATLIST_SetStatIfListIsValid(pStatList, nStatId, (nTemp << 8) + ((nRand + nTemp / 8 + 1) & 0xFF), (nLevel & ((WORD)gpDataTables.nShiftedStuff)) + (nSkillId << gpDataTables.nStuff));
+	STATLIST_SetStatIfListIsValid(pStatList, nStatId, (nTemp << 8) + ((nRand + nTemp / 8 + 1) & 0xFF), (nLevel & ((WORD)sgptDataTables->nShiftedStuff)) + (nSkillId << sgptDataTables->nStuff));
 
 	return nTemp;
 }
@@ -4231,9 +4231,9 @@ void __stdcall D2COMMON_11292_ItemAssignProperty(int nType, D2UnitStrc* pUnit, D
 	int nFirstValue = 0;
 	int nResult = 0;
 
-	if (pProperty && pProperty->nProperty >= 0 && pProperty->nProperty < gpDataTables.nPropertiesTxtRecordCount)
+	if (pProperty && pProperty->nProperty >= 0 && pProperty->nProperty < sgptDataTables->nPropertiesTxtRecordCount)
 	{
-		pPropertiesTxtRecord = &gpDataTables.pPropertiesTxt[pProperty->nProperty];
+		pPropertiesTxtRecord = &sgptDataTables->pPropertiesTxt[pProperty->nProperty];
 		if (pPropertiesTxtRecord)
 		{
 			for (int i = 0; i < ARRAY_SIZE(pPropertiesTxtRecord->nFunc); ++i)
@@ -4313,12 +4313,12 @@ int __stdcall ITEMMODS_EvaluateItemFormula(D2UnitStrc* pUnit, D2UnitStrc* pItem,
 {
 	D2ItemCalcStrc pItemCalc = {};
 
-	if (gpDataTables.pItemsCode && nCalc < gpDataTables.nItemsCodeSize)
+	if (sgptDataTables->pItemsCode && nCalc < sgptDataTables->nItemsCodeSize)
 	{
 		pItemCalc.pUnit = pUnit;
 		pItemCalc.pItem = pItem;
 
-		return FOG_10253(&gpDataTables.pItemsCode[nCalc], gpDataTables.nItemsCodeSize - nCalc, D2COMMON_10018_Return0, off_6FDE3BA0, dword_6FDE3BC0, &pItemCalc);
+		return FOG_10253(&sgptDataTables->pItemsCode[nCalc], sgptDataTables->nItemsCodeSize - nCalc, D2COMMON_10018_Return0, off_6FDE3BA0, dword_6FDE3BC0, &pItemCalc);
 	}
 
 	return 0;

--- a/source/D2Common/src/Monsters/Monsters.cpp
+++ b/source/D2Common/src/Monsters/Monsters.cpp
@@ -789,7 +789,7 @@ BOOL __stdcall MONSTESR_IsSandLeaper(D2UnitStrc* pMonster, BOOL bAlwaysReturnFal
 		nClassId = -1;
 	}
 
-	if (gpDataTables.nMonStatsTxtRecordCount > MONSTER_SANDLEAPER1)
+	if (sgptDataTables->nMonStatsTxtRecordCount > MONSTER_SANDLEAPER1)
 	{
 		if (nClassId == MONSTER_SANDLEAPER1)
 		{
@@ -910,7 +910,7 @@ int __stdcall MONSTERS_GetSpawnMode_XY(D2UnitStrc* pMonster, BOOL bFromMonster, 
 	else
 	{
 		pSkillsTxtRecord = DATATBLS_GetSkillsTxtRecord(nSkillId);
-		if (pSkillsTxtRecord && pSkillsTxtRecord->wSummon >= 0 && pSkillsTxtRecord->wSummon < gpDataTables.nMonStatsTxtRecordCount)
+		if (pSkillsTxtRecord && pSkillsTxtRecord->wSummon >= 0 && pSkillsTxtRecord->wSummon < sgptDataTables->nMonStatsTxtRecordCount)
 		{
 			UNITS_GetCoords(pMonster, &pCoords);
 
@@ -951,7 +951,7 @@ void __stdcall MONSTERS_GetMinionSpawnInfo(D2UnitStrc* pMonster, int* pId, int* 
 	{
 		nBaseId = MONSTERS_GetBaseIdFromMonsterId(pMonster->dwClassId);
 
-		if (nBaseId < 0 || nBaseId >= gpDataTables.nMonStatsTxtRecordCount)
+		if (nBaseId < 0 || nBaseId >= sgptDataTables->nMonStatsTxtRecordCount)
 		{
 			nBaseId = -1;
 		}
@@ -1313,7 +1313,7 @@ int __fastcall MONSTERS_GetClassIdFromMonsterChain(int nMonsterId, int nChainId)
 //D2Common.0x6FDA69C0
 int __fastcall MONSTERS_ValidateMonsterId(int nMonsterId)
 {
-	if (nMonsterId >= 0 && nMonsterId < gpDataTables.nMonStatsTxtRecordCount)
+	if (nMonsterId >= 0 && nMonsterId < sgptDataTables->nMonStatsTxtRecordCount)
 	{
 		return nMonsterId;
 	}

--- a/source/D2Common/src/Units/Missile.cpp
+++ b/source/D2Common/src/Units/Missile.cpp
@@ -1547,14 +1547,14 @@ int __stdcall MISSILE_EvaluateMissileFormula(D2UnitStrc* pMissile, D2UnitStrc* p
 		nMissile = nMissileId;
 	}
 
-	if (gpDataTables.pMissCode && nCalc < gpDataTables.nMissCodeSize)
+	if (sgptDataTables->pMissCode && nCalc < sgptDataTables->nMissCodeSize)
 	{
 		pMissileCalc.pMissile = pMissile;
 		pMissileCalc.pOwner = pOwner;
 		pMissileCalc.nMissileId = nMissile;
 		pMissileCalc.nMissileLevel = nMissileLevel;
 
-		return FOG_10253(&gpDataTables.pMissCode[nCalc], gpDataTables.nMissCodeSize - nCalc, MISSILE_GetCalcParamValue, off_6FDE5A50, dword_6FDE5A70, &pMissileCalc);
+		return FOG_10253(&sgptDataTables->pMissCode[nCalc], sgptDataTables->nMissCodeSize - nCalc, MISSILE_GetCalcParamValue, off_6FDE5A50, dword_6FDE5A70, &pMissileCalc);
 	}
 
 	return 0;

--- a/source/D2Common/src/Units/Units.cpp
+++ b/source/D2Common/src/Units/Units.cpp
@@ -672,10 +672,10 @@ void __stdcall UNITS_SetTargetUnitForPlayerOrMonster(D2UnitStrc* pUnit, D2UnitSt
 //D2Common.0x6FDBE470 (#10354)
 void __stdcall UNITS_GetRunAndWalkSpeedForPlayer(int nUnused, int nCharId, int* pWalkSpeed, int* pRunSpeed)
 {
-	if (nCharId >= 0 && nCharId < gpDataTables.nCharStatsTxtRecordCount)
+	if (nCharId >= 0 && nCharId < sgptDataTables->nCharStatsTxtRecordCount)
 	{
-		*pWalkSpeed = gpDataTables.pCharStatsTxt[nCharId].nWalkSpeed;
-		*pRunSpeed = gpDataTables.pCharStatsTxt[nCharId].nRunSpeed;
+		*pWalkSpeed = sgptDataTables->pCharStatsTxt[nCharId].nWalkSpeed;
+		*pRunSpeed = sgptDataTables->pCharStatsTxt[nCharId].nRunSpeed;
 	}
 }
 
@@ -729,9 +729,9 @@ void __stdcall UNITS_SetAnimStartFrame(D2UnitStrc* pUnit)
 		if (nNewMode == PLRMODE_RUN || nNewMode == PLRMODE_KNOCKBACK)
 		{
 			pStatList = STATLIST_AllocStatList(pUnit->pMemoryPool, 4, 0, pUnit->dwUnitType, pUnit->dwUnitId);
-			if (nClassId >= 0 && nClassId < gpDataTables.nCharStatsTxtRecordCount)
+			if (nClassId >= 0 && nClassId < sgptDataTables->nCharStatsTxtRecordCount)
 			{
-				pCharStatsTxtRecord = &gpDataTables.pCharStatsTxt[nClassId];
+				pCharStatsTxtRecord = &sgptDataTables->pCharStatsTxt[nClassId];
 				if (pCharStatsTxtRecord && pCharStatsTxtRecord->nWalkSpeed)
 				{
 					STATLIST_SetStat(pStatList, STAT_VELOCITYPERCENT, 100 * (pCharStatsTxtRecord->nRunSpeed / pCharStatsTxtRecord->nWalkSpeed - 1), 0);
@@ -772,9 +772,9 @@ void __stdcall UNITS_SetAnimStartFrame(D2UnitStrc* pUnit)
 		if (pUnit->dwUnitType == UNIT_PLAYER && STATES_IsUnitShapeShifted(pUnit) && (nNewMode == MONMODE_KNOCKBACK || nNewMode == MONMODE_RUN))
 		{
 			pStatList = STATLIST_AllocStatList(pUnit->pMemoryPool, 4, 0, pUnit->dwUnitType, pUnit->dwUnitId);
-			if (pUnit->dwClassId >= 0 && pUnit->dwClassId < gpDataTables.nCharStatsTxtRecordCount)
+			if (pUnit->dwClassId >= 0 && pUnit->dwClassId < sgptDataTables->nCharStatsTxtRecordCount)
 			{
-				pCharStatsTxtRecord = &gpDataTables.pCharStatsTxt[pUnit->dwClassId];
+				pCharStatsTxtRecord = &sgptDataTables->pCharStatsTxt[pUnit->dwClassId];
 				if (pCharStatsTxtRecord && pCharStatsTxtRecord->nWalkSpeed)
 				{
 					STATLIST_SetStat(pStatList, STAT_VELOCITYPERCENT, 100 * (pCharStatsTxtRecord->nRunSpeed / pCharStatsTxtRecord->nWalkSpeed - 1), 0);
@@ -2254,7 +2254,7 @@ void __stdcall UNITS_SetOverlay(D2UnitStrc* pUnit, int nOverlay, int nUnused)
 {
 	D2StatListStrc* pStatList = NULL;
 
-	if (nOverlay >= 0 && nOverlay < gpDataTables.nOverlayTxtRecordCount)
+	if (nOverlay >= 0 && nOverlay < sgptDataTables->nOverlayTxtRecordCount)
 	{
 		pStatList = STATLIST_GetStatListFromUnitAndFlag(pUnit, 0x80);
 		if (!pStatList)
@@ -2546,9 +2546,9 @@ int __stdcall UNITS_GetAttackRate(D2UnitStrc* pAttacker)
 	nDexterity = STATLIST_GetUnitStat(pAttacker, STAT_DEXTERITY, 0);
 	nAttackRate = nToHit + 5 * (nDexterity - 7);
 
-	if (pAttacker->dwUnitType == UNIT_PLAYER && pAttacker->dwClassId >= 0 && pAttacker->dwClassId < gpDataTables.nCharStatsTxtRecordCount)
+	if (pAttacker->dwUnitType == UNIT_PLAYER && pAttacker->dwClassId >= 0 && pAttacker->dwClassId < sgptDataTables->nCharStatsTxtRecordCount)
 	{
-		pCharStatsTxtRecord = &gpDataTables.pCharStatsTxt[pAttacker->dwClassId];
+		pCharStatsTxtRecord = &sgptDataTables->pCharStatsTxt[pAttacker->dwClassId];
 		if (pCharStatsTxtRecord)
 		{
 			return nAttackRate + pCharStatsTxtRecord->dwToHitFactor;
@@ -2584,9 +2584,9 @@ int __stdcall UNITS_GetBlockRate(D2UnitStrc* pUnit, BOOL bExpansion)
 
 	if (pUnit->dwUnitType == UNIT_PLAYER)
 	{
-		if (INVENTORY_GetEquippedShield(pUnit->pInventory, NULL) && pUnit->dwClassId >= 0 && pUnit->dwClassId < gpDataTables.nCharStatsTxtRecordCount)
+		if (INVENTORY_GetEquippedShield(pUnit->pInventory, NULL) && pUnit->dwClassId >= 0 && pUnit->dwClassId < sgptDataTables->nCharStatsTxtRecordCount)
 		{
-			pCharStatsTxtRecord = &gpDataTables.pCharStatsTxt[pUnit->dwClassId];
+			pCharStatsTxtRecord = &sgptDataTables->pCharStatsTxt[pUnit->dwClassId];
 
 			nBlockChance = pCharStatsTxtRecord->nBlockFactor + STATLIST_GetUnitStat(pUnit, STAT_TOBLOCK, 0);
 			if (bExpansion)
@@ -2614,7 +2614,7 @@ int __stdcall UNITS_GetBlockRate(D2UnitStrc* pUnit, BOOL bExpansion)
 		pMonStatsTxtRecord = DATATBLS_GetMonStatsTxtRecord(nClassId);
 		if (!pMonStatsTxtRecord || !(pMonStatsTxtRecord->dwMonStatsFlags & gdwBitMasks[MONSTATSFLAGINDEX_NOSHLDBLOCK]))
 		{
-			if (nClassId < 0 || nClassId >= gpDataTables.nMonStatsTxtRecordCount)
+			if (nClassId < 0 || nClassId >= sgptDataTables->nMonStatsTxtRecordCount)
 			{
 				nClassId = -1;
 			}
@@ -3340,9 +3340,9 @@ void __stdcall UNITS_MergeDualWieldWeaponStatLists(D2UnitStrc* pUnit, int a2)
 //D2Common.0x6FDC1EE0
 D2MonStats2Txt* __fastcall UNITS_GetMonStats2TxtRecord(int nRecordId)
 {
-	if (nRecordId >= 0 && nRecordId < gpDataTables.nMonStats2TxtRecordCount)
+	if (nRecordId >= 0 && nRecordId < sgptDataTables->nMonStats2TxtRecordCount)
 	{
-		return &gpDataTables.pMonStats2Txt[nRecordId];
+		return &sgptDataTables->pMonStats2Txt[nRecordId];
 	}
 
 	return NULL;
@@ -3408,9 +3408,9 @@ D2MonStats2Txt* __fastcall UNITS_GetMonStats2TxtRecordFromMonsterId(int nMonster
 {
 	int nMonStatsEx = DATATBLS_GetMonStatsTxtRecord(nMonsterId)->wMonStatsEx;
 
-	if (nMonStatsEx >= 0 && nMonStatsEx < gpDataTables.nMonStats2TxtRecordCount)
+	if (nMonStatsEx >= 0 && nMonStatsEx < sgptDataTables->nMonStats2TxtRecordCount)
 	{
-		return &gpDataTables.pMonStats2Txt[nMonStatsEx];
+		return &sgptDataTables->pMonStats2Txt[nMonStatsEx];
 	}
 
 	return NULL;
@@ -3858,9 +3858,9 @@ BOOL __stdcall UNITS_IsObjectInInteractRange(D2UnitStrc* pUnit, D2UnitStrc* pObj
 //D2Common.0x6FDC2C80
 D2CharStatsTxt* __fastcall UNITS_GetCharStatsTxtRecord(int nRecordId)
 {
-	if (nRecordId >= 0 && nRecordId < gpDataTables.nCharStatsTxtRecordCount)
+	if (nRecordId >= 0 && nRecordId < sgptDataTables->nCharStatsTxtRecordCount)
 	{
-		return &gpDataTables.pCharStatsTxt[nRecordId];
+		return &sgptDataTables->pCharStatsTxt[nRecordId];
 	}
 
 	return NULL;


### PR DESCRIPTION
This is required so that we can use the datatables from the original game and while using our own functions that use them at the same time.

I simply replaced all code using `gpDataTables.` by `sgptDataTables->`