### PR TITLE
Fix some StatList functions

### DIFF
--- a/source/D2Common/include/D2StatList.h
+++ b/source/D2Common/include/D2StatList.h
@@ -409,23 +409,36 @@ enum D2C_StatlistFlags : uint32_t
 };
 
 
-struct D2StatStrc
+struct D2SLayerStatIdStrc
 {
 	union
 	{
 		struct
 		{
-			uint16_t nLayer;					//0x00
-			uint16_t nStat;						//0x02
+			uint16_t nLayer;				//0x00
+			uint16_t nStat;					//0x02
 		};
-		int32_t nLayer_StatId;					//0x00
+		int32_t nLayer_StatId;				//0x00
 	};
-	int32_t nValue;								//0x04
+};
+
+struct D2StatStrc : D2SLayerStatIdStrc
+{
+	int32_t nValue;							//0x04
 };
 
 struct D2StatsArrayStrc
 {
 	D2StatStrc* pStat;						//0x00 An Array[wStatCount]
+	uint16_t nStatCount;					//0x04
+	uint16_t nCapacity;						//0x06
+	static const int nGrowthAmount = 4;
+	static const int nShrinkThreshold = 8;
+};
+
+struct D2ModStatsArrayStrc
+{
+	D2SLayerStatIdStrc* pStat;				//0x00 An Array[wStatCount]
 	uint16_t nStatCount;					//0x04
 	uint16_t nCapacity;						//0x06
 	static const int nGrowthAmount = 4;
@@ -456,7 +469,7 @@ struct D2StatListExStrc : public D2StatListStrc
 	D2StatListStrc* pMyStats;				//0x40
 	D2UnitStrc* pOwner;						//0x44
 	D2StatsArrayStrc FullStats;				//0x48
-	D2StatsArrayStrc ModStats;				//0x50
+	D2ModStatsArrayStrc ModStats;			//0x50
 	uint32_t* StatFlags;					//0x58 8bytes per states
 	void* fpCallBack;						//0x5C
 	D2GameStrc* pGame;						//0x60

--- a/source/D2Common/include/D2StatList.h
+++ b/source/D2Common/include/D2StatList.h
@@ -574,7 +574,7 @@ D2StatListStrc* __stdcall STATLIST_GetStatListFromUnitStateAndFlag(D2UnitStrc* p
 //D2Common.0x6FDB8310 (#10523)
 void __stdcall STATLIST_MergeStatLists(D2UnitStrc* pTarget, D2UnitStrc* pUnit, BOOL bType);
 //D2Common.0x6FDB83A0 (#10535)
-D2UnitStrc* __stdcall STATLIST_GetOwner(D2UnitStrc* pUnit, BOOL* pDynamic);
+D2UnitStrc* __stdcall STATLIST_GetOwner(D2UnitStrc* pUnit, BOOL* pStatNotDynamic);
 //D2Common.0x6FDB8420 (#10512)
 void __stdcall D2Common_10512(D2UnitStrc* pUnit1, D2UnitStrc* pUnit2, int nStatId, void(__fastcall* pfCallback)(D2UnitStrc*, int, int, D2UnitStrc*));
 //D2Common.0x6FDB84E0 (#10513)

--- a/source/D2Common/include/DataTbls/ItemsTbls.h
+++ b/source/D2Common/include/DataTbls/ItemsTbls.h
@@ -261,7 +261,9 @@ struct D2ItemStatCostTxt
 	uint16_t wItemEvent[2];					//0x48
 	uint16_t wItemEventFunc[2];				//0x4C
 	uint8_t nKeepZero;						//0x50
-	uint8_t unk0x51[3];						//0x51 - also related to op stats (see DATATBLS_LoadItemStatCostTxt)
+	uint8_t bIsBaseOfOtherStatOp;			//0x51
+	uint8_t bHasOpStatData;					//0x52
+	uint8_t bHasOpApplyingToItem;			//0x53
 	uint8_t nOp;							//0x54
 	uint8_t nOpParam;						//0x55
 	uint16_t wOpBase;						//0x56

--- a/source/D2Common/include/DataTbls/ItemsTbls.h
+++ b/source/D2Common/include/DataTbls/ItemsTbls.h
@@ -174,6 +174,15 @@ struct D2ItemRatioTxt
 	uint8_t nClassSpecific;					//0x43 
 };
 
+enum D2C_StatOp {
+	STAT_OP_NONE              =  0,
+	STAT_OP_APPLY_TO_ITEM     =  4,
+	STAT_OP_APPLY_TO_ITEM_PCT =  5,
+	STAT_OP_BY_TIME           =  6,
+	STAT_OP_BY_TIME_PCT       =  7,
+	STAT_OP_ADD_ITEM_STAT_PCT = 13,
+};
+
 struct D2OpStatDataStrc
 {
 	uint16_t nOpBase;						//0x00

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -711,10 +711,11 @@ void __fastcall sub_6FDB6C10(D2StatListExStrc* pStatListEx, int nLayer_StatId, i
 
 	const int nStatId = (nLayer_StatId >> 16) & 0xFFFF;
 	D2ItemStatCostTxt* pItemStatCostTxtRecord = ITEMS_GetItemStatCostTxtRecord(nStatId);
-	if (!pItemStatCostTxtRecord || pStatListEx->dwFlags & STATLIST_SET)
+	if (!pItemStatCostTxtRecord || (pStatListEx->dwFlags & STATLIST_SET))
 	{
 		return;
 	}
+	const bool bStatIsDamageRelated = (pItemStatCostTxtRecord->dwItemStatFlags & gdwBitMasks[ITEMSTATCOSTFLAGINDEX_DAMAGERELATED]);
 
 	D2StatListExStrc* pParentStatList = nullptr;
 	if (!STATLIST_IsExtended(pStatListEx))
@@ -739,8 +740,7 @@ void __fastcall sub_6FDB6C10(D2StatListExStrc* pStatListEx, int nLayer_StatId, i
 			int nNewValue = pStat->nValue + nValue;
 			STATLIST_SetUnitStatNewValue(pParentStatList, &pParentStatList->FullStats, pStat, nLayer_StatId, nNewValue, pItemStatCostTxtRecord, pUnit);
 		}
-
-		if ((pParentStatList->dwFlags & STATLIST_SET) || (pItemStatCostTxtRecord->dwItemStatFlags & gdwBitMasks[ITEMSTATCOSTFLAGINDEX_DAMAGERELATED] && (pParentStatList->dwFlags & STATLIST_DYNAMIC)))
+		if ((pParentStatList->dwFlags & STATLIST_SET) || (bStatIsDamageRelated && (pParentStatList->dwFlags & STATLIST_DYNAMIC)))
 		{
 			break;
 		}

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -1620,20 +1620,20 @@ void __stdcall STATLIST_MergeStatLists(D2UnitStrc* pTarget, D2UnitStrc* pUnit, B
 
 
 //D2Common.0x6FDB83A0 (#10535)
-D2UnitStrc* __stdcall STATLIST_GetOwner(D2UnitStrc* pUnit, BOOL* pDynamic)
+D2UnitStrc* __stdcall STATLIST_GetOwner(D2UnitStrc* pUnit, BOOL* pStatNotDynamic)
 {
 	if (!pUnit || !pUnit->pStatListEx || !pUnit->pStatListEx->pParent || !STATLIST_IsExtended(pUnit->pStatListEx->pParent))
 	{
-		if (pDynamic)
+		if (pStatNotDynamic)
 		{
-			*pDynamic = FALSE;
+			*pStatNotDynamic = FALSE;
 		}
 		return NULL;
 	}
 
-	if (pDynamic)
+	if (pStatNotDynamic)
 	{
-		*pDynamic = pUnit->pStatListEx->dwFlags & STATLIST_DYNAMIC;
+		*pStatNotDynamic = !(pUnit->pStatListEx->dwFlags & STATLIST_DYNAMIC);
 	}
 	return ((D2StatListExStrc*)pUnit->pStatListEx->pParent)->pOwner;
 }

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -756,25 +756,27 @@ void __stdcall D2Common_ExpireStatListEx_6FDB6E30(D2StatListStrc* pStatList)
 	{
 		return;
 	}
-	D2StatListStrc* pPrevStatList = pStatList->pParent;
-	if (pPrevStatList)
+	D2StatListStrc* pParentStatList = pStatList->pParent;
+	if (pParentStatList)
 	{
-		if (D2StatListExStrc* pStatListEx = STATLIST_StatListExCast(pStatList))
+		if (D2StatListExStrc* pParentStatListEx = STATLIST_StatListExCast(pParentStatList))
 		{
-			if (pStatListEx->pMyLastList == pStatList)
+			// Unlink the stat from the parent list
+			if (pParentStatListEx->pMyLastList == pStatList)
 			{
-				pStatListEx->pMyLastList = pStatList->pPrevLink;
+				pParentStatListEx->pMyLastList = pStatList->pPrevLink;
 			}
 
-			if (pStatListEx->pMyStats == pStatList)
+			if (pParentStatListEx->pMyStats == pStatList)
 			{
-				pStatListEx->pMyStats = pStatList->pPrevLink;
+				pParentStatListEx->pMyStats = pStatList->pPrevLink;
 			}
 		}
 
 		pStatList->pParent = NULL;
 	}
 
+	// Unlink the stat from the list
 	if (pStatList->pNextLink)
 	{
 		pStatList->pNextLink->pPrevLink = pStatList->pPrevLink;
@@ -820,7 +822,7 @@ void __stdcall D2Common_ExpireStatListEx_6FDB6E30(D2StatListStrc* pStatList)
 			}
 		}
 
-		if (pPrevStatList)
+		if (pParentStatList)
 		{
 			D2StatsArrayStrc* pStatsArray = nullptr;
 			if (D2StatListExStrc* pStatListEx = STATLIST_StatListExCast(pStatList))
@@ -832,10 +834,12 @@ void __stdcall D2Common_ExpireStatListEx_6FDB6E30(D2StatListStrc* pStatList)
 				pStatsArray = &pStatList->Stats;
 			}
 
-			D2StatListExStrc* pPrevStatListEx = STATLIST_StatListExCast(pPrevStatList);
+			D2StatListExStrc* pParentStatListEx = STATLIST_StatListExCast(pParentStatList);
 			// Something looks wrong, seems like some checks were eluded in D2Common.0x6FDB6C10
-			// Or inversely, the check above is useless as pCurStatList is in fact always an extended statlist
-			D2_ASSERT(pPrevStatListEx);
+			// Or inversely, the check above is useless as pParentStatListEx is in fact always an extended statlist
+			// if it exists or when STATLIST_SET is set on the current statlist ?
+			// In any case, we add an assert here
+			D2_ASSERT(pParentStatListEx);
 
 			if (pStatList->dwFlags & STATLIST_DYNAMIC)
 			{
@@ -844,7 +848,7 @@ void __stdcall D2Common_ExpireStatListEx_6FDB6E30(D2StatListStrc* pStatList)
 					D2ItemStatCostTxt* pItemStatCostTxtRecord = ITEMS_GetItemStatCostTxtRecord(i->nStat);
 					if (pItemStatCostTxtRecord && !(pItemStatCostTxtRecord->dwItemStatFlags & gdwBitMasks[ITEMSTATCOSTFLAGINDEX_DAMAGERELATED]))
 					{
-						sub_6FDB6C10(pPrevStatListEx, i->nLayer_StatId, -i->nValue, pOwner);
+						sub_6FDB6C10(pParentStatListEx, i->nLayer_StatId, -i->nValue, pOwner);
 					}
 				}
 			}
@@ -852,7 +856,7 @@ void __stdcall D2Common_ExpireStatListEx_6FDB6E30(D2StatListStrc* pStatList)
 			{
 				for (D2StatStrc* i = pStatsArray->pStat; i < &pStatsArray->pStat[pStatsArray->nStatCount]; ++i)
 				{
-					sub_6FDB6C10(pPrevStatListEx, i->nLayer_StatId, -i->nValue, pOwner);
+					sub_6FDB6C10(pParentStatListEx, i->nLayer_StatId, -i->nValue, pOwner);
 				}
 			}
 		}

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -454,7 +454,7 @@ int __fastcall STATLIST_FindStatIndex_6FDB6300(D2StatsArrayStrc* pStatArray, int
 // Helper function
 static int STATLIST_ApplyMinValue(int nValue, D2ItemStatCostTxt* pItemStatCostTxtRecord, D2StatListExStrc* pStatListEx)
 {
-	if (pItemStatCostTxtRecord->dwItemStatFlags & gdwBitMasks[ITEMSTATCOSTFLAGINDEX_FMIN])
+	if (pItemStatCostTxtRecord && pItemStatCostTxtRecord->dwItemStatFlags & gdwBitMasks[ITEMSTATCOSTFLAGINDEX_FMIN])
 	{
 		if (pStatListEx && pStatListEx->pOwner && (pStatListEx->pOwner->dwUnitType == UNIT_PLAYER || pStatListEx->pOwner->dwUnitType == UNIT_MONSTER))
 		{

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -126,7 +126,7 @@ static void STATLIST_SetUnitStatNewValue(D2StatListExStrc* pStatListEx, D2StatsA
 	if (nNewValue != 0 || pItemStatCostTxtRecord->nKeepZero)
 	{
 		pStat->nValue = nNewValue;
-		if (pItemStatCostTxtRecord->unk0x51[2])
+		if (pItemStatCostTxtRecord->bHasOpApplyingToItem)
 		{
 			pStatListEx->dwFlags |= STATLIST_PERMANENT;
 		}
@@ -179,7 +179,7 @@ int __fastcall sub_6FDB5830(D2StatListExStrc* pStatListEx, int nLayer_StatId)
 		}
 	}
 
-	if (!pItemStatCostTxtRecord->unk0x51[1])
+	if (!pItemStatCostTxtRecord->bHasOpStatData)
 	{
 		return nAccumulatedValue;
 	}
@@ -496,9 +496,9 @@ int __fastcall sub_6FDB64A0(D2StatListExStrc* pStatListEx, int nLayer_StatId, D2
 {
 	int nNewValue = sub_6FDB5830(pStatListEx, nLayer_StatId);
 
-	if (pItemStatCostTxtRecord->unk0x51[0])
+	if (pItemStatCostTxtRecord->bIsBaseOfOtherStatOp)
 	{
-		if (!nNewValue)
+		if (nNewValue == 0)
 		{
 			if (D2StatStrc* pStat = STATLIST_FindStat_6FDB6920(&pStatListEx->FullStats, nLayer_StatId))
 			{
@@ -727,7 +727,7 @@ void __fastcall sub_6FDB6C10(D2StatListExStrc* pStatListEx, int nLayer_StatId, i
 
 	while (pParentStatList)
 	{
-		if (pItemStatCostTxtRecord->unk0x51[0] || pItemStatCostTxtRecord->unk0x51[1])
+		if (pItemStatCostTxtRecord->bIsBaseOfOtherStatOp || pItemStatCostTxtRecord->bHasOpStatData)
 		{
 			sub_6FDB64A0(pParentStatList, nLayer_StatId, pItemStatCostTxtRecord, pUnit);
 		}
@@ -802,7 +802,7 @@ void __stdcall D2Common_ExpireStatListEx_6FDB6E30(D2StatListStrc* pStatList)
 			for (D2StatStrc* i = pStatListEx->FullStats.pStat; i < &pStatListEx->FullStats.pStat[pStatListEx->FullStats.nStatCount]; ++i)
 			{
 				D2ItemStatCostTxt* pItemStatCostTxtRecord = ITEMS_GetItemStatCostTxtRecord(i->nStat);
-				if (pItemStatCostTxtRecord && pItemStatCostTxtRecord->unk0x51[2])
+				if (pItemStatCostTxtRecord && pItemStatCostTxtRecord->bHasOpApplyingToItem)
 				{
 					nLayer_StatIds[nCounter] = i->nLayer_StatId;
 					++nCounter;
@@ -1125,7 +1125,7 @@ void __stdcall D2COMMON_10475_PostStatToStatList(D2UnitStrc* pUnit, D2StatListSt
 				for (D2StatStrc* i = pStatListEx->FullStats.pStat; i < &pStatListEx->FullStats.pStat[pStatListEx->FullStats.nStatCount]; ++i)
 				{
 					D2ItemStatCostTxt* pItemStatCostTxtRecord = ITEMS_GetItemStatCostTxtRecord(i->nStat);
-					if (pItemStatCostTxtRecord && pItemStatCostTxtRecord->unk0x51[2])
+					if (pItemStatCostTxtRecord && pItemStatCostTxtRecord->bHasOpApplyingToItem)
 					{
 						nLayer_StatIds[nCounter] = i->nLayer_StatId;
 						++nCounter;

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -550,8 +550,8 @@ int __fastcall sub_6FDB64A0(D2StatListExStrc* pStatListEx, int nLayer_StatId, D2
 					}
 					break;
 
-				case 4: // FALLTHROUGH
-				case 5:
+				case STAT_OP_APPLY_TO_ITEM: // FALLTHROUGH
+				case STAT_OP_APPLY_TO_ITEM_PCT:
 					if (pStatListEx->pUnit && (pStatListEx->pUnit->dwUnitType == UNIT_PLAYER || pStatListEx->pUnit->dwUnitType == UNIT_MONSTER))
 					{
 						int nOpBase = pItemStatCostTxtRecord->pOpStatData[nCounter].nOpBase;
@@ -566,15 +566,15 @@ int __fastcall sub_6FDB64A0(D2StatListExStrc* pStatListEx, int nLayer_StatId, D2
 					}
 					break;
 
-				case 6: // FALLTHROUGH
-				case 7:
+				case STAT_OP_BY_TIME: // FALLTHROUGH
+				case STAT_OP_BY_TIME_PCT:
 					if (pStatListEx->dwOwnerType == UNIT_PLAYER || pStatListEx->dwOwnerType == UNIT_MONSTER)
 					{
 						bUpdate = FALSE;
 					}
 					break;
 
-				case 13:
+				case STAT_OP_ADD_ITEM_STAT_PCT:
 					if (pStatListEx->dwOwnerType == UNIT_ITEM)
 					{
 						bUpdate = FALSE;

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -41,12 +41,12 @@ BOOL __stdcall STATLIST_AreUnitsAligned(D2UnitStrc* pUnit1, D2UnitStrc* pUnit2)
 
 
 // Helper function
-static int __fastcall STATLIST_FindStatInsertionIndex(D2StatsArrayStrc* pStatsArray, int nLayer_StatId)
+static int __fastcall STATLIST_FindStatInsertionIndex(D2StatsArrayStrc* pStatsArray, int nLayer_StatId, bool* pAlreadyInArray)
 {
+	*pAlreadyInArray = false;
 	// Find lower bound by dichotomy, stats are sorted by nLayer_StatId
 	int nMin = 0;
 	int nMax = pStatsArray->nStatCount;
-
 	if (nMax > 0)
 	{
 		do
@@ -63,15 +63,12 @@ static int __fastcall STATLIST_FindStatInsertionIndex(D2StatsArrayStrc* pStatsAr
 			}
 			else
 			{
-				return -1;
+				*pAlreadyInArray = true;
+				return nMidPoint;
 			}
 		} while (nMin < nMax);
-
-		if (nMin < 0)
-		{
-			return -1;
-		}
 	}
+
 	return nMin;
 }
 
@@ -100,9 +97,10 @@ D2StatStrc* __fastcall STATLIST_InsertStat(void* pMemPool, D2StatsArrayStrc* pSt
 // Helper function
 static D2StatStrc* __fastcall STATLIST_GetOrInsertStat(void* pMemPool, D2StatsArrayStrc* pStatsArray, int nLayer_StatId)
 {
-	const int insertionIdx = STATLIST_FindStatInsertionIndex(pStatsArray, nLayer_StatId);
+	bool bFoundStatInArray = false;
+	const int insertionIdx = STATLIST_FindStatInsertionIndex(pStatsArray, nLayer_StatId, &bFoundStatInArray);
 
-	if (insertionIdx >= 0)
+	if (bFoundStatInArray)
 	{
 		return &pStatsArray->pStat[insertionIdx];
 	}
@@ -646,8 +644,9 @@ D2StatStrc* __fastcall STATLIST_FindStat_6FDB6920(D2StatsArrayStrc* pStatArray, 
 //D2Common.0x6FDB6970
 D2StatStrc* __fastcall STATLIST_InsertStatOrFail_6FDB6970(void* pMemPool, D2StatsArrayStrc* pStatsArray, int nLayer_StatId)
 {
-	int insertionIdx = STATLIST_FindStatInsertionIndex(pStatsArray, nLayer_StatId);
-	if (insertionIdx <= 0)
+	bool bFoundStatInArray = false;
+	int insertionIdx = STATLIST_FindStatInsertionIndex(pStatsArray, nLayer_StatId, &bFoundStatInArray);
+	if (bFoundStatInArray)
 	{
 		return nullptr;
 	}
@@ -681,10 +680,11 @@ void __fastcall STATLIST_RemoveStat_6FDB6A30(void* pMemPool, D2StatsArrayStrc* p
 void __fastcall STATLIST_UpdateUnitStat_6FDB6AB0(D2StatListExStrc* pStatListEx, int nLayer_StatId, int nNewValue, D2ItemStatCostTxt* pItemStatCostTxtRecord, D2UnitStrc* pUnit)
 {
 	D2StatsArrayStrc* pStatsArray = &pStatListEx->FullStats;
-	const int insertionIdx = STATLIST_FindStatInsertionIndex(pStatsArray, nLayer_StatId);
+	bool bFoundStatInArray = false;
+	const int insertionIdx = STATLIST_FindStatInsertionIndex(pStatsArray, nLayer_StatId, &bFoundStatInArray);
 
 	D2StatStrc* pStat = nullptr;
-	if (insertionIdx >= 0)
+	if (bFoundStatInArray)
 	{
 		pStat = &pStatsArray->pStat[insertionIdx];
 	}

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -507,8 +507,8 @@ int __fastcall sub_6FDB64A0(D2StatListExStrc* pStatListEx, int nLayer_StatId, D2
 		}
 
 		bool bUpdate = TRUE;
-		int nCounter = 0;
-		while (nCounter < 3)
+		
+		for (int nCounter = 0; nCounter < 3; ++nCounter)
 		{
 			if (pItemStatCostTxtRecord->wOpStat[nCounter] == uint16_t(-1))
 			{
@@ -516,18 +516,21 @@ int __fastcall sub_6FDB64A0(D2StatListExStrc* pStatListEx, int nLayer_StatId, D2
 			}
 
 			int nOpStat = pItemStatCostTxtRecord->wOpStat[nCounter];
-			int nOpLayer_StatId = nOpStat << 16;
+			int nOpStatLayer_StatId = nOpStat << 16;
 			D2ItemStatCostTxt* pOpItemStatCostTxtRecord = ITEMS_GetItemStatCostTxtRecord(nOpStat);
 			D2StatsArrayStrc* pStatsArray = &pStatListEx->FullStats;
-			nNewValue = sub_6FDB64A0(pStatListEx, nOpLayer_StatId, pOpItemStatCostTxtRecord, pUnit);
+			nNewValue = sub_6FDB64A0(pStatListEx, nOpStatLayer_StatId, pOpItemStatCostTxtRecord, pUnit);
 			
-			D2StatStrc* pStat = STATLIST_FindStat_6FDB6920(&pStatListEx->FullStats, nOpLayer_StatId);
+			D2StatStrc* pStat = STATLIST_FindStat_6FDB6920(pStatsArray, nOpStatLayer_StatId);
 			if (pStat == nullptr && nNewValue != 0)
 			{
-				pStat = STATLIST_InsertStatOrFail_6FDB6970(pStatListEx->pMemPool, &pStatListEx->FullStats, nOpLayer_StatId);
+				pStat = STATLIST_InsertStatOrFail_6FDB6970(pStatListEx->pMemPool, pStatsArray, nOpStatLayer_StatId);
 			}
 
-			STATLIST_SetUnitStatNewValue(pStatListEx, &pStatListEx->FullStats, pStat, nOpLayer_StatId, nNewValue, pOpItemStatCostTxtRecord, pUnit);
+			if (pStat == nullptr)
+				continue;
+
+			STATLIST_SetUnitStatNewValue(pStatListEx, pStatsArray, pStat, nOpStatLayer_StatId, nNewValue, pOpItemStatCostTxtRecord, pUnit);
 
 			if (nNewValue)
 			{
@@ -593,8 +596,6 @@ int __fastcall sub_6FDB64A0(D2StatListExStrc* pStatListEx, int nLayer_StatId, D2
 					break;
 				}
 			}
-
-			++nCounter;
 		}
 
 		if (bUpdate && nNewValue)
@@ -605,7 +606,7 @@ int __fastcall sub_6FDB64A0(D2StatListExStrc* pStatListEx, int nLayer_StatId, D2
 			{
 				int nStatId = pItemStatCostTxtRecord->unk0x5E[i];
 
-				if (nStatId == -1)
+				if (nStatId == uint16_t(-1))
 				{
 					break;
 				}


### PR DESCRIPTION
As reported in #25, there were a few bugs in the current `STATLIST_*` functions.
Most notably, modstats do not store a value, and `STATLIST_FindStatInsertionIndex` was used incorrectly.

While I did fix quite a few things and it now seems to work fine, it is possible some issues remain.

Note I did not check the function 0x6FDB5830.

@Araksson could you review and check this is working as intended ?

