### PR TITLE
Add D2Lang.Unicode::isWordEnd

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -17,7 +17,7 @@ EXPORTS
 ;   D2LANG_10028 @10028 ; ?isNewline@Unicode@@QBEHXZ
 ;   D2LANG_10029 @10029 ; ?isPipe@Unicode@@QBEHXZ
 ;   D2LANG_10030 @10030 ; ?isWhitespace@Unicode@@QBEHXZ
-;   D2LANG_10031 @10031 ; ?isWordEnd@Unicode@@SIHPBU1@I@Z
+    ?isWordEnd@Unicode@@SIHPBU1@I@Z @10031 ; Unicode::isWordEnd
 ;   D2LANG_10032 @10032 ; ?loadSysMap@Unicode@@SIHPAUHD2ARCHIVE__@@PBD@Z
 ;   D2LANG_10033 @10033 ; ?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ
     ?strcat@Unicode@@SIPAU1@PAU1@PBU1@@Z @10034 ; Unicode::strcat

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -63,7 +63,8 @@ struct D2LANG_DLL_DECL Unicode {
    * Returns whether the specified character in the string is the last
    * character of a word. In this function, only characters in the
    * English alphabet or Arabic numerals are considered characters in
-   * a word.
+   * a word. The first character is also not considered the end of a
+   * word.
    *
    * D2Lang.0x6FC11190 (#10031) ?isWordEnd@Unicode@@SIHPBU1@I@Z
    */

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -59,6 +59,9 @@ struct D2LANG_DLL_DECL Unicode {
   // D2Lang.0x6FC11020 (#10016) ??BUnicode@@QBEGXZ
   operator unsigned short() const;
 
+  // D2Lang.0x6FC11190 (#10031) ?isWordEnd@Unicode@@SIHPBU1@I@Z
+  static BOOL __fastcall isWordEnd(const Unicode* str, size_t index);
+
   /**
    * Appends a null-terminated string to the end of a null-terminated
    * destination string. Returns the destination string.

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -59,7 +59,14 @@ struct D2LANG_DLL_DECL Unicode {
   // D2Lang.0x6FC11020 (#10016) ??BUnicode@@QBEGXZ
   operator unsigned short() const;
 
-  // D2Lang.0x6FC11190 (#10031) ?isWordEnd@Unicode@@SIHPBU1@I@Z
+  /**
+   * Returns whether the specified character in the string is the last
+   * character of a word. In this function, only characters in the
+   * English alphabet or Arabic numerals are considered characters in
+   * a word.
+   *
+   * D2Lang.0x6FC11190 (#10031) ?isWordEnd@Unicode@@SIHPBU1@I@Z
+   */
   static BOOL __fastcall isWordEnd(const Unicode* str, size_t index);
 
   /**

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -24,6 +24,17 @@
 
 #include <D2Unicode.h>
 
+#include <ctype.h>
+
+BOOL __fastcall Unicode::isWordEnd(const Unicode* str, size_t index) {
+  if (index == 0) {
+    return FALSE;
+  }
+
+  return ::isalnum(str[index].ch)
+      && !::isalnum(str[index + 1].ch);
+}
+
 Unicode* __fastcall Unicode::strcat(Unicode* dest, const Unicode* src) {
   size_t i = 0;
   while (dest[i].ch != L'\0') {


### PR DESCRIPTION
These changes add the D2Lang.Unicode::isWordEnd function. The function returns whether or not the specific character in a string is the last character in a word. In the context of this function, words are made up of characters from the English alphabet or Arabic numerals. The first character of a string is never considered the end of a word.

My own testing confirms that the function behaves the same as its vanilla counterpart.