### PR TITLE
Add D2Lang.Unicode::isPipe

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -15,7 +15,7 @@ EXPORTS
 ;   D2LANG_10026 @10026 ; ?isLeftToRight@Unicode@@QBEHXZ
 ;   D2LANG_10027 @10027 ; ?isLineBreak@Unicode@@SIHPBU1@I@Z
     ?isNewline@Unicode@@QBEHXZ @10028 ; Unicode::isNewline
-;   D2LANG_10029 @10029 ; ?isPipe@Unicode@@QBEHXZ
+    ?isPipe@Unicode@@QBEHXZ @10029 ; Unicode::isPipe
 ;   D2LANG_10030 @10030 ; ?isWhitespace@Unicode@@QBEHXZ
     ?isWordEnd@Unicode@@SIHPBU1@I@Z @10031 ; Unicode::isWordEnd
 ;   D2LANG_10032 @10032 ; ?loadSysMap@Unicode@@SIHPAUHD2ARCHIVE__@@PBD@Z

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -135,6 +135,9 @@ struct D2LANG_DLL_DECL Unicode {
   // D2Lang.0x6FC11050 (#10028) ?isNewline@Unicode@@QBEHXZ
   BOOL isNewline() const;
 
+  // D2Lang.0x6FC11060 (#10029) ?isPipe@Unicode@@QBEHXZ
+  BOOL isPipe() const;
+
   /**
    * Returns this character's lowercase if there is a lowercase for
    * this character. Otherwise, returns a copy of this character.

--- a/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
@@ -259,6 +259,14 @@ BOOL Unicode::isNewline() const {
   return this->ch == L'\n';
 }
 
+BOOL Unicode::isPipe() const {
+  if (this->ch < 0x100) {
+    return this->ch == 0xFF;
+  }
+
+  return FALSE;
+}
+
 Unicode Unicode::toLower() const {
   if (this->ch > 0xFF) {
     return this->ch;


### PR DESCRIPTION
These changes add the D2Lang.Unicode::isPipe function. The function checks whether the Unicode character is equal to the decimal value 255.

When compiled with Visual C++ 6.0, the binary is identical to its vanilla counterpart.