### PR TITLE
Add D2Lang.Unicode::strncmp

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -28,7 +28,7 @@ EXPORTS
     ?stricmp@Unicode@@SIHPBU1@0@Z @10039 ; Unicode::stricmp
     ?strlen@Unicode@@SIHPBU1@@Z @10040 ; Unicode::strlen
 ;   D2LANG_10041 @10041 ; ?strncat@Unicode@@SIPAU1@PAU1@PBU1@H@Z
-;   D2LANG_10042 @10042 ; ?strncmp@Unicode@@SIHPBU1@0I@Z
+    ?strncmp@Unicode@@SIHPBU1@0I@Z @10042 ; Unicode::strncmp
 ;   D2LANG_10043 @10043 ; ?strncoll@Unicode@@SIHPBU1@0H@Z
 ;   D2LANG_10044 @10044 ; ?strncpy@Unicode@@SIPAU1@PAU1@PBU1@H@Z
 ;   D2LANG_10045 @10045 ; ?strnicmp@Unicode@@SIHPBU1@0I@Z

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -134,6 +134,25 @@ struct D2LANG_DLL_DECL Unicode {
    */
   static int __fastcall strlen(const Unicode* str);
 
+  /*
+   * Compares two null-terminated strings or substrings
+   * lexicographically. Returns -1, 0, or 1, depending on the results
+   * of the comparison.
+   *
+   * If either string is the NULL pointer, then the behavior is
+   * undefined.
+   *
+   * Vanilla bug: If one string is a prefix of another, then the
+   * function will always return 0, even when the specified count is
+   * greater than the length of the prefix.
+   *
+   * D2Lang.0x6FC11250 (#10042) ?strncmp@Unicode@@SIHPBU1@0I@Z
+   */
+  static int __fastcall strncmp(
+      const Unicode* str1,
+      const Unicode* str2,
+      size_t count);
+
   /**
    * Returns the first occurrence of a null-terminated substring in a
    * null-terminated string. If the substring is empty, or the

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -117,6 +117,27 @@ int __fastcall Unicode::strlen(const Unicode* str) {
   return i;
 }
 
+int __fastcall Unicode::strncmp(
+    const Unicode* str1,
+    const Unicode* str2,
+    size_t count) {
+  /*
+   * Vanilla bug: If one string is a prefix of the other string, then
+   * the loop ends early and 0 is returned.
+   */
+  for (size_t i = 0;
+      (str1[i].ch != L'\0') && (str2[i].ch != L'\0') && (i < count);
+      ++i) {
+    if (str1[i].ch < str2[i].ch) {
+      return -1;
+    } else if (str1[i].ch > str2[i].ch) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
 Unicode* __fastcall Unicode::strstr(
     const Unicode* str,
     const Unicode* substr) {


### PR DESCRIPTION
These changes add the D2Lang.Unicode::strncmp function.

The function performs lexicographical, case-insensitive comparison between two null-terminated strings, up to a specified length. It returns -1, 0, or 1, depending on the result of the comparison.

It also replicates a vanilla bug, where the the function returns 0 if one of the strings is a prefix of another.

My own testing confirms that the function produces the same results as its vanilla counterpart.