### PR TITLE
Add D2Lang.Unicode::isASCII

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -10,7 +10,7 @@ EXPORTS
 ;   D2LANG_10021 @10021 ; ?compare@Unicode@@QBEHU1@@Z
 ;   D2LANG_10022 @10022 ; ?compare@Unicode@@SIHU1@0@Z
     ?directionality@Unicode@@QAE?AW4Direction@1@XZ @10023 ; Unicode::directionality
-;   D2LANG_10024 @10024 ; ?isASCII@Unicode@@QBEHXZ
+    ?isASCII@Unicode@@QBEHXZ @10024 ; Unicode::isASCII
 ;   D2LANG_10025 @10025 ; ?isAlpha@Unicode@@QBEHXZ
 ;   D2LANG_10026 @10026 ; ?isLeftToRight@Unicode@@QBEHXZ
 ;   D2LANG_10027 @10027 ; ?isLineBreak@Unicode@@SIHPBU1@I@Z

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -68,4 +68,13 @@ struct D2LANG_DLL_DECL Unicode {
 
   // D2Lang.0x6FC11C50 (#10023) ?directionality@Unicode@@QAE?AW4Direction@1@XZ
   Direction directionality();
+
+  /**
+   * Returns whether or not this Unicode character is in 
+   * "C0 Controls and Basic Latin" character block, otherwise known as
+   * the ASCII character block.
+   *
+   * D2Lang.0x6FC11080 (#10024) ?isASCII@Unicode@@QBEHXZ
+   */
+  int isASCII() const;
 };

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -26,6 +26,7 @@
 
 #include <wchar.h>
 
+#include <D2BasicTypes.h>
 #include "D2Lang.h"
 
 /*
@@ -76,5 +77,5 @@ struct D2LANG_DLL_DECL Unicode {
    *
    * D2Lang.0x6FC11080 (#10024) ?isASCII@Unicode@@QBEHXZ
    */
-  int isASCII() const;
+  BOOL isASCII() const;
 };

--- a/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
@@ -137,3 +137,7 @@ Unicode::Direction Unicode::directionality() {
 
   return DIR_NEUTRAL;
 }
+
+int Unicode::isASCII() const {
+  return this->ch < 0x80;
+}

--- a/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
@@ -138,6 +138,6 @@ Unicode::Direction Unicode::directionality() {
   return DIR_NEUTRAL;
 }
 
-int Unicode::isASCII() const {
+BOOL Unicode::isASCII() const {
   return this->ch < 0x80;
 }


### PR DESCRIPTION
These changes add the D2Lang.Unicode::isASCII function. The function returns whether or not the Unicode character is part or the "C0 Controls and Basic Latin" character block, otherwise known as the ASCII character block.

When compiled with Visual C++ 6.0, the binary is identical to its vanilla counterpart.