### PR TITLE
Add D2Lang.Unicode::strchr

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -21,7 +21,7 @@ EXPORTS
 ;   D2LANG_10032 @10032 ; ?loadSysMap@Unicode@@SIHPAUHD2ARCHIVE__@@PBD@Z
 ;   D2LANG_10033 @10033 ; ?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ
     ?strcat@Unicode@@SIPAU1@PAU1@PBU1@@Z @10034 ; Unicode::strcat
-;   D2LANG_10035 @10035 ; ?strchr@Unicode@@SIPAU1@PBU1@U1@@Z
+    ?strchr@Unicode@@SIPAU1@PBU1@U1@@Z @10035 ; Unicode::strchr
     ?strcmp@Unicode@@SIHPBU1@0@Z @10036 ; Unicode::strcmp
 ;   D2LANG_10037 @10037 ; ?strcoll@Unicode@@SIHPBU1@0@Z
     ?strcpy@Unicode@@SIPAU1@PAU1@PBU1@@Z @10038 ; Unicode::strcpy

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -87,6 +87,17 @@ struct D2LANG_DLL_DECL Unicode {
   static Unicode* __fastcall strcat(Unicode* dest, const Unicode* src);
 
   /**
+   * Returns the first occurrence of a character in a null-terminated
+   * string.
+   *
+   * If the character could not be found, or the character to find is
+   * the null-terminating character, then the function returns NULL.
+   *
+   * D2Lang.0x6FC113C0 (#10035) ?strchr@Unicode@@SIPAU1@PBU1@U1@@Z
+   */
+  static Unicode* __fastcall strchr(const Unicode* str, Unicode ch);
+
+  /**
    * Compares two null-terminated strings lexicographically. Returns
    * -1, 0, or 1, depending on the results of the comparison.
    *

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -46,6 +46,16 @@ Unicode* __fastcall Unicode::strcat(Unicode* dest, const Unicode* src) {
   return dest;
 }
 
+Unicode* __fastcall Unicode::strchr(const Unicode* str, Unicode ch) {
+  for (size_t i = 0; str[i].ch != L'\0'; ++i) {
+    if (str[i].ch == ch.ch) {
+      return (Unicode*)&str[i];
+    }
+  }
+
+  return NULL;
+}
+
 int __fastcall Unicode::strcmp(const Unicode* str1, const Unicode* str2) {
   /*
    * This loop does not run beyond the end of either string. If the


### PR DESCRIPTION
These changes add the D2Lang.Unicode::strchr function.

The function returns the first occurrence of a character in a null-terminated string. If the character could not be found, or the character to find is the null-terminating character, then the function returns NULL.

My own testing confirms that the function produces the same results as its vanilla counterpart.