### PR TITLE
Statlist: more cleaning related to D2SLayerStatIdStrc

### DIFF
--- a/source/D2Common/include/D2StatList.h
+++ b/source/D2Common/include/D2StatList.h
@@ -10,17 +10,17 @@ enum D2C_ItemStats
 	STAT_INVALID = -1,
 	STAT_STRENGTH = 0, 					// 000
 	STAT_ENERGY, 						// 001
-	STAT_DEXTERITY, 						// 002
+	STAT_DEXTERITY, 					// 002
 	STAT_VITALITY, 						// 003
 	STAT_STATPTS, 						// 004
 	STAT_SKILLPTS, 						// 005
-	STAT_HITPOINTS, 						// 006
-	STAT_MAXHP, 							// 007
+	STAT_HITPOINTS, 					// 006
+	STAT_MAXHP, 						// 007
 	STAT_MANA, 							// 008
 	STAT_MAXMANA, 						// 009
 	STAT_STAMINA, 						// 00A
 	STAT_MAXSTAMINA, 					// 00B
-	STAT_LEVEL, 							// 00C
+	STAT_LEVEL, 						// 00C
 	STAT_EXPERIENCE, 					// 00D
 	STAT_GOLD, 							// 00E
 	STAT_GOLDBANK, 						// 00F
@@ -422,7 +422,7 @@ struct D2SLayerStatIdStrc
 			uint16_t nLayer;				//0x00
 			uint16_t nStat;					//0x02
 		};
-		PackedType nPackedValue;				//0x00
+		PackedType nPackedValue;			//0x00
 	};
 
 	static D2SLayerStatIdStrc Make(uint16_t wLayer, uint16_t wStatId) { return { wLayer, wStatId }; }

--- a/source/D2Common/include/D2StatList.h
+++ b/source/D2Common/include/D2StatList.h
@@ -411,6 +411,10 @@ enum D2C_StatlistFlags : uint32_t
 
 struct D2SLayerStatIdStrc
 {
+	// We can not use a struct as function parameters here as it has a different effect when using the __fastcall calling convetion.
+	// Instead we just use D2SLayerStatIdStrc::PackedType so that we may easily change it later
+	using PackedType = int32_t;
+
 	union
 	{
 		struct
@@ -418,8 +422,16 @@ struct D2SLayerStatIdStrc
 			uint16_t nLayer;				//0x00
 			uint16_t nStat;					//0x02
 		};
-		int32_t nLayer_StatId;				//0x00
+		PackedType nPackedValue;				//0x00
 	};
+
+	static D2SLayerStatIdStrc Make(uint16_t wLayer, uint16_t wStatId) { return { wLayer, wStatId }; }
+	static D2SLayerStatIdStrc MakeFromStatId(uint16_t wStatId) { return { 0, wStatId }; }
+	static D2SLayerStatIdStrc FromPackedType(PackedType nPackedValue) {
+		D2SLayerStatIdStrc ls;
+		ls.nPackedValue = nPackedValue;
+		return ls; 
+	}
 };
 
 struct D2StatStrc : D2SLayerStatIdStrc
@@ -490,25 +502,25 @@ inline bool STATLIST_IsExtended(D2StatListStrc* pStatList) { return pStatList->d
 //D2Common.0x6FDB57C0 (#10563)
 D2COMMON_DLL_DECL BOOL __stdcall STATLIST_AreUnitsAligned(D2UnitStrc* pUnit1, D2UnitStrc* pUnit2);
 //----- (6FDB5830) --------------------------------------------------------
-int __fastcall sub_6FDB5830(D2StatListExStrc* a1, int a2);
+int __fastcall sub_6FDB5830(D2StatListExStrc* a1, D2SLayerStatIdStrc::PackedType a2);
 //D2Common.0x6FDB6300
-int __fastcall STATLIST_FindStatIndex_6FDB6300(D2StatsArrayStrc* pStatArray, int nLayer_StatId);
+int __fastcall STATLIST_FindStatIndex_6FDB6300(D2StatsArrayStrc* pStatArray, D2SLayerStatIdStrc::PackedType nLayer_StatId);
 //D2Common.0x6FDB6340
-int __fastcall STATLIST_GetBaseStat_6FDB6340(D2StatListStrc* pStatListEx, int nLayer_StatId, D2ItemStatCostTxt* pItemStatCostTxtRecord);
+int __fastcall STATLIST_GetBaseStat_6FDB6340(D2StatListStrc* pStatListEx, D2SLayerStatIdStrc::PackedType nLayer_StatId, D2ItemStatCostTxt* pItemStatCostTxtRecord);
 //D2Common.0x6FDB63E0
-int __fastcall STATLIST_GetTotalStat_6FDB63E0(D2StatListStrc* pStatList, int nLayer_StatId, D2ItemStatCostTxt* pItemStatCostTxtRecord);
+int __fastcall STATLIST_GetTotalStat_6FDB63E0(D2StatListStrc* pStatList, D2SLayerStatIdStrc::PackedType nLayer_StatId, D2ItemStatCostTxt* pItemStatCostTxtRecord);
 //D2Common.0x6FDB64A0
-int __fastcall sub_6FDB64A0(D2StatListExStrc* pStatListEx, int nLayer_StatId, D2ItemStatCostTxt* pItemStatCostTxtRecord, D2UnitStrc* pUnit);
+int __fastcall sub_6FDB64A0(D2StatListExStrc* pStatListEx, D2SLayerStatIdStrc::PackedType nLayer_StatId, D2ItemStatCostTxt* pItemStatCostTxtRecord, D2UnitStrc* pUnit);
 //D2Common.0x6FDB6920
-D2StatStrc* __fastcall STATLIST_FindStat_6FDB6920(D2StatsArrayStrc* pStatEx, int nLayer_StatId);
+D2StatStrc* __fastcall STATLIST_FindStat_6FDB6920(D2StatsArrayStrc* pStatEx, D2SLayerStatIdStrc::PackedType nLayer_StatId);
 //D2Common.0x6FDB6970
-D2StatStrc* __fastcall STATLIST_InsertStatOrFail_6FDB6970(void* pMemPool, D2StatsArrayStrc* pStatEx, int nLayer_StatId);
+D2StatStrc* __fastcall STATLIST_InsertStatOrFail_6FDB6970(void* pMemPool, D2StatsArrayStrc* pStatEx, D2SLayerStatIdStrc::PackedType nLayer_StatId);
 //D2Common.0x6FDB6A30
 void __fastcall STATLIST_RemoveStat_6FDB6A30(void* pMemPool, D2StatsArrayStrc* pStatEx, D2StatStrc* pStat);
 //D2Common.0x6FDB6AB0
-void __fastcall STATLIST_UpdateUnitStat_6FDB6AB0(D2StatListExStrc* pStatList, int nLayer_StatId, int nValue, D2ItemStatCostTxt* pItemStatCostTxtRecord, D2UnitStrc* pUnit);
+void __fastcall STATLIST_UpdateUnitStat_6FDB6AB0(D2StatListExStrc* pStatList, D2SLayerStatIdStrc::PackedType nLayer_StatId, int nValue, D2ItemStatCostTxt* pItemStatCostTxtRecord, D2UnitStrc* pUnit);
 //D2Common.0x6FDB6C10
-void __fastcall sub_6FDB6C10(D2StatListExStrc* pStatListEx, int nLayer_StatId, int nValue, D2UnitStrc* pUnit);
+void __fastcall sub_6FDB6C10(D2StatListExStrc* pStatListEx, D2SLayerStatIdStrc::PackedType nLayer_StatId, int nValue, D2UnitStrc* pUnit);
 //D2Common.0x6FDB6E30
 void __stdcall D2Common_ExpireStatList_6FDB6E30(D2StatListStrc* pStatList);
 //D2Common.0x6FDB7030 (#10485)
@@ -542,7 +554,7 @@ D2COMMON_DLL_DECL void __stdcall D2COMMON_10475_PostStatToStatList(D2UnitStrc* p
 //D2Common.0x6FDB7560 (#10464)
 D2COMMON_DLL_DECL void __stdcall STATLIST_AddStat(D2StatListStrc* pStatList, int nStatId, int nValue, uint16_t nLayer);
 //D2Common.0x6FDB7690
-void __fastcall STATLIST_InsertStatModOrFail_6FDB7690(D2StatListStrc* pStatList, int nLayer_StatId);
+void __fastcall STATLIST_InsertStatModOrFail_6FDB7690(D2StatListStrc* pStatList, D2SLayerStatIdStrc::PackedType nLayer_StatId);
 //D2Common.0x6FDB77B0 (#10463)
 D2COMMON_DLL_DECL BOOL __stdcall STATLIST_SetStat(D2StatListStrc* pStatList, int nStatId, int nValue, uint16_t nLayer);
 //D2Common.0x6FDB7910 (#10465)

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -1975,7 +1975,7 @@ static void STATLIST_ClampStat(D2StatListExStrc* pStatListEx, int nStatId)
 		nCurrentValue = STATLIST_GetTotalStat_6FDB63E0(pStatListEx, D2SLayerStatIdStrc::MakeFromStatId(nStatId).nPackedValue, pItemStatCostTxtRecord);
 	}
 
-	const int nMaxStatId = nStatId + 1;
+	const int nMaxStatId = nStatId + 1; // Assumes the Max of the input stat is the next stat, for example STAT_MANA = 8 and STAT_MAXMANA = 9
 	int nMaxValue = 0;
 	if (D2ItemStatCostTxt* pItemStatCostTxtRecord = ITEMS_GetItemStatCostTxtRecord(nMaxStatId))
 	{

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -755,7 +755,7 @@ void __fastcall sub_6FDB6C10(D2StatListExStrc* pStatListEx, D2SLayerStatIdStrc::
 }
 
 //D2Common.0x6FDB6E30
-void __stdcall D2Common_ExpireStatListEx_6FDB6E30(D2StatListStrc* pStatList)
+void __stdcall D2Common_ExpireStatList_6FDB6E30(D2StatListStrc* pStatList)
 {
 	if (!pStatList)
 	{
@@ -885,7 +885,7 @@ void __stdcall STATLIST_FreeStatList(D2StatListStrc* pStatList)
 void __fastcall D2Common_STATLIST_FreeStatListImpl_6FDB7050(D2StatListStrc* pStatList)
 {
 
-	D2Common_ExpireStatListEx_6FDB6E30(pStatList);
+	D2Common_ExpireStatList_6FDB6E30(pStatList);
 
 	if (pStatList->Stats.pStat)
 	{
@@ -1077,7 +1077,7 @@ void __stdcall D2COMMON_10475_PostStatToStatList(D2UnitStrc* pUnit, D2StatListSt
 {
 	if (D2StatListExStrc* pUnitStatListEx = STATLIST_StatListExCast(pUnit->pStatListEx))
 	{
-		D2Common_ExpireStatListEx_6FDB6E30((D2StatListExStrc*)pStatList);
+		D2Common_ExpireStatList_6FDB6E30((D2StatListExStrc*)pStatList);
 		D2StatListExStrc* pCurrentStatList = pUnitStatListEx;
 
 		while (pCurrentStatList && (pStatList != pCurrentStatList))
@@ -1618,7 +1618,7 @@ void __stdcall STATLIST_MergeStatLists(D2UnitStrc* pTarget, D2UnitStrc* pUnit, B
 	{
 		if (pUnit->dwUnitType == UNIT_ITEM && (ITEMS_GetBodyLocation(pUnit) == BODYLOC_SWRARM || ITEMS_GetBodyLocation(pUnit) == BODYLOC_SWLARM))
 		{
-			D2Common_ExpireStatListEx_6FDB6E30(pUnit->pStatListEx);
+			D2Common_ExpireStatList_6FDB6E30(pUnit->pStatListEx);
 		}
 		else if (pUnit->pStatListEx->pUnit == pTarget)
 		{
@@ -2011,7 +2011,7 @@ BOOL __stdcall D2Common_10574(D2UnitStrc* pUnit, int nStateId, BOOL bSet)
 			{
 				if (!(pStatList->dwFlags & STATLIST_SET))
 				{
-					D2Common_ExpireStatListEx_6FDB6E30((D2StatListExStrc*)pStatList);
+					D2Common_ExpireStatList_6FDB6E30((D2StatListExStrc*)pStatList);
 					pStatList->dwFlags |= STATLIST_SET;
 					D2COMMON_10475_PostStatToStatList(pUnit, pStatList, TRUE);
 				}
@@ -2020,7 +2020,7 @@ BOOL __stdcall D2Common_10574(D2UnitStrc* pUnit, int nStateId, BOOL bSet)
 			{
 				if (pStatList->dwFlags & STATLIST_SET)
 				{
-					D2Common_ExpireStatListEx_6FDB6E30((D2StatListExStrc*)pStatList);
+					D2Common_ExpireStatList_6FDB6E30((D2StatListExStrc*)pStatList);
 					pStatList->dwFlags &= ~STATLIST_SET;
 					D2COMMON_10475_PostStatToStatList(pUnit, pStatList, TRUE);
 				}
@@ -2079,7 +2079,7 @@ void __stdcall D2Common_10525(D2UnitStrc* pUnit1, D2UnitStrc* pUnit2)
 //D2Common.0x6FDB91C0 (#10474)
 void __stdcall D2Common_10474(D2UnitStrc* pUnused, D2StatListStrc* pStatList)
 {
-	D2Common_ExpireStatListEx_6FDB6E30((D2StatListExStrc*)pStatList);
+	D2Common_ExpireStatList_6FDB6E30((D2StatListExStrc*)pStatList);
 }
 
 //D2Common.0x6FDB91D0 (#10564)
@@ -2155,7 +2155,7 @@ void __stdcall STATLIST_ExpireUnitStatlist(D2UnitStrc* pUnused, D2UnitStrc* pUni
 {
 	if (pUnit && pUnit->pStatListEx)
 	{
-		D2Common_ExpireStatListEx_6FDB6E30(pUnit->pStatListEx);
+		D2Common_ExpireStatList_6FDB6E30(pUnit->pStatListEx);
 	}
 }
 


### PR DESCRIPTION
There were originally some doubts as to what the type of the `D2SLayerStatIdStrc::nLayer_StatId` was (signed or not).
While I can pretty firmly say that the game uses a signed value for comparisons (`D2Common.0x6FDB6323` uses a `jle` jump instruction, which is signed according to http://unixwiz.net/techtips/x86-jumps.html ), I think it is still interesting to use a dedicated type in function signatures instead of a plain `int`.
The reason I'm using `D2SLayerStatIdStrc::PackedType` and not `D2SLayerStatIdStrc` directly in the functions signatures is that it is an ABI break as calling conventions are not the same for integer types and structures. So instead I we use the integer type, which is a bit annoying because we need to explicitly access the `D2SLayerStatIdStrc::nPackedValue` member. (previously `D2SLayerStatIdStrc::nLayer_StatId` )

This also makes the code more explicit by using helper functions such as `D2SLayerStatIdStrc::MakeFromStatId` and `D2SLayerStatIdStrc::FromPackedType` instead of bit shifts.