### PR TITLE
Add the D2Hell library (mostly empty except for Fault.cpp/.h)

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_subdirectory(D2CommonDefinitions)
 add_subdirectory(Fog)
+add_subdirectory(D2Hell)
 add_subdirectory(D2CMP)
 add_subdirectory(D2Lang)
 add_subdirectory(D2Common)

--- a/source/D2Hell/CMakeLists.txt
+++ b/source/D2Hell/CMakeLists.txt
@@ -1,0 +1,19 @@
+# This library is linked statically by each DLL.
+# Any modules (exe or DLL) linking it will need to include Fault.h after defining XFAULT_IMPL and XFAULT_MODULE_NAME in EXACTLY one of its translation units (.cpp file).
+
+add_library(D2Hell
+  STATIC
+    src/Archive.cpp
+    src/CRC.cpp
+    src/Fault.cpp
+    src/Window.cpp
+
+    include/Archive.h
+    include/CRC.h
+    include/Fault.h
+    include/Window.h
+)
+# The definition file that matches functions with their ordinals
+target_include_directories(D2Hell PUBLIC include)
+
+target_link_libraries(D2Hell PUBLIC Fog)

--- a/source/D2Hell/include/Archive.h
+++ b/source/D2Hell/include/Archive.h
@@ -1,0 +1,2 @@
+#pragma once
+

--- a/source/D2Hell/include/CRC.h
+++ b/source/D2Hell/include/CRC.h
@@ -1,0 +1,2 @@
+#pragma once
+

--- a/source/D2Hell/include/Fault.h
+++ b/source/D2Hell/include/Fault.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include <Windows.h>
+
+typedef void(__stdcall* FaultAssertHandler)(const char*, unsigned __int32, const char*);
+typedef BOOL(__stdcall* MessageSource)(DWORD dwMessageId, char* buffer, unsigned int iMaxLength);
+
+//D2OpenGL.0x1000948F
+void __fastcall FaultGetString(DWORD dwMessageId, char* buffer, unsigned int iMaxLength);
+
+//D2OpenGL.0x1000934F
+FaultAssertHandler __fastcall FaultSetAssertHandler(FaultAssertHandler newAssertHandler);
+
+//D2OpenGL.0x10009370
+void __fastcall FaultRegisterMessageSource(MessageSource newMessageSource);
+
+//D2OpenGL.0x10009782
+BOOL __fastcall FaultDoAssert(const char* a1, unsigned int a2, const char* a3);
+
+//D2OpenGL.0x100095EC
+void __cdecl FaultExit();
+
+
+
+// See comment near #ifdef XFAULT_IMPL if you get linker errors using any of the XFault functions
+BOOL __fastcall XFaultMessage(const char* msg);
+BOOL XFaultMessage(DWORD errorCode, ...);
+
+BOOL __fastcall XFaultFatal(const char* msg);
+BOOL XFaultFatal(DWORD errorCode, ...);
+
+BOOL XFaultContinuableError(DWORD errorCode, ...);
+
+
+
+// To use any of the XFault functions, you need to include this header with XFAULT_IMPL and XFAULT_MODULE_NAME defined in ONE (and only one) of the .cpp files of your .dll.
+#ifdef XFAULT_IMPL
+
+const char* gpszModuleName = XFAULT_MODULE_NAME;
+
+
+BOOL __fastcall XFaultMessage(const char* msg)
+{
+	MessageBoxA(0, msg, gpszModuleName, MB_ICONHAND | MB_TASKMODAL);
+	return TRUE;
+}
+
+BOOL XFaultMessage(DWORD errorCode, ...)
+{
+	va_list va;
+	CHAR faultStringBuffer[512];
+	CHAR msgBuffer[512];
+
+	va_start(va, errorCode);
+	FaultGetString(errorCode, faultStringBuffer, sizeof(faultStringBuffer));
+	wvsprintfA(msgBuffer, faultStringBuffer, va);
+	va_end(va);
+	return XFaultMessage(msgBuffer);
+}
+
+BOOL __fastcall XFaultFatal(const char* msg)
+{
+	MessageBoxA(0, msg, gpszModuleName, MB_ICONHAND | MB_TASKMODAL);
+	FaultExit();
+	return FALSE;
+}
+
+BOOL XFaultFatal(DWORD errorCode, ...)
+{
+	va_list va;
+	CHAR faultStringBuffer[512];
+	CHAR msgBuffer[512];
+
+	va_start(va, errorCode);
+	FaultGetString(errorCode, faultStringBuffer, sizeof(faultStringBuffer));
+	wvsprintfA(msgBuffer, faultStringBuffer, va);
+	va_end(va);
+	return XFaultFatal(msgBuffer);
+}
+
+
+BOOL XFaultContinuableError(DWORD errorCode, ...)
+{
+	va_list va;
+	CHAR faultStringBuffer[512];
+	CHAR msgBuffer[512];
+
+	va_start(va, errorCode);
+	FaultGetString(errorCode, faultStringBuffer, sizeof(faultStringBuffer));
+	wvsprintfA(msgBuffer, faultStringBuffer, va);
+	va_end(va);
+	const int buttonID = MessageBoxA(0, msgBuffer, gpszModuleName, MB_RETRYCANCEL | MB_ICONHAND | MB_DEFBUTTON3 | MB_TASKMODAL);
+	if (buttonID == IDRETRY)
+		return 1;
+	FaultExit();
+	return 0;
+}
+
+
+#endif

--- a/source/D2Hell/include/Window.h
+++ b/source/D2Hell/include/Window.h
@@ -1,0 +1,2 @@
+#pragma once
+

--- a/source/D2Hell/src/Archive.cpp
+++ b/source/D2Hell/src/Archive.cpp
@@ -1,0 +1,1 @@
+#include "Archive.h"

--- a/source/D2Hell/src/CRC.cpp
+++ b/source/D2Hell/src/CRC.cpp
@@ -1,0 +1,1 @@
+#include "CRC.h"

--- a/source/D2Hell/src/Fault.cpp
+++ b/source/D2Hell/src/Fault.cpp
@@ -1,0 +1,129 @@
+#include "Fault.h"
+#include <Windows.h>
+#include <Fog.h>
+#include <list>
+
+
+bool sgfFaultInited = false;
+CRITICAL_SECTION sgcsFault;
+FaultAssertHandler sgpfnAssertHandler;
+
+extern const char* gpszModuleName; // Initialized by the .dll to the value of XFAULT_MODULE_NAME when including "Fault.h" with both XFAULT_IMPL and XFAULT_MODULE_NAME defined before.
+
+static const char* sgszUnknownError = "D2Hell Fault.cpp error.";
+static const char* sgszAssertFormatString = "An assertion has failed.\n\nFile:\t\t % s\nLine:\t\t % d\nExpression:\t % s\n\nAbort to exit, Retry to break, Ignore to continue";
+
+static_assert((MB_TASKMODAL | MB_ICONHAND) == 0x2010, "Make sure we have the correct MessageBox options");
+static_assert((MB_RETRYCANCEL | MB_ICONHAND | MB_DEFBUTTON3 | MB_TASKMODAL) == 0x2215, "Make sure we have the correct MessageBox options");
+static_assert((MB_RETRYCANCEL | MB_ICONHAND | MB_DEFBUTTON3 | MB_TASKMODAL | MB_SETFOREGROUND | MB_TOPMOST) == 0x52215, "Make sure we have the correct MessageBox options");
+
+#if 1
+// Note: the game uses a TSExplicitList, but there's not much point in rewriting it for now.
+static std::list<MessageSource> sgMessageSourceList;
+#else
+struct TMESSAGESOURCE;
+TMESSAGESOURCE sglFaultMessageSource;
+#endif
+void __cdecl sFaultAtExit()
+{
+    EnterCriticalSection(&sgcsFault);
+#if 1
+    sgMessageSourceList.clear();
+#else
+    TMESSAGESOURCE* v0; // [esp+0h] [ebp-Ch]
+    while (1)
+    {
+        v0 = (TMESSAGESOURCE*)(*((int*)&unk_1005C6A4 + 1) <= 0 ? 0 : *((_DWORD*)&unk_1005C6A4 + 1));
+        if (!v0)
+            break;
+        TMESSAGESOURCE::~TMESSAGESOURCE(v0);
+        SMemFree(v0, ".?AUTMESSAGESOURCE@@", -2, 0);
+    }
+#endif
+    LeaveCriticalSection(&sgcsFault);
+    DeleteCriticalSection(&sgcsFault);
+    sgfFaultInited = false;
+}
+
+void __cdecl sFaultInit()
+{
+    if (!sgfFaultInited)
+    {
+        InitializeCriticalSection(&sgcsFault);
+        atexit(sFaultAtExit);
+        sgfFaultInited = true;
+    }
+}
+
+FaultAssertHandler __fastcall FaultSetAssertHandler(FaultAssertHandler newAssertHandler)
+{
+    const FaultAssertHandler oldHandler = sgpfnAssertHandler;
+    sgpfnAssertHandler = newAssertHandler;
+    return oldHandler;
+}
+
+
+void __fastcall FaultGetString(DWORD dwMessageId, char* buffer, unsigned int iMaxLength)
+{
+
+    if (sgfFaultInited)
+    {
+        EnterCriticalSection(&sgcsFault);
+#if 1
+        for (MessageSource messageSource : sgMessageSourceList)
+        {
+
+#else
+        TMESSAGESOURCE* v3;
+        TMESSAGESOURCE* i;
+        if (*((int*)&unk_1005C6A4 + 1) <= 0)
+            v3 = 0;
+        else
+            v3 = (TMESSAGESOURCE*)*((_DWORD*)&unk_1005C6A4 + 1);
+        for (i = v3; (int)i > 0; i = *(TMESSAGESOURCE**)((char*)i + sglFaultMessageSource + 4))
+        {
+            const MessageSource messageSource = (*(MessageSource*)((void**)i + 2));
+#endif
+            if (messageSource(dwMessageId, buffer, iMaxLength))
+            {
+                LeaveCriticalSection(&sgcsFault);
+                return;
+            }
+        }
+        LeaveCriticalSection(&sgcsFault);
+    }
+    lstrcpynA(buffer, sgszUnknownError, iMaxLength);
+}
+
+
+void __fastcall FaultRegisterMessageSource(MessageSource newMessageSource)
+{
+    if (!sgfFaultInited)
+        sFaultInit();
+    EnterCriticalSection(&sgcsFault);
+#if 1 
+    sgMessageSourceList.push_front(newMessageSource);
+#else
+    *(_DWORD*)(TSList<TMESSAGESOURCE, TSGetExplicitLink<TMESSAGESOURCE>>::NewNode(1, 0, 0) + 8) = a1;
+#endif
+    LeaveCriticalSection(&sgcsFault);
+}
+
+BOOL __fastcall FaultDoAssert(const char* a1, unsigned int a2, const char* a3)
+{
+    CHAR Text[512];
+    
+    if (sgpfnAssertHandler)
+        sgpfnAssertHandler(a1, a2, a3);
+    wsprintfA(Text, sgszAssertFormatString, a1, a2, a3);
+    const int buttonID = MessageBoxA(0, Text, gpszModuleName, MB_RETRYCANCEL | MB_ICONHAND | MB_DEFBUTTON3 | MB_TASKMODAL | MB_SETFOREGROUND | MB_TOPMOST);
+    if (buttonID != IDABORT)
+        return buttonID == IDRETRY;
+    FaultExit();
+    return 1;
+}
+
+void __cdecl FaultExit()
+{
+    TerminateProcess(GetCurrentProcess(), -1);
+}

--- a/source/D2Hell/src/Window.cpp
+++ b/source/D2Hell/src/Window.cpp
@@ -1,0 +1,1 @@
+#include "Window.h"


### PR DESCRIPTION
There are recurring functions in multiple DLLs that are related to reading files from MPQ archives and Assert handling.
They are coming from a static library identified as `D2Hell`.

This pull requests adds this library to the project and also implements the asserts part of the dll (`Fault.cpp` and `Fault.h` ).
There were probably helper macros to use the functions in those files, but those are left for later.

List of modules confirmed to be linking `D2Hell`:

- D2Client.dll
- D2CMP.dll
- D2Common.dll
- D2Game.dll
- D2Gfx.dll
- D2Lang.dll
- D2OpenGL.dll
- D2Sound.dll
- D2VidTst.exe
- D2Win.dll

For now those modules are not linking `D2Hell` in D2MOO, as we'll need to implement it / copy existing code from those modules to avoid duplicates. Ideally we should reference the addresses of each module in the headers for known functions.


