### PR TITLE
Replace patch pointers to globals by original dll content

### DIFF
--- a/D2.Detours.patches/1.10f/D2Common.patch.cpp
+++ b/D2.Detours.patches/1.10f/D2Common.patch.cpp
@@ -1,5 +1,8 @@
 #include <DetoursPatch.h>
 
+#include <D2DataTbls.h>
+#include <Drlg/D2DrlgPreset.h>
+
 extern "C" {
     __declspec(dllexport)
     constexpr int __cdecl GetBaseOrdinal() { return 10'000; }
@@ -1365,6 +1368,13 @@ static ExtraPatchAction extraPatchActions[] = {
     //{ 0x6FDB6AB0 - D2CommonImageBase, &STATLIST_UpdateUnitStat_6FDB6AB0, PatchAction::FunctionReplaceOriginalByPatch },
     //{ 0x6FDB63E0 - D2CommonImageBase, &STATLIST_GetTotalStat_6FDB63E0, PatchAction::FunctionReplaceOriginalByPatch },
     //{ 0x6FD85A10 - D2CommonImageBase, &DRLGPRESET_ParseDS1File, PatchAction::FunctionReplaceOriginalByPatch },
+    // Patch globals using original DLL pointers for now
+    { 0x6FDEA700 - D2CommonImageBase, &gpLevelFilesList_6FDEA700, PatchAction::PointerReplacePatchByOriginal },
+    { 0x6FDE9600 - D2CommonImageBase, &gpArenaTxtTable, PatchAction::PointerReplacePatchByOriginal },
+    { 0x6FDE95F8 - D2CommonImageBase, &gpCharTemplateTxtTable, PatchAction::PointerReplacePatchByOriginal },
+    { 0x6FDEA704 - D2CommonImageBase, &gpBeltsTxtTable, PatchAction::PointerReplacePatchByOriginal },
+    { 0x6FDEA704 - D2CommonImageBase, &gpAutomapSeed, PatchAction::PointerReplacePatchByOriginal },
+    
 
     { 0, 0, PatchAction::Ignore}, // Here because we need at least one element in the array
 };

--- a/source/D2Common/include/D2DataTbls.h
+++ b/source/D2Common/include/D2DataTbls.h
@@ -486,17 +486,21 @@ struct D2DataTablesStrc
 	D2PlrModeDataTbl pPlrModeDataTables;				//0x10D4
 };
 
-
+// D2Common.0x6FDE9600
 extern D2ArenaTxt* gpArenaTxtTable;
+// D2Common.0x6FDE95F8
 extern D2CharTemplateTxt* gpCharTemplateTxtTable;
 extern int gnCharTemplateTxtTableRecordCount;
 extern uint32_t gnCharTemplateStartIds[64];
+// D2Common.0x6FDE9604
 extern D2BeltsTxt* gpBeltsTxtTable;
 extern D2DataTablesStrc gpDataTables;
+// D2Common.0x6FDD6A20 (#10042)
 extern D2DataTablesStrc* sgptDataTables;
 
 
 extern D2SeedStrc* gpAutomapSeed;
+//D2Common.0x6FDEA704
 extern LPCRITICAL_SECTION gpLvlSubTypeFilesCriticalSection;
 
 //TODO: Reimport defs from .cpps

--- a/source/D2Common/include/Drlg/D2DrlgPreset.h
+++ b/source/D2Common/include/Drlg/D2DrlgPreset.h
@@ -143,3 +143,6 @@ void __fastcall DRLGPRESET_GenerateLevel(D2DrlgLevelStrc* pLevel);
 void __fastcall DRLGPRESET_ResetDrlgMap(D2DrlgLevelStrc* pLevel, BOOL bKeepPreset);
 //D2Common.0x6FD88850
 int __fastcall DRLGPRESET_MapOrientationLayer(int nId);
+
+// D2Common.0x6FDEA700
+extern D2LevelFileListStrc* gpLevelFilesList_6FDEA700;

--- a/source/D2Common/src/DataTbls/DataTbls.cpp
+++ b/source/D2Common/src/DataTbls/DataTbls.cpp
@@ -5,12 +5,16 @@
 #include <Units/Units.h>
 #include <D2States.h>
 
+// D2Common.0x6FDE9600
 D2ArenaTxt* gpArenaTxtTable;
+// D2Common.0x6FDE95F8
 D2CharTemplateTxt* gpCharTemplateTxtTable;
 int gnCharTemplateTxtTableRecordCount;
 uint32_t gnCharTemplateStartIds[64];
+// D2Common.0x6FDE9604
 D2BeltsTxt* gpBeltsTxtTable;
 D2DataTablesStrc gpDataTables;
+// D2Common.0x6FDD6A20 (#10042)
 D2DataTablesStrc* sgptDataTables = &gpDataTables;
 BOOL DATATBLS_LoadFromBin = TRUE;
 

--- a/source/D2Common/src/DataTbls/LevelsTbls.cpp
+++ b/source/D2Common/src/DataTbls/LevelsTbls.cpp
@@ -73,8 +73,9 @@ static const char* gszAutomapTileNames[] =
 };
 
 D2SeedStrc* gpAutomapSeed = &sgptDataTables->pAutomapSeed;
-LPCRITICAL_SECTION gpLvlSubTypeFilesCriticalSection;
 
+//D2Common.0x6FDEA704
+LPCRITICAL_SECTION gpLvlSubTypeFilesCriticalSection;
 
 //D2Common.0x6FD5EAE0
 void __fastcall DATATBLS_LoadLevelsTxt(void* pMemPool)

--- a/source/D2Common/src/Drlg/DrlgPreset.cpp
+++ b/source/D2Common/src/Drlg/DrlgPreset.cpp
@@ -23,9 +23,8 @@
 #include <Units/Units.h>
 #include <algorithm>
 
-
+// D2Common.0x6FDEA700
 D2LevelFileListStrc* gpLevelFilesList_6FDEA700;
-
 
 //D2Common.0x6FD859A0 (#11222)
 int __stdcall DRLGPRESET_CountPresetObjectsByAct(uint8_t nAct)


### PR DESCRIPTION
This patches a few global pointers similarly to what was done for `sgptDataTables`.
This way we can incrementally patch functions while still using data from the game more easily.