### PR TITLE
Add D2Lang.Unicode::isNewline

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -14,7 +14,7 @@ EXPORTS
 ;   D2LANG_10025 @10025 ; ?isAlpha@Unicode@@QBEHXZ
 ;   D2LANG_10026 @10026 ; ?isLeftToRight@Unicode@@QBEHXZ
 ;   D2LANG_10027 @10027 ; ?isLineBreak@Unicode@@SIHPBU1@I@Z
-;   D2LANG_10028 @10028 ; ?isNewline@Unicode@@QBEHXZ
+    ?isNewline@Unicode@@QBEHXZ @10028 ; Unicode::isNewline
 ;   D2LANG_10029 @10029 ; ?isPipe@Unicode@@QBEHXZ
 ;   D2LANG_10030 @10030 ; ?isWhitespace@Unicode@@QBEHXZ
     ?isWordEnd@Unicode@@SIHPBU1@I@Z @10031 ; Unicode::isWordEnd

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -132,6 +132,9 @@ struct D2LANG_DLL_DECL Unicode {
    */
   BOOL isASCII() const;
 
+  // D2Lang.0x6FC11050 (#10028) ?isNewline@Unicode@@QBEHXZ
+  BOOL isNewline() const;
+
   /**
    * Returns this character's lowercase if there is a lowercase for
    * this character. Otherwise, returns a copy of this character.

--- a/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
@@ -255,6 +255,10 @@ BOOL Unicode::isASCII() const {
   return this->ch < 0x80;
 }
 
+BOOL Unicode::isNewline() const {
+  return this->ch == L'\n';
+}
+
 Unicode Unicode::toLower() const {
   if (this->ch > 0xFF) {
     return this->ch;


### PR DESCRIPTION
These changes add the D2Lang.Unicode::isNewline function. The function checks whether the Unicode character is a newline character, represented by the decimal value 10.

When compiled with Visual C++ 6.0, the binary is identical to its vanilla counterpart.