### PR TITLE
Add D2Lang.Unicode::isWhitespace

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -16,7 +16,7 @@ EXPORTS
 ;   D2LANG_10027 @10027 ; ?isLineBreak@Unicode@@SIHPBU1@I@Z
     ?isNewline@Unicode@@QBEHXZ @10028 ; Unicode::isNewline
     ?isPipe@Unicode@@QBEHXZ @10029 ; Unicode::isPipe
-;   D2LANG_10030 @10030 ; ?isWhitespace@Unicode@@QBEHXZ
+    ?isWhitespace@Unicode@@QBEHXZ @10030 ; Unicode::isWhitespace
     ?isWordEnd@Unicode@@SIHPBU1@I@Z @10031 ; Unicode::isWordEnd
 ;   D2LANG_10032 @10032 ; ?loadSysMap@Unicode@@SIHPAUHD2ARCHIVE__@@PBD@Z
 ;   D2LANG_10033 @10033 ; ?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -138,6 +138,9 @@ struct D2LANG_DLL_DECL Unicode {
   // D2Lang.0x6FC11060 (#10029) ?isPipe@Unicode@@QBEHXZ
   BOOL isPipe() const;
 
+  // D2Lang.0x6FC11030 (#10030) ?isWhitespace@Unicode@@QBEHXZ
+  BOOL isWhitespace() const;
+
   /**
    * Returns this character's lowercase if there is a lowercase for
    * this character. Otherwise, returns a copy of this character.

--- a/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeChar.cpp
@@ -267,6 +267,14 @@ BOOL Unicode::isPipe() const {
   return FALSE;
 }
 
+BOOL Unicode::isWhitespace() const {
+  if (this->ch < 0x100) {
+    return ::isspace(this->ch);
+  }
+
+  return FALSE;
+}
+
 Unicode Unicode::toLower() const {
   if (this->ch > 0xFF) {
     return this->ch;


### PR DESCRIPTION
These changes add the D2Lang.Unicode::isWhitespace function. The function checks whether the Unicode character is a whitespace character.

When compiled with Visual C++ 6.0, the binary is identical to its vanilla counterpart.