### PR TITLE
Add D2Lang.Unicode::strcpy

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -24,7 +24,7 @@ EXPORTS
 ;   D2LANG_10035 @10035 ; ?strchr@Unicode@@SIPAU1@PBU1@U1@@Z
 ;   D2LANG_10036 @10036 ; ?strcmp@Unicode@@SIHPBU1@0@Z
 ;   D2LANG_10037 @10037 ; ?strcoll@Unicode@@SIHPBU1@0@Z
-;   D2LANG_10038 @10038 ; ?strcpy@Unicode@@SIPAU1@PAU1@PBU1@@Z
+    ?strcpy@Unicode@@SIPAU1@PAU1@PBU1@@Z @10038 ; Unicode::strcpy
 ;   D2LANG_10039 @10039 ; ?stricmp@Unicode@@SIHPBU1@0@Z
     ?strlen@Unicode@@SIHPBU1@@Z @10040 ; Unicode::strlen
 ;   D2LANG_10041 @10041 ; ?strncat@Unicode@@SIPAU1@PAU1@PBU1@H@Z

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -59,6 +59,15 @@ struct D2LANG_DLL_DECL Unicode {
   operator unsigned short() const;
 
   /**
+   * Copies the characters from a null-terminated source string into a
+   * null-terminated destination string. Returns the destination
+   * string.
+   *
+   * D2Lang.0x6FC114A0 (#10038) ?strcpy@Unicode@@SIPAU1@PAU1@PBU1@@Z
+   */
+  static Unicode* __fastcall strcpy(Unicode* dest, const Unicode* src);
+
+  /**
    * Returns the length of the null-terminated string. If the string
    * pointer is NULL, the function returns 0;
    *

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -29,8 +29,8 @@ Unicode* __fastcall Unicode::strcpy(Unicode* dest, const Unicode* src) {
 
   i = 0;
   do {
-    dest[i] = src[i];
-  } while (src[i++] != L'\0');
+    dest[i].ch = src[i].ch;
+  } while (src[i++].ch != L'\0');
 
   return dest;
 }

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -24,6 +24,17 @@
 
 #include <D2Unicode.h>
 
+Unicode* __fastcall Unicode::strcpy(Unicode* dest, const Unicode* src) {
+  size_t i;
+
+  i = 0;
+  do {
+    dest[i] = src[i];
+  } while (src[i++] != L'\0');
+
+  return dest;
+}
+
 int __fastcall Unicode::strlen(const Unicode* str) {
   if (str == NULL) {
     return 0;

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -25,9 +25,7 @@
 #include <D2Unicode.h>
 
 Unicode* __fastcall Unicode::strcpy(Unicode* dest, const Unicode* src) {
-  size_t i;
-
-  i = 0;
+  size_t i = 0;
   do {
     dest[i].ch = src[i].ch;
   } while (src[i++].ch != L'\0');


### PR DESCRIPTION
These changes add the D2Lang.Unicode::strcpy function. The function copies the characters of a null-terminated source Unicode string into a destination string.

My own testing indicates that the function produces the same results as its vanilla counterpart.