### PR TITLE
Add D2Lang.Unicode::strcmp

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -22,7 +22,7 @@ EXPORTS
 ;   D2LANG_10033 @10033 ; ?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ
     ?strcat@Unicode@@SIPAU1@PAU1@PBU1@@Z @10034 ; Unicode::strcat
 ;   D2LANG_10035 @10035 ; ?strchr@Unicode@@SIPAU1@PBU1@U1@@Z
-;   D2LANG_10036 @10036 ; ?strcmp@Unicode@@SIHPBU1@0@Z
+    ?strcmp@Unicode@@SIHPBU1@0@Z @10036 ; Unicode::strcmp
 ;   D2LANG_10037 @10037 ; ?strcoll@Unicode@@SIHPBU1@0@Z
     ?strcpy@Unicode@@SIPAU1@PAU1@PBU1@@Z @10038 ; Unicode::strcpy
 ;   D2LANG_10039 @10039 ; ?stricmp@Unicode@@SIHPBU1@0@Z

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -68,6 +68,14 @@ struct D2LANG_DLL_DECL Unicode {
   static Unicode* __fastcall strcat(Unicode* dest, const Unicode* src);
 
   /**
+   * Compares two null-terminated strings lexicographically. Returns
+   * -1, 0, or 1, depending on the results of the comparison.
+   *
+   * D2Lang.0x6FC11210 (#10036) ?strcmp@Unicode@@SIHPBU1@0@Z
+   */
+  static int __fastcall strcmp(const Unicode* str1, const Unicode* str2);
+
+  /**
    * Copies the characters from a null-terminated source string into a
    * null-terminated destination string. Returns the destination
    * string.

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -35,6 +35,18 @@ Unicode* __fastcall Unicode::strcat(Unicode* dest, const Unicode* src) {
   return dest;
 }
 
+int __fastcall Unicode::strcmp(const Unicode* str1, const Unicode* str2) {
+  for (size_t i = 0; (str1[i].ch != L'\0') || (str2[i].ch != L'\0'); ++i) {
+    if (str1[i].ch < str2[i].ch) {
+      return -1;
+    } else if (str1[i].ch > str2[i].ch) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
 Unicode* __fastcall Unicode::strcpy(Unicode* dest, const Unicode* src) {
   size_t i = 0;
   do {

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -36,6 +36,12 @@ Unicode* __fastcall Unicode::strcat(Unicode* dest, const Unicode* src) {
 }
 
 int __fastcall Unicode::strcmp(const Unicode* str1, const Unicode* str2) {
+  /*
+   * This loop does not run beyond the end of either string. If the
+   * end of only one string is reached, then a comparison between '\0'
+   * to a different character is made, and a return is guaranteed to
+   * happen.
+   */
   for (size_t i = 0; (str1[i].ch != L'\0') || (str2[i].ch != L'\0'); ++i) {
     if (str1[i].ch < str2[i].ch) {
       return -1;


### PR DESCRIPTION
These changes add the D2Lang.Unicode::strcmp function.

The function compares two null-terminated string lexicographically. It returns -1, 0, or 1, depending on the result of the comparison.

My own testing confirms that the function produces the same results as its vanilla counterpart.