### PR TITLE
Add D2Lang static and non-static Unicode::compare

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -7,8 +7,8 @@ EXPORTS
 ;   D2LANG_10018 @10018 ; ?Personalize@Unicode@@SIXPAU1@PBU1@1HW4ELANGUAGE@@@Z
     ?_toLowerTable@Unicode@@0PAGA @10019 ; Unicode::_toLowerTable
     ?_toUpperTable@Unicode@@0PAGA @10020 ; Unicode::_toUpperTable
-;   D2LANG_10021 @10021 ; ?compare@Unicode@@QBEHU1@@Z
-;   D2LANG_10022 @10022 ; ?compare@Unicode@@SIHU1@0@Z
+    ?compare@Unicode@@QBEHU1@@Z @10021 ; Unicode::compare
+    ?compare@Unicode@@SIHU1@0@Z @10022 ; static Unicode::compare
     ?directionality@Unicode@@QAE?AW4Direction@1@XZ @10023 ; Unicode::directionality
     ?isASCII@Unicode@@QBEHXZ @10024 ; Unicode::isASCII
 ;   D2LANG_10025 @10025 ; ?isAlpha@Unicode@@QBEHXZ

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -60,6 +60,14 @@ struct D2LANG_DLL_DECL Unicode {
   operator unsigned short() const;
 
   /**
+   * Performs case insensitive comparison between a Unicode code
+   * unit to another.
+   *
+   * D2Lang.0x6FC11150 (#10022) ?compare@Unicode@@SIHU1@0@Z
+   */
+  static BOOL __fastcall compare(Unicode lhs, Unicode rhs);
+
+  /**
    * Returns whether the specified character in the string is the last
    * character of a word. In this function, only characters in the
    * English alphabet or Arabic numerals are considered characters in
@@ -119,6 +127,14 @@ struct D2LANG_DLL_DECL Unicode {
    * D2Lang.0x6FC12B60 (#10053) ?toUtf@Unicode@@SIPADPADPBU1@H@Z
    */
   static char* __fastcall toUtf(char* dest, const Unicode* src, int count);
+
+  /**
+   * Performs case insensitive comparison between this Unicode code
+   * unit to another.
+   *
+   * D2Lang.0x6FC11110 (#10021) ?compare@Unicode@@QBEHU1@@Z
+   */
+  BOOL compare(Unicode ch) const;
 
   // D2Lang.0x6FC11C50 (#10023) ?directionality@Unicode@@QAE?AW4Direction@1@XZ
   Direction directionality();

--- a/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
@@ -150,6 +150,14 @@ Unicode::operator unsigned short() const {
   return this->ch;
 }
 
+BOOL __fastcall Unicode::compare(Unicode lhs, Unicode rhs) {
+  return lhs.toUpper().ch == rhs.toUpper().ch;
+}
+
+BOOL Unicode::compare(Unicode ch) const {
+  return this->toUpper().ch == ch.toUpper().ch;
+}
+
 Unicode::Direction Unicode::directionality() {
   /*
    * Hebrew, Arabic, Syriac, Arabic Supplement, Thaana, NKo,


### PR DESCRIPTION
These changes add the static and non-static Unicode::compare functions. The functions perform case-insensitive comparison between two Unicode code points.

When compiled with Visual C++ 6.0, the binary is identical to its vanilla counterpart.