### PR TITLE
Add Unicode struct type

### DIFF
--- a/source/D2Lang/CMakeLists.txt
+++ b/source/D2Lang/CMakeLists.txt
@@ -1,5 +1,12 @@
 
-add_library(D2Lang SHARED src/DllMain.cpp include/D2Lang.h)
+add_library(D2Lang
+  SHARED
+    src/DllMain.cpp
+    src/D2Unicode/D2UnicodeChar.cpp
+
+    include/D2Lang.h
+    include/D2Unicode.h
+)
 # The definition file that matches functions with their ordinals
 target_sources(D2Lang PRIVATE definitions/D2Lang.${D2MOO_ORDINALS_VERSION}.def)
 target_include_directories(D2Lang PUBLIC include)

--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -3,7 +3,7 @@ EXPORTS
     ??0Unicode@@QAE@G@Z @10014 ; Unicode::Unicode(unsigned short)
     ??4Unicode@@QAEAAU0@ABU0@@Z @10015 ; Unicode& Unicode::Unicode(const Unicode&)
     ??BUnicode@@QBEGXZ @10016 ; Unicode::unsigned short() const
-;   ??_FUnicode@@QAEXXZ @10017 ; Unicode::`default constructor closure` 
+    ??_FUnicode@@QAEXXZ @10017 ; Unicode::`default constructor closure` 
 ;   D2LANG_10018 @10018 ; ?Personalize@Unicode@@SIXPAU1@PBU1@1HW4ELANGUAGE@@@Z
 ;   D2LANG_10019 @10019 ; ?_toLowerTable@Unicode@@0PAGA
 ;   D2LANG_10020 @10020 ; ?_toUpperTable@Unicode@@0PAGA

--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -1,9 +1,9 @@
 LIBRARY		D2Lang
 EXPORTS
-;   D2LANG_10014 @10014 ; ??0Unicode@@QAE@G@Z
-;   D2LANG_10015 @10015 ; ??4Unicode@@QAEAAU0@ABU0@@Z
-;   D2LANG_10016 @10016 ; ??BUnicode@@QBEGXZ
-;   D2LANG_10017 @10017 ; ??_FUnicode@@QAEXXZ
+    ??0Unicode@@QAE@G@Z @10014 ; Unicode::Unicode(unsigned short)
+    ??4Unicode@@QAEAAU0@ABU0@@Z @10015 ; Unicode& Unicode::Unicode(const Unicode&)
+    ??BUnicode@@QBEGXZ @10016 ; Unicode::unsigned short() const
+;   ??_FUnicode@@QAEXXZ @10017 ; Unicode::`default constructor closure` 
 ;   D2LANG_10018 @10018 ; ?Personalize@Unicode@@SIXPAU1@PBU1@1HW4ELANGUAGE@@@Z
 ;   D2LANG_10019 @10019 ; ?_toLowerTable@Unicode@@0PAGA
 ;   D2LANG_10020 @10020 ; ?_toUpperTable@Unicode@@0PAGA

--- a/source/D2Lang/include/D2Lang.h
+++ b/source/D2Lang/include/D2Lang.h
@@ -3,7 +3,7 @@
 #include <D2Dll.h>
 
 #ifdef D2LANG_IMPL
-#define D2LANG_DLL_DECL // We use .def files, not dllexport
+#define D2LANG_DLL_DECL __declspec( dllexport ) // D2Lang uses both .def files and dllexport
 #else
 #define D2LANG_DLL_DECL __declspec( dllimport )
 #endif

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2021 Mir Drualga
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#pragma once
+
+#include <wchar.h>
+
+#include "D2Lang.h"
+
+/*
+* This type must be struct in order to make certain functions'
+* mangled names the same as the ones in D2Lang.
+*/
+struct D2LANG_DLL_DECL Unicode {
+ public:
+  unsigned short ch;
+
+  /**
+   * Default parameter value generates the default constructor
+   * closure, but also requires dllexport to generate.
+   *
+   * D2Lang.0x6FC11200 (#10017) ??_FUnicode@@QAEXXZ
+   */
+
+  // D2Lang.0x6FC11010 (#10014) ??0Unicode@@QAE@G@Z
+  Unicode(unsigned short ch = 0);
+
+  // D2Lang.0x6FC111F0 (#10015) ??4Unicode@@QAEAAU0@ABU0@@Z
+  Unicode& operator=(const Unicode& str);
+
+  // D2Lang.0x6FC11020 (#10016) ??BUnicode@@QBEGXZ
+  operator unsigned short() const;
+};

--- a/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2021 Mir Drualga
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <D2Unicode.h>
+
+Unicode::Unicode(unsigned short ch) : ch(ch) {
+}
+
+Unicode& Unicode::operator=(const Unicode& str) {
+  this->ch = str.ch;
+
+  return *this;
+}
+
+Unicode::operator unsigned short() const {
+  return this->ch;
+}


### PR DESCRIPTION
This adds a basic reimplementation of the Unicode struct with its constructors and `unsigned short` conversion operator. Other functions are significantly large and will be added in later pull requests.

I can confirm that the functions, with the exception with the default constructor closure, are generated with the exact same code in Visual C++ 6.0. In VS 2019, The default constructor closure does not generate unless the `Unicode::Unicode(unsigned short)` constructor is declared with `__declspec(dllexport)`. In addition, the default constructor closure generates the exact same code if the same constructor is also declared `inline`.

Otherwise, the code behaves exactly the same as vanilla Diablo II.