### PR TITLE
Add D2Lang.Unicode::isAlpha

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -11,7 +11,7 @@ EXPORTS
 ;   D2LANG_10022 @10022 ; ?compare@Unicode@@SIHU1@0@Z
     ?directionality@Unicode@@QAE?AW4Direction@1@XZ @10023 ; Unicode::directionality
     ?isASCII@Unicode@@QBEHXZ @10024 ; Unicode::isASCII
-;   D2LANG_10025 @10025 ; ?isAlpha@Unicode@@QBEHXZ
+    ?isAlpha@Unicode@@QBEHXZ @10025 ; Unicode::isAlpha
 ;   D2LANG_10026 @10026 ; ?isLeftToRight@Unicode@@QBEHXZ
 ;   D2LANG_10027 @10027 ; ?isLineBreak@Unicode@@SIHPBU1@I@Z
     ?isNewline@Unicode@@QBEHXZ @10028 ; Unicode::isNewline

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -132,6 +132,14 @@ struct D2LANG_DLL_DECL Unicode {
    */
   BOOL isASCII() const;
 
+  /**
+   * Returns whether or not this Unicode character is an alphabetic
+   * character.
+   *
+   * D2Lang.0x6FC11090 (#10025) ?isAlpha@Unicode@@QBEHXZ
+   */
+  BOOL isAlpha() const;
+
   // D2Lang.0x6FC11050 (#10028) ?isNewline@Unicode@@QBEHXZ
   BOOL isNewline() const;
 

--- a/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
@@ -255,6 +255,10 @@ BOOL Unicode::isASCII() const {
   return this->ch < 0x80;
 }
 
+BOOL Unicode::isAlpha() const {
+  return (isASCII() && ::isalpha((char)this->ch));
+}
+
 BOOL Unicode::isNewline() const {
   return this->ch == L'\n';
 }


### PR DESCRIPTION
These changes add the D2Lang.Unicode::isAlpha function. The function checks whether the Unicode character is an alphabetic character (as defined by 7-bit ASCII).

When compiled with Visual C++ 6.0, the binary is identical to its vanilla counterpart.