### PR TITLE
Add D2lang.Unicode::stricmp

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -25,7 +25,7 @@ EXPORTS
     ?strcmp@Unicode@@SIHPBU1@0@Z @10036 ; Unicode::strcmp
 ;   D2LANG_10037 @10037 ; ?strcoll@Unicode@@SIHPBU1@0@Z
     ?strcpy@Unicode@@SIPAU1@PAU1@PBU1@@Z @10038 ; Unicode::strcpy
-;   D2LANG_10039 @10039 ; ?stricmp@Unicode@@SIHPBU1@0@Z
+    ?stricmp@Unicode@@SIHPBU1@0@Z @10039 ; Unicode::stricmp
     ?strlen@Unicode@@SIHPBU1@@Z @10040 ; Unicode::strlen
 ;   D2LANG_10041 @10041 ; ?strncat@Unicode@@SIPAU1@PAU1@PBU1@H@Z
 ;   D2LANG_10042 @10042 ; ?strncmp@Unicode@@SIHPBU1@0I@Z

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -104,6 +104,18 @@ struct D2LANG_DLL_DECL Unicode {
   static Unicode* __fastcall strcpy(Unicode* dest, const Unicode* src);
 
   /**
+   * Performs lexicographical, case-insensitive comparison between two
+   * null-terminated strings. Returns -1, 0, or 1, depending on the
+   * results of the comparison.
+   *
+   * If either string is the NULL pointer, then the behavior is
+   * undefined.
+   *
+   * D2Lang.0x6FC112A0 (#10039) ?stricmp@Unicode@@SIHPBU1@0@Z
+   */
+  static int __fastcall stricmp(const Unicode* str1, const Unicode* str2);
+
+  /**
    * Returns the length of the null-terminated string. If the string
    * pointer is NULL, the function returns 0;
    *

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -73,6 +73,27 @@ Unicode* __fastcall Unicode::strcpy(Unicode* dest, const Unicode* src) {
   return dest;
 }
 
+int __fastcall Unicode::stricmp(const Unicode* str1, const Unicode* str2) {
+  /*
+   * This loop does not run beyond the end of either string. If the
+   * end of only one string is reached, then a comparison between '\0'
+   * to a different character is made, and a return is guaranteed to
+   * happen.
+   */
+  for (size_t i = 0; (str1[i].ch != L'\0') || (str2[i].ch != L'\0'); ++i) {
+    Unicode ch1_upper = str1[i].toUpper();
+    Unicode ch2_upper = str2[i].toUpper();
+
+    if (ch1_upper.ch < ch2_upper.ch) {
+      return -1;
+    } else if (ch1_upper.ch > ch2_upper.ch) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
 int __fastcall Unicode::strlen(const Unicode* str) {
   if (str == NULL) {
     return 0;


### PR DESCRIPTION
These changes add the D2Lang.Unicode::stricmp function.

The function performs lexicographical, case-insensitive comparison between two null-terminated strings. It returns -1, 0, or 1, depending on the result of the comparison.

My own testing confirms that the function produces the same results as its vanilla counterpart.