### PR TITLE
Inventory rewrite

### DIFF
--- a/source/D2Common/include/D2Dungeon.h
+++ b/source/D2Common/include/D2Dungeon.h
@@ -99,7 +99,7 @@ D2COMMON_DLL_DECL BOOL __stdcall DUNGEON_HasWaypoint(D2RoomStrc* pRoom);
 //D2Common.0x6FD8C840 (#10061)
 D2COMMON_DLL_DECL char* __stdcall DUNGEON_GetPickedLevelPrestFilePathFromRoom(D2RoomStrc* pRoom);
 //D2Common.0x6FD8C860 (#10066)
-D2COMMON_DLL_DECL void __stdcall DUNGEON_AllocDrlgDelete(D2RoomStrc* pRoom, int nUnitType, int nUnitId);
+D2COMMON_DLL_DECL void __stdcall DUNGEON_AllocDrlgDelete(D2RoomStrc* pRoom, int nUnitType, D2UnitGUID nUnitGuid);
 //D2Common.0x6FD8C8B0 (#10067)
 D2COMMON_DLL_DECL void __stdcall DUNGEON_FreeDrlgDelete(D2RoomStrc* pRoom);
 //D2Common.0x6FD8C910 (#10068)

--- a/source/D2Common/include/D2Inventory.h
+++ b/source/D2Common/include/D2Inventory.h
@@ -122,9 +122,9 @@ struct D2InventoryStrc
 	D2UnitStrc* pLastItem;					//0x10
 	D2InventoryGridStrc* pGrids;			//0x14
 	int32_t nGridCount;						//0x18
-	uint32_t dwLeftItemGUID;				//0x1C
+	D2UnitGUID dwLeftItemGUID;				//0x1C
 	D2UnitStrc* pCursorItem;				//0x20
-	uint32_t dwOwnerId;						//0x24
+	D2UnitGUID dwOwnerGuid;					//0x24
 	uint32_t dwItemCount;					//0x28
 	D2InventoryNodeStrc* pFirstNode;		//0x2C
 	D2InventoryNodeStrc* pLastNode;			//0x30
@@ -279,7 +279,7 @@ D2COMMON_DLL_DECL void __stdcall INVENTORY_UpdateWeaponGUIDOnRemoval(D2Inventory
 //D2Common.0x6FD91050 (#10291)
 D2COMMON_DLL_DECL int __stdcall INVENTORY_GetWieldType(D2UnitStrc* pPlayer, D2InventoryStrc* pInventory);
 //D2Common.0x6FD91140 (#10292)
-D2COMMON_DLL_DECL void __stdcall INVENTORY_SetOwnerId(D2InventoryStrc* pInventory, int nOwnerId);
+D2COMMON_DLL_DECL void __stdcall INVENTORY_SetOwnerId(D2InventoryStrc* pInventory, D2UnitGUID nOwnerId);
 //D2Common.0x6FD91160 (#10293)
 D2COMMON_DLL_DECL int __stdcall INVENTORY_GetOwnerId(D2InventoryStrc* pInventory);
 //D2Common.0x6FD91190 (#10294)
@@ -293,7 +293,7 @@ D2COMMON_DLL_DECL int __stdcall INVENTORY_GetCorpseCount(D2InventoryStrc* pInven
 //D2Common.0x6FD912D0 (#10313)
 D2COMMON_DLL_DECL D2CorpseStrc* __stdcall INVENTORY_GetNextCorpse(D2CorpseStrc* pCorpse);
 //D2Common.0x6FDAFEA0 (#10314)
-D2COMMON_DLL_DECL int __stdcall INVENTORY_GetUnitGUIDFromCorpse(D2CorpseStrc* pCorpse);
+D2COMMON_DLL_DECL D2UnitGUID __stdcall INVENTORY_GetUnitGUIDFromCorpse(D2CorpseStrc* pCorpse);
 //D2Common.0x6FDB18D0 (#10315)
 D2COMMON_DLL_DECL int __stdcall D2Common_10315(D2CorpseStrc* pCorpse);
 //D2Common.0x6FD912F0 (#10298)
@@ -315,7 +315,7 @@ D2UnitStrc* __stdcall INVENTORY_GetUnknownItem(D2UnitStrc* pItem);
 //D2Common.0x6FD920C0 (#10305)
 D2COMMON_DLL_DECL D2UnitStrc* __stdcall INVENTORY_UnitIsItem(D2UnitStrc* pItem);
 //D2Common.0x6FD920E0 (#10306)
-D2COMMON_DLL_DECL int __stdcall INVENTORY_GetItemGUID(D2UnitStrc* pItem);
+D2COMMON_DLL_DECL D2UnitGUID __stdcall INVENTORY_GetItemGUID(D2UnitStrc* pItem);
 //D2Common.0x6FD92100 (#10307)
 D2COMMON_DLL_DECL int __stdcall INVENTORY_GetItemNodePage(D2UnitStrc* pItem);
 //D2Common.0x6FD92140 (#10310)
@@ -323,7 +323,7 @@ D2COMMON_DLL_DECL D2UnitStrc* __stdcall INVENTORY_IsItemInInventory(D2InventoryS
 //D2Common.0x6FDAFEA0 (#10311)
 D2COMMON_DLL_DECL D2InventoryNodeStrc* __stdcall INVENTORY_GetNextNode(D2InventoryNodeStrc* pNode);
 //D2Common.0x6FD90AB0 (#10312)
-D2COMMON_DLL_DECL int __stdcall INVENTORY_GetItemGUIDFromNode(D2InventoryNodeStrc* pNode);
+D2COMMON_DLL_DECL D2UnitGUID __stdcall INVENTORY_GetItemGUIDFromNode(D2InventoryNodeStrc* pNode);
 //D2Common.0x6FD92180 (#10300)
 D2COMMON_DLL_DECL BOOL __stdcall INVENTORY_RemoveAllItems(D2InventoryStrc* pInventory);
 //D2Common.0x6FD921D0 (#10302)

--- a/source/D2Common/include/D2Inventory.h
+++ b/source/D2Common/include/D2Inventory.h
@@ -145,6 +145,12 @@ struct D2ItemExtraDataStrc
 };
 #pragma pack()
 
+// Helper functions
+// Check if the header signature is correct. Assumes non null ptr.
+inline bool INVENTORY_CheckSignature(D2InventoryStrc* pInventory) { return pInventory->dwSignature == D2C_InventoryHeader; }
+// Check if ptr is non null and if header signature is correct.
+inline D2InventoryStrc* INVENTORY_GetPtrIfValid(D2InventoryStrc* pInventory) { return (pInventory && INVENTORY_CheckSignature(pInventory)) ? pInventory : nullptr; }
+
 //D2Common.0x6FD8E210
 BOOL __fastcall INVENTORY_RemoveItem(D2UnitStrc* pItem);
 //D2Common.0x6FD8E4A0

--- a/source/D2Common/include/D2Inventory.h
+++ b/source/D2Common/include/D2Inventory.h
@@ -26,7 +26,8 @@ enum D2C_PlayerBodyLocs
 	BODYLOC_FEET,		//Boots
 	BODYLOC_GLOVES,		//Gloves
 	BODYLOC_SWRARM,		//Right-Hand on Switch
-	BODYLOC_SWLARM		//Left-Hand on Switch
+	BODYLOC_SWLARM,		//Left-Hand on Switch
+	NUM_BODYLOC
 };
 
 #define D2C_InventoryHeader 0x1020304
@@ -150,6 +151,8 @@ struct D2ItemExtraDataStrc
 inline bool INVENTORY_CheckSignature(D2InventoryStrc* pInventory) { return pInventory->dwSignature == D2C_InventoryHeader; }
 // Check if ptr is non null and if header signature is correct.
 inline D2InventoryStrc* INVENTORY_GetPtrIfValid(D2InventoryStrc* pInventory) { return (pInventory && INVENTORY_CheckSignature(pInventory)) ? pInventory : nullptr; }
+// Return true if matches a valid body location
+inline bool INVENTORY_ValidateBodyLoc(int nBodyLoc) { return nBodyLoc >= 0 && nBodyLoc < NUM_BODYLOC; }
 
 //D2Common.0x6FD8E210
 BOOL __fastcall INVENTORY_RemoveItem(D2UnitStrc* pItem);

--- a/source/D2Common/include/D2Items.h
+++ b/source/D2Common/include/D2Items.h
@@ -2,6 +2,7 @@
 
 #include "CommonDefinitions.h"
 #include <DataTbls/ItemsTbls.h>
+#include <Units/Units.h>
 //TODO: Revise
 
 #pragma pack(1)
@@ -204,6 +205,10 @@ struct D2ItemSaveStrc
 	int32_t nItemFileIndex;						//0x14
 };
 #pragma pack()
+
+// Helper function
+// Checks that the given unit is an item with data
+inline D2ItemDataStrc* ITEMS_GetItemData(D2UnitStrc* pItem) { return (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData) ? pItem->pItemData : nullptr; }
 
 //D2Common.0x6FD98380 (#10687)
 D2COMMON_DLL_DECL void __stdcall ITEMS_AllocItemData(void* pMemPool, D2UnitStrc* pItem);

--- a/source/D2Common/include/D2Items.h
+++ b/source/D2Common/include/D2Items.h
@@ -471,7 +471,7 @@ D2COMMON_DLL_DECL void __stdcall ITEMS_GetRealmData(D2UnitStrc* pItem, int* pRea
 //D2Common.0x6FD9E070 (#11245)
 D2COMMON_DLL_DECL void __stdcall ITEMS_SetRealmData(D2UnitStrc* pItem, int a2, int a3);
 //D2Common.0x6FD9E0A0 (#10734)
-D2COMMON_DLL_DECL void __stdcall ITEMS_SetOwnerId(D2UnitStrc* pItem, int nOwnerGUID);
+D2COMMON_DLL_DECL void __stdcall ITEMS_SetOwnerId(D2UnitStrc* pItem, D2UnitGUID nOwnerGUID);
 //D2Common.0x6FD9E120 (#10735)
 D2COMMON_DLL_DECL int __stdcall ITEMS_GetOwnerId(D2UnitStrc* pItem);
 //D2Common.0x6FD9E1A0 (#10736)

--- a/source/D2Common/include/D2Roster.h
+++ b/source/D2Common/include/D2Roster.h
@@ -100,8 +100,8 @@ struct D2RosterUnitStrc
 	uint32_t dwPartyFlags;					//0x30
 	D2RosterInfoStrc** pRosterInfo;			//0x34
 	D2RosterCorpseStrc* pCorpse;			//0x38
-	uint32_t dwSrcPortalGUID;				//0x3C
-	uint32_t dwDstPortalGUID;				//0x40
+	D2UnitGUID dwSrcPortalGUID;				//0x3C
+	D2UnitGUID dwDstPortalGUID;				//0x40
 	uint16_t unk0x44;						//0x44
 	uint8_t unk0x46[32];					//0x46
 	char szNameEx[26];						//0x66 - name with clan tag

--- a/source/D2Common/include/D2Skills.h
+++ b/source/D2Common/include/D2Skills.h
@@ -121,7 +121,7 @@ struct D2SkillStrc
 	};
 	union
 	{
-		uint32_t dwTargetGUID;					//0x20
+		D2UnitGUID dwTargetGUID;					//0x20
 		uint32_t nPar3;						//0x20
 	};
 
@@ -129,7 +129,7 @@ struct D2SkillStrc
 	int32_t nSkillLevel;						//0x28
 	uint32_t nLevelBonus;						//0x2C
 	int32_t nQuantity;							//0x30
-	int32_t nOwnerGUID;							//0x34 -1 = Native Skill
+	D2UnitGUID nOwnerGUID;						//0x34 -1 = Native Skill
 	int32_t nCharges;							//0x38
 };
 
@@ -191,7 +191,7 @@ void __fastcall SKILLS_SetUsedSkillInSkillList(D2SkillListStrc* pSkillList, D2Sk
 //D2Common.0x6FDAFF30
 D2SkillStrc* __fastcall SKILLS_GetUsedSkillFromSkillList(D2SkillListStrc* pSkillList);
 //D2Common.0x6FDAFF40 (#10949)
-D2COMMON_DLL_DECL D2SkillStrc* __fastcall SKILLS_GetSkillById(D2UnitStrc* pUnit, int nSkillId, int nOwnerGUID);
+D2COMMON_DLL_DECL D2SkillStrc* __fastcall SKILLS_GetSkillById(D2UnitStrc* pUnit, int nSkillId, D2UnitGUID nOwnerGUID);
 //D2Common.0x6FDAFF80 (#10950)
 D2COMMON_DLL_DECL D2SkillStrc* __fastcall SKILLS_GetHighestLevelSkillFromUnitAndId(D2UnitStrc* pUnit, int nSkillId);
 //D2Common.0x6FDAFFD0 (#10951)
@@ -209,17 +209,17 @@ D2COMMON_DLL_DECL D2SkillStrc* __stdcall SKILLS_AddSkill(D2UnitStrc* pUnit, int 
 //D2Common.0x6FDB04D0 (#10953)
 D2COMMON_DLL_DECL void __stdcall SKILLS_AssignSkill(D2UnitStrc* pUnit, int nSkillId, int nSkillLevel, BOOL bRemove, char* szFile, int nLine);
 //D2Common.0x6FDB05E0 (#10954)
-D2COMMON_DLL_DECL void __stdcall D2Common_10954(D2UnitStrc* pUnit, int nOwnerGUID, int nSkillId, int nSkillLevel, int nCharges, BOOL bFreeMemory);
+D2COMMON_DLL_DECL void __stdcall D2Common_10954(D2UnitStrc* pUnit, D2UnitGUID nOwnerGUID, int nSkillId, int nSkillLevel, int nCharges, BOOL bFreeMemory);
 //D2Common.0x6FDB08C0 (#10957)
-D2COMMON_DLL_DECL int __stdcall SKILLS_GetOwnerGUIDFromSkill(D2SkillStrc* pSkill);
+D2COMMON_DLL_DECL D2UnitGUID __stdcall SKILLS_GetOwnerGUIDFromSkill(D2SkillStrc* pSkill);
 //D2Common.0x6FDB08F0 (#10955)
-D2COMMON_DLL_DECL BOOL __stdcall SKILLS_GetSkillInfo(D2SkillStrc* pSkill, int* pOwnerGUID, int* pSkillId, int* pSkillLevel, int* pCharges);
+D2COMMON_DLL_DECL BOOL __stdcall SKILLS_GetSkillInfo(D2SkillStrc* pSkill, D2UnitGUID* pOwnerGUID, int* pSkillId, int* pSkillLevel, int* pCharges);
 //D2Common.0x6FDB0960 (#10956)
 D2COMMON_DLL_DECL BOOL __stdcall SKILLS_SetCharges(D2SkillStrc* pSkill, int nCharges);
 //D2Common.0x6FDB09A0 (#10961)
-D2COMMON_DLL_DECL void __stdcall SKILLS_SetLeftActiveSkill(D2UnitStrc* pUnit, int nSkillId, int nOwnerGUID);
+D2COMMON_DLL_DECL void __stdcall SKILLS_SetLeftActiveSkill(D2UnitStrc* pUnit, int nSkillId, D2UnitGUID nOwnerGUID);
 //D2Common.0x6FDB0A30 (#10962)
-D2COMMON_DLL_DECL void __stdcall SKILLS_SetRightActiveSkill(D2UnitStrc* pUnit, int nSkillId, int nOwnerGUID);
+D2COMMON_DLL_DECL void __stdcall SKILLS_SetRightActiveSkill(D2UnitStrc* pUnit, int nSkillId, D2UnitGUID nOwnerGUID);
 //D2Common.0x6FDB0AC0 (#10963)
 D2COMMON_DLL_DECL int __stdcall SKILLS_GetSkillIdFromSkill(D2SkillStrc* pSkill, char* szFile, int nLine);
 //D2Common.0x6FDB0AF0 (#10965)
@@ -295,7 +295,7 @@ D2COMMON_DLL_DECL int __stdcall SKILLS_GetRequiredLevelBasedOnCurrent(D2UnitStrc
 //D2Common.0x6FDB1C80 (#10988)
 D2COMMON_DLL_DECL BOOL __stdcall SKILLS_CheckRequiredSkills(D2UnitStrc* pUnit, int nSkillId);
 //D2Common.0x6FDB1F80
-D2SkillStrc* __fastcall SKILLS_GetSkill(D2UnitStrc* pUnit, int nSkillId, int nOwnerGUID);
+D2SkillStrc* __fastcall SKILLS_GetSkill(D2UnitStrc* pUnit, int nSkillId, D2UnitGUID nOwnerGUID);
 //D2Common.0x6FDB1FC0 (#10989)
 D2COMMON_DLL_DECL BOOL __stdcall SKILLS_CheckRequiredAttributes(D2UnitStrc* pUnit, int nSkillId);
 //D2Common.0x6FDB2110 (#10999)

--- a/source/D2Common/include/D2StatList.h
+++ b/source/D2Common/include/D2StatList.h
@@ -530,13 +530,13 @@ void __fastcall D2Common_STATLIST_FreeStatListImpl_6FDB7050(D2StatListStrc* pSta
 //D2Common.0x6FDB7110 (#10527)
 D2COMMON_DLL_DECL void __stdcall STATLIST_FreeStatListEx(D2UnitStrc* pUnit);
 //D2Common.0x6FDB7140 (#10470)
-D2COMMON_DLL_DECL D2StatListStrc* __stdcall STATLIST_AllocStatList(void* pMemPool, uint32_t fFilter, uint32_t dwTimeout, int nUnitType, int nUnitGUID);
+D2COMMON_DLL_DECL D2StatListStrc* __stdcall STATLIST_AllocStatList(void* pMemPool, uint32_t fFilter, uint32_t dwTimeout, int nUnitType, D2UnitGUID nUnitGUID);
 //D2Common.0x6FDB7190 (#10526)
 D2COMMON_DLL_DECL void __stdcall STATLIST_AllocStatListEx(D2UnitStrc* pUnit, char nFlags, void* pCallbackFunc, D2GameStrc* pGame);
 //D2Common.0x6FDB7260 (#10471)
 D2COMMON_DLL_DECL int __stdcall STATLIST_GetOwnerType(D2StatListStrc* pStatList);
 //D2Common.0x6FD912D0 (#10472)
-D2COMMON_DLL_DECL int __stdcall STATLIST_GetOwnerGUID(D2StatListStrc* pStatList);
+D2COMMON_DLL_DECL D2UnitGUID __stdcall STATLIST_GetOwnerGUID(D2StatListStrc* pStatList);
 //D2Common.0x6FDB7280 (#11304)
 D2COMMON_DLL_DECL int __stdcall STATLIST_GetBaseStatsCount(D2StatListStrc* pStatList);
 //D2Common.0x6FDB72A0 (#11305)

--- a/source/D2Common/include/Drlg/D2DrlgDrlg.h
+++ b/source/D2Common/include/Drlg/D2DrlgDrlg.h
@@ -176,7 +176,7 @@ struct D2RoomStrc
 	int32_t unk0x60;							//0x60
 	uint8_t nCurrentDeathIndex;				//0x64
 	uint8_t pad0x65[3];						//0x65
-	int32_t nLastDeadGUIDs[4];					//0x68
+	D2UnitGUID nLastDeadGUIDs[4];					//0x68
 	D2DrlgActStrc* pAct;					//0x78
 	D2RoomStrc* pRoomNext;					//0x7C
 };
@@ -303,8 +303,8 @@ struct D2DrlgBuildStrc
 struct D2DrlgDeleteStrc
 {
 	int32_t nUnitType;							//0x00
-	int32_t nUnitGUID;							//0x04
-	D2DrlgDeleteStrc* pNext;				//0x08
+	D2UnitGUID nUnitGUID;						//0x04
+	D2DrlgDeleteStrc* pNext;					//0x08
 };
 
 struct D2DrlgFileStrc

--- a/source/D2Common/include/Path/Path.h
+++ b/source/D2Common/include/Path/Path.h
@@ -295,7 +295,7 @@ D2COMMON_DLL_DECL BOOL __stdcall D2Common_10174(D2DynamicPathStrc* pDynamicPath)
 //D2Common.0x6FDA9F40 (#10179)
 D2COMMON_DLL_DECL void __stdcall PATH_SetTargetUnit(D2DynamicPathStrc* pDynamicPath, D2UnitStrc* pUnit);
 //D2Common.0x6FDA9F60 (#10171)
-D2COMMON_DLL_DECL void __stdcall PATH_GetTargetTypeAndGUID(D2DynamicPathStrc* pDynamicPath, int* pTargetType, int* pTargetGUID);
+D2COMMON_DLL_DECL void __stdcall PATH_GetTargetTypeAndGUID(D2DynamicPathStrc* pDynamicPath, int* pTargetType, D2UnitGUID* pTargetGUID);
 //D2Common.0x6FDA9FA0 (#10180)
 D2COMMON_DLL_DECL D2UnitStrc* __stdcall PATH_GetTargetUnit(D2DynamicPathStrc* pDynamicPath);
 //D2Common.0x6FDA9FC0 (#10181)

--- a/source/D2Common/include/Units/Item.h
+++ b/source/D2Common/include/Units/Item.h
@@ -8,7 +8,7 @@ struct D2ItemDataStrc
 {
 	uint32_t dwQualityNo;						//0x00
 	D2SeedStrc pSeed;						//0x04
-	uint32_t dwOwnerGUID;						//0x0C
+	D2UnitGUID dwOwnerGUID;						//0x0C
 	uint32_t dwInitSeed;						//0x10
 	uint32_t dwCommandFlags;					//0x14
 	uint32_t dwItemFlags;						//0x18

--- a/source/D2Common/include/Units/Missile.h
+++ b/source/D2Common/include/Units/Missile.h
@@ -75,9 +75,9 @@ struct D2MissileDataStrc
 	uint16_t unk0x12;							//0x12
 	uint32_t fFlags;							//0x14
 	int32_t nOwnerType;							//0x18
-	uint32_t dwOwnerGUID;						//0x1C
+	D2UnitGUID dwOwnerGUID;						//0x1C
 	int32_t nHomeType;							//0x20
-	uint32_t dwHomeGUID;						//0x24
+	D2UnitGUID dwHomeGUID;						//0x24
 	union
 	{
 		struct
@@ -184,7 +184,7 @@ D2COMMON_DLL_DECL int __stdcall MISSILE_GetTargetY(D2UnitStrc* pMissile);
 //D2Common.0x6FDBA510 (#11144)
 D2COMMON_DLL_DECL void __stdcall MISSILE_SetHomeType(D2UnitStrc* pMissile, D2UnitStrc* pTarget);
 //D2Common.0x6FDBA550 (#11145)
-D2COMMON_DLL_DECL void __stdcall MISSILE_GetHomeType(D2UnitStrc* pMissile, int* nHomeType, int* nHomeGUID);
+D2COMMON_DLL_DECL void __stdcall MISSILE_GetHomeType(D2UnitStrc* pMissile, int* nHomeType, D2UnitGUID* nHomeGUID);
 //D2Common.0x6FDBA5B0 (#11217)
 D2COMMON_DLL_DECL void __stdcall MISSILE_CalculateDamageData(D2MissileDamageDataStrc* pMissileDamageData, D2UnitStrc* pOwner, D2UnitStrc* pOrigin, D2UnitStrc* pMissile, int nLevel);
 //D2Common.0x6FDBADF0

--- a/source/D2Common/include/Units/Object.h
+++ b/source/D2Common/include/Units/Object.h
@@ -36,7 +36,7 @@ struct D2ObjectDataStrc
 	uint8_t nPortalFlags;					//0x05
 	uint16_t unk0x06;						//0x06
 	D2ShrinesTxt* pShrineTxt;				//0x08
-	uint32_t dwOperateGUID;					//0x0C
+	D2UnitGUID dwOperateGUID;					//0x0C
 	BOOL bPermanent;						//0x10
 	uint32_t __014;							//0x14
 	D2CoordStrc DestRoomCooords;			//0x18

--- a/source/D2Common/include/Units/Player.h
+++ b/source/D2Common/include/Units/Player.h
@@ -91,7 +91,7 @@ struct D2PlayerDataStrc
 	int32_t nSwitchLeftSkillId;					//0x84
 	int32_t nSwitchRightSkillFlags;				//0x88
 	int32_t nSwitchLeftSkillFlags;				//0x8C
-	int32_t nWeaponGUID;						//0x90
+	D2UnitGUID nWeaponGUID;						//0x90
 	uint32_t unk0x94[2];						//0x94
 	D2ClientStrc* pClient;					//0x9C
 	uint32_t unk0xA0[48];						//0xA0

--- a/source/D2Common/include/Units/Units.h
+++ b/source/D2Common/include/Units/Units.h
@@ -79,7 +79,7 @@ struct D2UnitStrc
 	uint32_t dwUnitType;						//0x00
 	int32_t dwClassId;							//0x04
 	void* pMemoryPool;							//0x08
-	uint32_t dwUnitId;							//0x0C
+	D2UnitGUID dwUnitId;						//0x0C
 	union										//0x10
 	{
 		uint32_t dwAnimMode;					//Player, Monster, Object, Items
@@ -122,7 +122,7 @@ struct D2UnitStrc
 	{
 		struct									//Server Unit
 		{
-			uint32_t dwInteractGUID;			//0x064
+			D2UnitGUID dwInteractGUID;			//0x064
 			uint32_t dwInteractType;			//0x068
 			uint16_t nInteract;					//0x06C
 			uint16_t nUpdateType;				//0x06E
@@ -153,9 +153,9 @@ struct D2UnitStrc
 		};
 	};
 	uint32_t dwOwnerType;						//0x94
-	uint32_t dwOwnerGUID;						//0x98
+	D2UnitGUID dwOwnerGUID;						//0x98
 	uint32_t dwKillerType;						//0x09C
-	uint32_t dwKillerGUID;						//0x0A0
+	D2UnitGUID dwKillerGUID;						//0x0A0
 	D2HoverTextStrc* pHoverText;				//0xA4
 	D2SkillListStrc* pSkills;					//0xA8
 	D2CombatStrc* pCombat;						//0xAC
@@ -251,7 +251,7 @@ D2COMMON_DLL_DECL void __stdcall UNITS_SetTargetUnitForDynamicUnit(D2UnitStrc* p
 //D2Common.0x6FDBE330 (#10345)
 D2COMMON_DLL_DECL int __stdcall UNITS_GetTargetTypeFromDynamicUnit(D2UnitStrc* pUnit);
 //D2Common.0x6FDBE3A0 (#10346)
-D2COMMON_DLL_DECL int __stdcall UNITS_GetTargetGUIDFromDynamicUnit(D2UnitStrc* pUnit);
+D2COMMON_DLL_DECL D2UnitGUID __stdcall UNITS_GetTargetGUIDFromDynamicUnit(D2UnitStrc* pUnit);
 //D2Common.0x6FDBE410 (#10347)
 D2COMMON_DLL_DECL void __stdcall UNITS_SetTargetUnitForPlayerOrMonster(D2UnitStrc* pUnit, D2UnitStrc* pTargetUnit);
 //D2Common.0x6FDBE470 (#10354)
@@ -321,7 +321,7 @@ D2COMMON_DLL_DECL void __stdcall UNITS_UpdateDirectionAndSpeed(D2UnitStrc* pUnit
 //D2Common.0x6FDBFDD0 (#10414)
 D2COMMON_DLL_DECL int __stdcall UNITS_GetNewDirection(D2UnitStrc* pUnit);
 //D2Common.0x6FDBFF20 (#10416)
-D2COMMON_DLL_DECL void __stdcall UNITS_StoreOwnerTypeAndGUID(D2UnitStrc* pUnit, int nOwnerType, int nOwnerId);
+D2COMMON_DLL_DECL void __stdcall UNITS_StoreOwnerTypeAndGUID(D2UnitStrc* pUnit, int nOwnerType, D2UnitGUID nOwnerId);
 //D2Common.0x6FDBFF40
 void __fastcall UNITS_StoreOwnerInfo(D2UnitStrc* pUnit, int nOwnerType, int nOwnerId);
 //D2Common.0x6FDBFFE0 (#10415)
@@ -435,7 +435,7 @@ D2COMMON_DLL_DECL void __stdcall UNITS_SetSwitchRightSkill(D2UnitStrc* pUnit, in
 //D2Common.0x6FDC2530 (#10455)
 D2COMMON_DLL_DECL void __stdcall UNITS_SetWeaponGUID(D2UnitStrc* pUnit, D2UnitStrc* pWeapon);
 //D2Common.0x6FDC25B0 (#10456)
-D2COMMON_DLL_DECL int __stdcall UNITS_GetWeaponGUID(D2UnitStrc* pUnit);
+D2COMMON_DLL_DECL D2UnitGUID __stdcall UNITS_GetWeaponGUID(D2UnitStrc* pUnit);
 //D2Common.0x6FDC2630 (#10339)
 D2COMMON_DLL_DECL unsigned int __stdcall UNITS_GetStashGoldLimit(D2UnitStrc* pUnit);
 //D2Common.0x6FDC2680 (#10317)
@@ -469,4 +469,4 @@ D2COMMON_DLL_DECL D2UnitStrc* __stdcall D2Common_10406(D2UnitStrc* pUnit, int(__
 //D2Common.0x6FDC33C0 (#10407)
 D2COMMON_DLL_DECL D2UnitStrc* __stdcall D2Common_10407(D2RoomStrc* pRoom, int nX, int nY, int(__fastcall* pCallback)(D2UnitStrc*, D2UnitStrc*), D2UnitStrc* a5, int a6);
 //D2Common.0x6FDC3680 (#10419)
-D2COMMON_DLL_DECL void __fastcall UNITS_SetInteractData(D2UnitStrc* pUnit, int nSkillId, int nUnitType, int nUnitGUID);
+D2COMMON_DLL_DECL void __fastcall UNITS_SetInteractData(D2UnitStrc* pUnit, int nSkillId, int nUnitType, D2UnitGUID nUnitGUID);

--- a/source/D2Common/src/D2Dungeon.cpp
+++ b/source/D2Common/src/D2Dungeon.cpp
@@ -617,7 +617,7 @@ char* __stdcall DUNGEON_GetPickedLevelPrestFilePathFromRoom(D2RoomStrc* pRoom)
 }
 
 //D2Common.0x6FD8C860 (#10066)
-void __stdcall DUNGEON_AllocDrlgDelete(D2RoomStrc* pRoom, int nUnitType, int nUnitGUID)
+void __stdcall DUNGEON_AllocDrlgDelete(D2RoomStrc* pRoom, int nUnitType, D2UnitGUID nUnitGUID)
 {
 	D2DrlgDeleteStrc* pDrlgDelete = NULL;
 
@@ -1257,7 +1257,7 @@ void __stdcall DUNGEON_SetActCallbackFunc(D2DrlgActStrc* pAct, ACTCALLBACKFN pAc
 }
 
 //D2Common.0x6FD8D600 (#10106)
-void __stdcall DUNGEON_SaveKilledUnitGUID(D2RoomStrc* pRoom, int nUnitGUID)
+void __stdcall DUNGEON_SaveKilledUnitGUID(D2RoomStrc* pRoom, D2UnitGUID nUnitGUID)
 {
 	if (pRoom)
 	{

--- a/source/D2Common/src/D2Inventory.cpp
+++ b/source/D2Common/src/D2Inventory.cpp
@@ -1314,7 +1314,7 @@ D2UnitStrc* __stdcall INVENTORY_GetItemFromInventoryPage(D2InventoryStrc* pInven
 //D2Common.0x6FD8FAB0 (#10253)
 BOOL __stdcall INVENTORY_PlaceItemInBodyLoc(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nBodyLoc)
 {
-	if (pInventory && nBodyLoc >= 0 && nBodyLoc < 13)
+	if (pInventory && INVENTORY_ValidateBodyLoc(nBodyLoc))
 	{
 		return INVENTORY_PlaceItemInGrid(pInventory, pItem, nBodyLoc, 0, INVGRID_BODYLOC, 0, 0);
 	}
@@ -1325,7 +1325,7 @@ BOOL __stdcall INVENTORY_PlaceItemInBodyLoc(D2InventoryStrc* pInventory, D2UnitS
 //D2Common.0x6FD8FAE0 (#10257)
 D2UnitStrc* __stdcall INVENTORY_GetItemFromBodyLoc(D2InventoryStrc* pInventory, int nBodyLoc)
 {
-	if (INVENTORY_GetPtrIfValid(pInventory) && nBodyLoc >= 0 && nBodyLoc < 13)
+	if (INVENTORY_GetPtrIfValid(pInventory) && INVENTORY_ValidateBodyLoc(nBodyLoc))
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 		if (pInventoryGrid)
@@ -1340,7 +1340,7 @@ D2UnitStrc* __stdcall INVENTORY_GetItemFromBodyLoc(D2InventoryStrc* pInventory, 
 //D2Common.0x6FD8FB20 (#10255)
 void __stdcall INVENTORY_GetSecondWieldingWeapon(D2UnitStrc* pPlayer, D2InventoryStrc* pInventory, D2UnitStrc** ppItem, int nBodyLoc)
 {
-	if (INVENTORY_GetPtrIfValid(pInventory) && !*ppItem && nBodyLoc >= 0 && nBodyLoc < 13)
+	if (INVENTORY_GetPtrIfValid(pInventory) && !*ppItem && INVENTORY_ValidateBodyLoc(nBodyLoc))
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 		if (pInventoryGrid)
@@ -1992,7 +1992,7 @@ BOOL __stdcall INVENTORY_HasBodyArmorEquipped(D2InventoryStrc* pInventory)
 //D2Common.0x6FD908A0 (#10276)
 BOOL __stdcall INVENTORY_IsItemBodyLocFree(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nBodyLoc, int nInventoryRecordId)
 {
-	if (INVENTORY_GetPtrIfValid(pInventory) && nBodyLoc >= 0 && nBodyLoc < 13)
+	if (INVENTORY_GetPtrIfValid(pInventory) && INVENTORY_ValidateBodyLoc(nBodyLoc))
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 
@@ -2946,12 +2946,12 @@ int __stdcall D2Common_10299(D2UnitStrc* pUnit, int nBodyLoc, D2UnitStrc* pItem,
 					nOtherBodyLoc = BODYLOC_RARM;
 				}
 
-				if (INVENTORY_CheckSignature(pUnit->pInventory) && nBodyLoc >= 0 && nBodyLoc < 13 && pInventoryGrid)
+				if (INVENTORY_CheckSignature(pUnit->pInventory) && INVENTORY_ValidateBodyLoc(nBodyLoc) && pInventoryGrid)
 				{
 					pItem1 = pInventoryGrid->ppItems[nBodyLoc];
 				}
 
-				if (INVENTORY_CheckSignature(pUnit->pInventory) && nOtherBodyLoc >= 0 && nOtherBodyLoc < 13 && pInventoryGrid)
+				if (INVENTORY_CheckSignature(pUnit->pInventory) && INVENTORY_ValidateBodyLoc(nOtherBodyLoc) && pInventoryGrid)
 				{
 					pItem2 = pInventoryGrid->ppItems[nOtherBodyLoc];
 				}
@@ -2970,12 +2970,12 @@ int __stdcall D2Common_10299(D2UnitStrc* pUnit, int nBodyLoc, D2UnitStrc* pItem,
 					nOtherBodyLoc = BODYLOC_SWRARM;
 				}
 
-				if (INVENTORY_CheckSignature(pUnit->pInventory) && nBodyLoc >= 0 && nBodyLoc < 13 && pInventoryGrid)
+				if (INVENTORY_CheckSignature(pUnit->pInventory) && INVENTORY_ValidateBodyLoc(nBodyLoc) && pInventoryGrid)
 				{
 					pItem1 = pInventoryGrid->ppItems[nBodyLoc];
 				}
 
-				if (INVENTORY_CheckSignature(pUnit->pInventory) && nOtherBodyLoc >= 0 && nOtherBodyLoc < 13 && pInventoryGrid)
+				if (INVENTORY_CheckSignature(pUnit->pInventory) && INVENTORY_ValidateBodyLoc(nOtherBodyLoc) && pInventoryGrid)
 				{
 					pItem2 = pInventoryGrid->ppItems[nOtherBodyLoc];
 				}
@@ -2985,7 +2985,7 @@ int __stdcall D2Common_10299(D2UnitStrc* pUnit, int nBodyLoc, D2UnitStrc* pItem,
 			default:
 			{
 				D2UnitStrc* pInventoryItem = nullptr;
-				if (INVENTORY_CheckSignature(pUnit->pInventory) && nBodyLoc >= 0 && nBodyLoc < 13 && pInventoryGrid)
+				if (INVENTORY_CheckSignature(pUnit->pInventory) && INVENTORY_ValidateBodyLoc(nBodyLoc) && pInventoryGrid)
 				{
 					pInventoryItem = pInventoryGrid->ppItems[nBodyLoc];
 				}
@@ -3038,7 +3038,7 @@ int __fastcall sub_6FD91D50(D2UnitStrc* pPlayer, int a2, int nBodyLoc, D2UnitStr
 		}
 
 		const int nInventoryRecord = UNITS_GetInventoryRecordId(pPlayer, 0, 1);
-		if (INVENTORY_GetPtrIfValid(pPlayer->pInventory) && nBodyLoc >= 0 && nBodyLoc < 13)
+		if (INVENTORY_GetPtrIfValid(pPlayer->pInventory) && INVENTORY_ValidateBodyLoc(nBodyLoc))
 		{
 			D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pPlayer->pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 			if (pInventoryGrid && pInventoryGrid->ppItems[nBodyLoc] && INVENTORY_GetFreePosition(pPlayer->pInventory, pInventoryGrid->ppItems[nBodyLoc], nInventoryRecord, (int*)&a4, (int*)&pItem, 0))

--- a/source/D2Common/src/D2Inventory.cpp
+++ b/source/D2Common/src/D2Inventory.cpp
@@ -484,7 +484,7 @@ D2InventoryStrc* __stdcall INVENTORY_AllocInventory(void* pMemPool, D2UnitStrc* 
 		pMemPool = pOwner->pMemoryPool;
 	}
 
-	D2InventoryStrc* pInventory = (D2InventoryStrc*)FOG_AllocServerMemory(pMemPool, sizeof(D2InventoryStrc), __FILE__, __LINE__, 0);
+	D2InventoryStrc* pInventory = D2_ALLOC_STRC_SERVER(pMemPool, D2InventoryStrc);
 	if (pInventory)
 	{
 		memset(pInventory, 0x00, sizeof(D2InventoryStrc));
@@ -522,13 +522,13 @@ void __stdcall INVENTORY_FreeInventory(D2InventoryStrc* pInventory)
 		{
 			if (pInventory->pGrids[i].ppItems)
 			{
-				FOG_FreeServerMemory(pInventory->pMemPool, pInventory->pGrids[i].ppItems, __FILE__, __LINE__, 0);
+				D2_FREE_SERVER(pInventory->pMemPool, pInventory->pGrids[i].ppItems);
 			}
 		}
 
 		if (pInventory->pGrids)
 		{
-			FOG_FreeServerMemory(pInventory->pMemPool, pInventory->pGrids, __FILE__, __LINE__, 0);
+			D2_FREE_SERVER(pInventory->pMemPool, pInventory->pGrids);
 		}
 
 		if (pInventory->pOwner)
@@ -540,7 +540,7 @@ void __stdcall INVENTORY_FreeInventory(D2InventoryStrc* pInventory)
 		for (D2InventoryNodeStrc* pNode = pInventory->pFirstNode; pNode; pNode = pNextNode)
 		{
 			pNextNode = pNode->pNext;
-			FOG_FreeServerMemory(pInventory->pMemPool, pNode, __FILE__, __LINE__, 0);
+			D2_FREE_SERVER(pInventory->pMemPool, pNode);
 			
 		}
 
@@ -548,10 +548,10 @@ void __stdcall INVENTORY_FreeInventory(D2InventoryStrc* pInventory)
 		for (D2CorpseStrc* pCorpse = pInventory->pFirstCorpse; pCorpse; pCorpse = pNextCorpse)
 		{
 			pNextCorpse = pCorpse->pNextCorpse;
-			FOG_FreeServerMemory(pInventory->pMemPool, pCorpse, __FILE__, __LINE__, 0);	
+			D2_FREE_SERVER(pInventory->pMemPool, pCorpse);
 		}
 
-		FOG_FreeServerMemory(pInventory->pMemPool, pInventory, __FILE__, __LINE__, 0);
+		D2_FREE_SERVER(pInventory->pMemPool, pInventory);
 	}
 }
 
@@ -672,7 +672,7 @@ BOOL __stdcall INVENTORY_GetFreePosition(D2InventoryStrc* pInventory, D2UnitStrc
 	D2InventoryGridInfoStrc pInventoryGridInfo = {};
 	DATATBLS_GetInventoryGridInfo(nInventoryRecordId, 0, &pInventoryGridInfo);
 
-	D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, nPage + 2, &pInventoryGridInfo);
+	D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, nPage + INVGRID_INVENTORY, &pInventoryGridInfo);
 	if (!pInventoryGrid)
 	{
 		return FALSE;
@@ -722,14 +722,14 @@ D2InventoryGridStrc* __fastcall INVENTORY_GetGrid(D2InventoryStrc* pInventory, i
 			return nullptr;
 		}
 
-		pInventory->pGrids = (D2InventoryGridStrc*)FOG_ReallocServerMemory(pInventory->pMemPool, pInventory->pGrids, sizeof(D2InventoryGridStrc) * (nInventoryGrid + 1), __FILE__, __LINE__, 0);
+		pInventory->pGrids = (D2InventoryGridStrc*)D2_REALLOC_SERVER(pInventory->pMemPool, pInventory->pGrids, sizeof(D2InventoryGridStrc) * (nInventoryGrid + 1));
 		memset(&pInventory->pGrids[pInventory->nGridCount], 0x00, sizeof(D2InventoryGridStrc) * (nInventoryGrid - pInventory->nGridCount + 1));
 		pInventory->nGridCount = nInventoryGrid + 1;
 
 		pInventoryGrid = &pInventory->pGrids[nInventoryGrid];
 		pInventoryGrid->nGridWidth = pInventoryGridInfo->nGridX;
 		pInventoryGrid->nGridHeight = pInventoryGridInfo->nGridY;
-		pInventoryGrid->ppItems = (D2UnitStrc**)FOG_AllocServerMemory(pInventory->pMemPool, sizeof(D2UnitStrc*) * pInventoryGrid->nGridHeight * pInventoryGrid->nGridWidth, __FILE__, __LINE__, 0);
+		pInventoryGrid->ppItems = (D2UnitStrc**)D2_ALLOC_SERVER(pInventory->pMemPool, sizeof(D2UnitStrc*) * pInventoryGrid->nGridHeight * pInventoryGrid->nGridWidth);
 		memset(pInventoryGrid->ppItems, 0x00, sizeof(D2UnitStrc*) * pInventoryGrid->nGridHeight * pInventoryGrid->nGridWidth);
 	}
 	else
@@ -741,7 +741,7 @@ D2InventoryGridStrc* __fastcall INVENTORY_GetGrid(D2InventoryStrc* pInventory, i
 			{
 				pInventoryGrid->nGridWidth = pInventoryGridInfo->nGridX;
 				pInventoryGrid->nGridHeight = pInventoryGridInfo->nGridY;
-				pInventoryGrid->ppItems = (D2UnitStrc**)FOG_AllocServerMemory(pInventory->pMemPool, sizeof(D2UnitStrc*) * pInventoryGrid->nGridHeight * pInventoryGrid->nGridWidth, __FILE__, __LINE__, 0);
+				pInventoryGrid->ppItems = (D2UnitStrc**)D2_ALLOC_SERVER(pInventory->pMemPool, sizeof(D2UnitStrc*) * pInventoryGrid->nGridHeight * pInventoryGrid->nGridWidth);
 				memset(pInventoryGrid->ppItems, 0x00, sizeof(D2UnitStrc*) * pInventoryGrid->nGridHeight * pInventoryGrid->nGridWidth);
 			}
 
@@ -2034,7 +2034,7 @@ void __stdcall INVENTORY_FreeTradeInventory(D2InventoryStrc* pInventory)
 		for (D2InventoryNodeStrc* pNode = pInventory->pFirstNode; pNode; pNode = pNextNode)
 		{
 			pNextNode = pNode->pNext;
-			FOG_FreeServerMemory(pInventory->pMemPool, pNode, __FILE__, __LINE__, 0);
+			D2_FREE_SERVER(pInventory->pMemPool, pNode);
 		}
 
 		pInventory->pFirstNode = nullptr;
@@ -2069,7 +2069,7 @@ void __stdcall INVENTORY_AddItemToTradeInventory(D2InventoryStrc* pInventory, D2
 			return;
 		}
 
-		D2InventoryNodeStrc* pNode = (D2InventoryNodeStrc*)FOG_AllocServerMemory(pInventory->pMemPool, sizeof(D2InventoryNodeStrc), __FILE__, __LINE__, 0);
+		D2InventoryNodeStrc* pNode = D2_ALLOC_STRC_SERVER(pInventory->pMemPool, D2InventoryNodeStrc);
 		D2_ASSERT(pNode);
 
 		pNode->pNext = nullptr;
@@ -2489,7 +2489,7 @@ void __stdcall INVENTORY_CreateCorpseForPlayer(D2InventoryStrc* pInventory, int 
 {
 	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
-		D2CorpseStrc* pCorpse = (D2CorpseStrc*)FOG_AllocServerMemory(pInventory->pMemPool, sizeof(D2CorpseStrc), __FILE__, __LINE__, 0);
+		D2CorpseStrc* pCorpse = D2_ALLOC_STRC_SERVER(pInventory->pMemPool, D2CorpseStrc);
 		pCorpse->unk0x00 = a4;
 		pCorpse->dwUnitId = nUnitId;
 		pCorpse->unk0x08 = a3;
@@ -2553,7 +2553,7 @@ BOOL __stdcall INVENTORY_FreeCorpse(D2InventoryStrc* pInventory, int nUnitId, in
 			--pInventory->nCorpseCount;
 		}
 
-		FOG_FreeServerMemory(pInventory->pMemPool, pCorpse, __FILE__, __LINE__, 0);
+		D2_FREE_SERVER(pInventory->pMemPool, pCorpse);
 		return TRUE;
 	}
 	

--- a/source/D2Common/src/D2Inventory.cpp
+++ b/source/D2Common/src/D2Inventory.cpp
@@ -455,7 +455,7 @@ BOOL __fastcall INVENTORY_RemoveItem(D2UnitStrc* pItem)
 
 	if (pItemExtraData->pParentInv->dwLeftItemGUID == pItem->dwUnitId)
 	{
-		pItemExtraData->pParentInv->dwLeftItemGUID = -1;
+		pItemExtraData->pParentInv->dwLeftItemGUID = D2UnitInvalidGUID;
 	}
 
 	pItemExtraData->pParentInv = nullptr;
@@ -496,7 +496,7 @@ D2InventoryStrc* __stdcall INVENTORY_AllocInventory(void* pMemPool, D2UnitStrc* 
 		if (pOwner)
 		{
 			pOwner->pInventory = pInventory;
-			pInventory->dwOwnerId = pOwner->dwUnitId;
+			pInventory->dwOwnerGuid = pOwner->dwUnitId;
 		}
 	}
 
@@ -1386,7 +1386,7 @@ BOOL __stdcall INVENTORY_CheckEquipmentForWeaponByClass(D2InventoryStrc* pInvent
 //D2Common.0x6FD8FC60 (#10258)
 D2UnitStrc* __stdcall INVENTORY_GetLeftHandWeapon(D2InventoryStrc* pInventory)
 {
-	if (INVENTORY_GetPtrIfValid(pInventory) && pInventory->dwLeftItemGUID != -1)
+	if (INVENTORY_GetPtrIfValid(pInventory) && pInventory->dwLeftItemGUID != D2UnitInvalidGUID)
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 		if (pInventoryGrid)
@@ -1411,7 +1411,7 @@ D2UnitStrc* __stdcall INVENTORY_GetLeftHandWeapon(D2InventoryStrc* pInventory)
 //D2Common.0x6FD8FD10 (#11301)
 D2UnitStrc* __stdcall INVENTORY_GetSecondaryWeapon(D2InventoryStrc* pInventory)
 {
-	if (INVENTORY_GetPtrIfValid(pInventory) && pInventory->dwLeftItemGUID != -1)
+	if (INVENTORY_GetPtrIfValid(pInventory) && pInventory->dwLeftItemGUID != D2UnitInvalidGUID)
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 		if (pInventoryGrid)
@@ -2342,7 +2342,7 @@ void __stdcall INVENTORY_UpdateWeaponGUIDOnInsert(D2InventoryStrc* pInventory, D
 			
 			if (INVENTORY_CheckSignature(pInventory) && pInventory->dwLeftItemGUID == pItem->dwUnitId)
 			{
-				pInventory->dwLeftItemGUID = -1;
+				pInventory->dwLeftItemGUID = D2UnitInvalidGUID;
 			}
 		}
 	}
@@ -2355,7 +2355,7 @@ void __stdcall INVENTORY_UpdateWeaponGUIDOnRemoval(D2InventoryStrc* pInventory, 
 	{
 		if (pInventory->dwLeftItemGUID == pItem->dwUnitId)
 		{
-			pInventory->dwLeftItemGUID = -1;
+			pInventory->dwLeftItemGUID = D2UnitInvalidGUID;
 		}
 
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
@@ -2465,11 +2465,11 @@ int __stdcall INVENTORY_GetWieldType(D2UnitStrc* pPlayer, D2InventoryStrc* pInve
 }
 
 //D2Common.0x6FD91140 (#10292)
-void __stdcall INVENTORY_SetOwnerId(D2InventoryStrc* pInventory, int nOwnerId)
+void __stdcall INVENTORY_SetOwnerId(D2InventoryStrc* pInventory, D2UnitGUID nOwnerGuid)
 {
 	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
-		pInventory->dwOwnerId = nOwnerId;
+		pInventory->dwOwnerGuid = nOwnerGuid;
 	}
 }
 
@@ -2478,7 +2478,7 @@ int __stdcall INVENTORY_GetOwnerId(D2InventoryStrc* pInventory)
 {
 	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
-		return pInventory->dwOwnerId;
+		return pInventory->dwOwnerGuid;
 	}
 
 	return -1;
@@ -2595,7 +2595,7 @@ D2CorpseStrc* __stdcall INVENTORY_GetNextCorpse(D2CorpseStrc* pCorpse)
 }
 
 //D2Common.0x6FDAFEA0 (#10314)
-int __stdcall INVENTORY_GetUnitGUIDFromCorpse(D2CorpseStrc* pCorpse)
+D2UnitGUID __stdcall INVENTORY_GetUnitGUIDFromCorpse(D2CorpseStrc* pCorpse)
 {
 	if (pCorpse)
 	{
@@ -3178,7 +3178,7 @@ D2UnitStrc* __stdcall INVENTORY_UnitIsItem(D2UnitStrc* pItem)
 }
 
 //D2Common.0x6FD920E0 (#10306)
-int __stdcall INVENTORY_GetItemGUID(D2UnitStrc* pItem)
+D2UnitGUID __stdcall INVENTORY_GetItemGUID(D2UnitStrc* pItem)
 {
 	if (INVENTORY_UnitIsItem(pItem))
 	{
@@ -3227,7 +3227,7 @@ D2InventoryNodeStrc* __stdcall INVENTORY_GetNextNode(D2InventoryNodeStrc* pNode)
 }
 
 //D2Common.0x6FD90AB0 (#10312)
-int __stdcall INVENTORY_GetItemGUIDFromNode(D2InventoryNodeStrc* pNode)
+D2UnitGUID __stdcall INVENTORY_GetItemGUIDFromNode(D2InventoryNodeStrc* pNode)
 {
 	if (pNode)
 	{
@@ -3246,7 +3246,7 @@ BOOL __stdcall INVENTORY_RemoveAllItems(D2InventoryStrc* pInventory)
 	}
 
 	pInventory->pCursorItem = nullptr;
-	pInventory->dwLeftItemGUID = -1;
+	pInventory->dwLeftItemGUID = D2UnitInvalidGUID;
 	
 	while (pInventory->pFirstItem)
 	{

--- a/source/D2Common/src/D2Inventory.cpp
+++ b/source/D2Common/src/D2Inventory.cpp
@@ -468,7 +468,7 @@ BOOL __fastcall INVENTORY_RemoveItem(D2UnitStrc* pItem)
 //D2Common.0x6FD8E4A0
 D2ItemExtraDataStrc* __fastcall INVENTORY_GetItemExtraDataFromItem(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (INVENTORY_UnitIsItem(pItem) && pItem->pItemData)
 	{
 		return &pItem->pItemData->pExtraData;
 	}
@@ -561,12 +561,7 @@ BOOL __stdcall INVENTORY_CompareWithItemsParentInventory(D2InventoryStrc* pInven
 	if (pInventory)
 	{
 		D2ItemExtraDataStrc* pItemExtraData = INVENTORY_GetItemExtraDataFromItem(pItem);
-		D2InventoryStrc** ppParentInv = &pItemExtraData->pParentInv;
-
-		if (ppParentInv)
-		{
-			return *ppParentInv == pInventory;
-		}
+		return pItemExtraData->pParentInv == pInventory;
 	}
 
 	return FALSE;
@@ -661,7 +656,7 @@ D2UnitStrc* __stdcall INVENTORY_GetLastItem(D2InventoryStrc* pInventory)
 //D2Common.0x6FD8E7E0 (#10245)
 BOOL __stdcall INVENTORY_GetFreePosition(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nInventoryRecordId, int* pFreeX, int* pFreeY, uint8_t nPage)
 {
-	if (!INVENTORY_GetPtrIfValid(pInventory) || !pItem || pItem->dwUnitType != UNIT_ITEM || !pItem->pItemData)
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !INVENTORY_UnitIsItem(pItem) || !pItem->pItemData)
 	{
 		return FALSE;
 	}
@@ -953,7 +948,7 @@ BOOL __stdcall INVENTORY_PlaceItemAtFreePosition(D2InventoryStrc* pInventory, D2
 {
 	int nX = 0;
 	int nY = 0;
-	if (pInventory && pItem && pItem->dwUnitType == UNIT_ITEM && INVENTORY_GetFreePosition(pInventory, pItem, nInventoryRecordId, &nX, &nY, nPage))
+	if (pInventory && INVENTORY_UnitIsItem(pItem) && INVENTORY_GetFreePosition(pInventory, pItem, nInventoryRecordId, &nX, &nY, nPage))
 	{
 		return INVENTORY_PlaceItemInGrid(pInventory, pItem, nX, nY, nPage + 2, nInventoryRecordId, bUnused);
 	}
@@ -1121,7 +1116,7 @@ BOOL __stdcall INVENTORY_CanItemBePlaced(D2InventoryStrc* pInventory, D2UnitStrc
 {
 	*pHoveredItems = 0;
 
-	if (!INVENTORY_GetPtrIfValid(pInventory) || !pItem || pItem->dwUnitType != UNIT_ITEM || nPage == -1 || nXPos < 0 || nYPos < 0)
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !INVENTORY_UnitIsItem(pItem) || nPage == -1 || nXPos < 0 || nYPos < 0)
 	{
 		return FALSE;
 	}
@@ -1184,7 +1179,7 @@ BOOL __stdcall INVENTORY_CanItemBePlaced(D2InventoryStrc* pInventory, D2UnitStrc
 //D2Common.0x6FD8F780 (#10248)
 BOOL __stdcall INVENTORY_CanItemsBeExchanged(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nXPos, int nYPos, int nInventoryRecordId, D2UnitStrc** ppExchangeItem, uint8_t nPage, BOOL bCheckIfCube)
 {
-	if (!INVENTORY_GetPtrIfValid(pInventory) || !pItem || pItem->dwUnitType != UNIT_ITEM || nPage == -1 || nXPos < 0 || nYPos < 0)
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !INVENTORY_UnitIsItem(pItem) || nPage == -1 || nXPos < 0 || nYPos < 0)
 	{
 		return FALSE;
 	}
@@ -1498,7 +1493,7 @@ D2UnitStrc* __stdcall INVENTORY_GetCompositItem(D2InventoryStrc* pInventory, int
 //D2Common.0x6FD8FE80 (#10260)
 int __stdcall INVENTORY_GetBodyLocFromEquippedItem(D2InventoryStrc* pInventory, D2UnitStrc* pItem)
 {
-	if (INVENTORY_GetPtrIfValid(pInventory) && pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pStaticPath->nXPos < 11)
+	if (INVENTORY_GetPtrIfValid(pInventory) && INVENTORY_UnitIsItem(pItem) && pItem->pStaticPath->nXPos < 11)
 	{
 		return pItem->pStaticPath->nXPos;
 	}
@@ -1509,7 +1504,7 @@ int __stdcall INVENTORY_GetBodyLocFromEquippedItem(D2InventoryStrc* pInventory, 
 //D2Common.0x6FD8FED0 (#11278)
 int __stdcall INVENTORY_GetItemsXPosition(D2InventoryStrc* pInventory, D2UnitStrc* pItem)
 {
-	if (INVENTORY_GetPtrIfValid(pInventory) && pItem && pItem->dwUnitType == UNIT_ITEM)
+	if (INVENTORY_GetPtrIfValid(pInventory) && INVENTORY_UnitIsItem(pItem))
 	{
 		return pItem->pStaticPath->nXPos;
 	}
@@ -1697,7 +1692,7 @@ D2UnitStrc* __stdcall INVENTORY_FindFillableBook(D2InventoryStrc* pInventory, D2
 //D2Common.0x6FD90230 (#10266)
 BOOL __stdcall INVENTORY_PlaceItemInBeltSlot(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nSlot)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && ITEMS_CheckIfBeltable(pItem))
+	if (INVENTORY_UnitIsItem(pItem) && ITEMS_CheckIfBeltable(pItem))
 	{
 		uint8_t nHeight = 0;
 		uint8_t nWidth = 0;
@@ -1716,7 +1711,7 @@ BOOL __stdcall INVENTORY_PlaceItemInBeltSlot(D2InventoryStrc* pInventory, D2Unit
 //D2Common.0x6FD902B0 (#10268)
 BOOL __stdcall INVENTORY_HasSimilarPotionInBelt(D2InventoryStrc* pInventory, D2UnitStrc* pPotion)
 {
-	if (INVENTORY_GetPtrIfValid(pInventory) && pPotion && pPotion->dwUnitType == UNIT_ITEM)
+	if (INVENTORY_GetPtrIfValid(pInventory) && INVENTORY_UnitIsItem(pPotion))
 	{
 		D2ItemsTxt* pItemsTxtRecord = DATATBLS_GetItemsTxtRecord(pPotion->dwClassId);
 		if (pItemsTxtRecord && pItemsTxtRecord->dwCode != ' csi' && pItemsTxtRecord->dwCode != ' cst')
@@ -1741,7 +1736,7 @@ BOOL __stdcall INVENTORY_HasSimilarPotionInBelt(D2InventoryStrc* pInventory, D2U
 //D2Common.0x6FD90340 (#10269)
 BOOL __stdcall INVENTORY_GetFreeBeltSlot(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int* pFreeSlotId)
 {
-	if (!INVENTORY_GetPtrIfValid(pInventory) || !pItem || pItem->dwUnitType != UNIT_ITEM || !ITEMS_CheckIfBeltable(pItem))
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !INVENTORY_UnitIsItem(pItem) || !ITEMS_CheckIfBeltable(pItem))
 	{
 		return FALSE;
 	}
@@ -1811,7 +1806,7 @@ BOOL __stdcall INVENTORY_GetFreeBeltSlot(D2InventoryStrc* pInventory, D2UnitStrc
 BOOL __stdcall INVENTORY_PlaceItemInFreeBeltSlot(D2InventoryStrc* pInventory, D2UnitStrc* pItem)
 {
 	int nFreeSlot = 0;
-	if (INVENTORY_GetFreeBeltSlot(pInventory, pItem, &nFreeSlot) && pInventory && pItem && pItem->dwUnitType == UNIT_ITEM && nFreeSlot >= 0 && nFreeSlot < 16)
+	if (INVENTORY_GetFreeBeltSlot(pInventory, pItem, &nFreeSlot) && pInventory && INVENTORY_UnitIsItem(pItem) && nFreeSlot >= 0 && nFreeSlot < 16)
 	{
 		return INVENTORY_PlaceItemInGrid(pInventory, pItem, nFreeSlot, 0, INVGRID_BELT, 0, 0);
 	}
@@ -1840,7 +1835,7 @@ BOOL __stdcall INVENTORY_GetUseableItemFromBeltSlot(D2InventoryStrc* pInventory,
 	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BELT, &gBeltInventoryGridInfo);
-		if (pInventoryGrid && pItem && pItem->dwUnitType == UNIT_ITEM && ITEMS_CheckIfBeltable(pItem))
+		if (pInventoryGrid && INVENTORY_UnitIsItem(pItem) && ITEMS_CheckIfBeltable(pItem))
 		{
 			uint8_t nHeight = 0;
 			uint8_t nWidth = 0;
@@ -2067,7 +2062,7 @@ BOOL __stdcall INVENTORY_CheckForItemInTradeInventory(D2InventoryStrc* pInventor
 //D2Common.0x6FD909F0 (#10283)
 void __stdcall INVENTORY_AddItemToTradeInventory(D2InventoryStrc* pInventory, D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM)
+	if (INVENTORY_UnitIsItem(pItem))
 	{
 		if (INVENTORY_CheckForItemInTradeInventory(pInventory, pItem->dwUnitId))
 		{
@@ -2308,7 +2303,7 @@ int __stdcall INVENTORY_GetSetItemEquipCountByFileIndex(D2InventoryStrc* pInvent
 	if (pInventoryGrid)
 	{
 		int nCounter = 0;
-		for (D2UnitStrc* pItem = pInventoryGrid->pItem; pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData; pItem = pItem->pItemData->pExtraData.unk0x14)
+		for (D2UnitStrc* pItem = pInventoryGrid->pItem; INVENTORY_UnitIsItem(pItem) && pItem->pItemData; pItem = pItem->pItemData->pExtraData.unk0x14)
 		{
 			if (ITEMS_GetItemQuality(pItem) == ITEMQUAL_SET && ITEMS_GetFileIndex(pItem) == nItemFileIndex)
 			{
@@ -2328,7 +2323,7 @@ int __stdcall INVENTORY_GetSetItemEquipCountByFileIndex(D2InventoryStrc* pInvent
 //D2Common.0x6FD90ED0 (#10289)
 void __stdcall INVENTORY_UpdateWeaponGUIDOnInsert(D2InventoryStrc* pInventory, D2UnitStrc* pItem)
 {
-	if (pInventory && pItem && pItem->dwUnitType == UNIT_ITEM && ITEMS_CheckItemTypeId(pItem, ITEMTYPE_WEAPON))
+	if (pInventory && INVENTORY_UnitIsItem(pItem) && ITEMS_CheckItemTypeId(pItem, ITEMTYPE_WEAPON))
 	{
 		if (ITEMS_GetBodyLocation(pItem) == BODYLOC_RARM || ITEMS_GetBodyLocation(pItem) == BODYLOC_LARM)
 		{
@@ -2356,9 +2351,9 @@ void __stdcall INVENTORY_UpdateWeaponGUIDOnInsert(D2InventoryStrc* pInventory, D
 //D2Common.0x6FD90F80 (#10290)
 void __stdcall INVENTORY_UpdateWeaponGUIDOnRemoval(D2InventoryStrc* pInventory, D2UnitStrc* pItem)
 {
-	if (INVENTORY_GetPtrIfValid(pInventory) && pItem && pItem->dwUnitType == UNIT_ITEM && ITEMS_CheckItemTypeId(pItem, ITEMTYPE_WEAPON))
+	if (INVENTORY_GetPtrIfValid(pInventory) && INVENTORY_UnitIsItem(pItem) && ITEMS_CheckItemTypeId(pItem, ITEMTYPE_WEAPON))
 	{
-		if (pItem->dwUnitType == UNIT_ITEM && pInventory->dwLeftItemGUID == pItem->dwUnitId)
+		if (pInventory->dwLeftItemGUID == pItem->dwUnitId)
 		{
 			pInventory->dwLeftItemGUID = -1;
 		}
@@ -3185,7 +3180,7 @@ D2UnitStrc* __stdcall INVENTORY_UnitIsItem(D2UnitStrc* pItem)
 //D2Common.0x6FD920E0 (#10306)
 int __stdcall INVENTORY_GetItemGUID(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM)
+	if (INVENTORY_UnitIsItem(pItem))
 	{
 		return pItem->dwUnitId;
 	}

--- a/source/D2Common/src/D2Inventory.cpp
+++ b/source/D2Common/src/D2Inventory.cpp
@@ -468,9 +468,9 @@ BOOL __fastcall INVENTORY_RemoveItem(D2UnitStrc* pItem)
 //D2Common.0x6FD8E4A0
 D2ItemExtraDataStrc* __fastcall INVENTORY_GetItemExtraDataFromItem(D2UnitStrc* pItem)
 {
-	if (INVENTORY_UnitIsItem(pItem) && pItem->pItemData)
+	if (D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem))
 	{
-		return &pItem->pItemData->pExtraData;
+		return &pItemData->pExtraData;
 	}
 	
 	return nullptr;
@@ -656,7 +656,7 @@ D2UnitStrc* __stdcall INVENTORY_GetLastItem(D2InventoryStrc* pInventory)
 //D2Common.0x6FD8E7E0 (#10245)
 BOOL __stdcall INVENTORY_GetFreePosition(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nInventoryRecordId, int* pFreeX, int* pFreeY, uint8_t nPage)
 {
-	if (!INVENTORY_GetPtrIfValid(pInventory) || !INVENTORY_UnitIsItem(pItem) || !pItem->pItemData)
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !ITEMS_GetItemData(pItem))
 	{
 		return FALSE;
 	}
@@ -2303,7 +2303,7 @@ int __stdcall INVENTORY_GetSetItemEquipCountByFileIndex(D2InventoryStrc* pInvent
 	if (pInventoryGrid)
 	{
 		int nCounter = 0;
-		for (D2UnitStrc* pItem = pInventoryGrid->pItem; INVENTORY_UnitIsItem(pItem) && pItem->pItemData; pItem = pItem->pItemData->pExtraData.unk0x14)
+		for (D2UnitStrc* pItem = pInventoryGrid->pItem; ITEMS_GetItemData(pItem) != nullptr; pItem = pItem->pItemData->pExtraData.unk0x14)
 		{
 			if (ITEMS_GetItemQuality(pItem) == ITEMQUAL_SET && ITEMS_GetFileIndex(pItem) == nItemFileIndex)
 			{

--- a/source/D2Common/src/D2Inventory.cpp
+++ b/source/D2Common/src/D2Inventory.cpp
@@ -11,7 +11,7 @@
 #include "Units/Units.h"
 #include <Path/Path.h>
 
-struct D2UnkInventoryComponentStrc
+struct D2InventoryComponentItemTypeStrc
 {
 	int dwCode;
 	int nItemType;
@@ -24,7 +24,7 @@ D2InventoryGridInfoStrc gBodyLocInventoryGridInfo = { 13, 1, 0, 0, 0, 0, 0, 0, 0
 D2InventoryGridInfoStrc gBeltInventoryGridInfo = { 16, 1, 0, 0, 0, 0, 0, 0, 0, 0 };
 
 //D2Common.0x6FDE2820
-D2UnkInventoryComponentStrc stru_6FDE2820[]
+D2InventoryComponentItemTypeStrc gComponentItemTypeMap[]
 {
 	{ 0, ITEMTYPE_NONE_2 },
 	{ ' til', ITEMTYPE_NONE_2 },
@@ -312,7 +312,7 @@ D2UnkInventoryComponentStrc stru_6FDE2820[]
 };
 
 //D2Common.0x6FDEA708
-D2UnkInventoryComponentStrc stru_6FDEA708[255] = {};
+D2InventoryComponentItemTypeStrc gTxtComponentItemTypeMap[255] = {};
 
 //D2Common.0x6FDEAF00
 int gnComponentArrayRecordCount;
@@ -2621,29 +2621,29 @@ int __stdcall D2Common_10315(D2CorpseStrc* pCorpse)
 // Helper function
 inline int INVENTORY_GetComponentArrayIndexFromItemsTxtRecord(D2ItemsTxt* pItemsTxtRecord)
 {
-	for (int nCounter = 1; nCounter < ARRAY_SIZE(stru_6FDEA708); ++nCounter)
+	for (int nCounter = 1; nCounter < ARRAY_SIZE(gTxtComponentItemTypeMap); ++nCounter)
 	{
-		if (stru_6FDEA708[nCounter].dwCode == pItemsTxtRecord->dwAlternateGfx || stru_6FDEA708[nCounter].dwCode == pItemsTxtRecord->dwCode)
+		if (gTxtComponentItemTypeMap[nCounter].dwCode == pItemsTxtRecord->dwAlternateGfx || gTxtComponentItemTypeMap[nCounter].dwCode == pItemsTxtRecord->dwCode)
 		{
 			return nCounter;
 		}
 	}
 
-	return ARRAY_SIZE(stru_6FDEA708);
+	return ARRAY_SIZE(gTxtComponentItemTypeMap);
 }
 
 // Helper function
 inline int INVENTORY_GetComponentArrayIndexFromArmTypeTxtRecord(D2ArmTypeTxt* pArmTypeTxtRecord)
 {
-	for (int nCounter = 1; nCounter < ARRAY_SIZE(stru_6FDEA708); ++nCounter)
+	for (int nCounter = 1; nCounter < ARRAY_SIZE(gTxtComponentItemTypeMap); ++nCounter)
 	{
-		if (stru_6FDEA708[nCounter].dwCode == *(uint32_t*)&pArmTypeTxtRecord->szToken[0])
+		if (gTxtComponentItemTypeMap[nCounter].dwCode == *(uint32_t*)&pArmTypeTxtRecord->szToken[0])
 		{
 			return nCounter;
 		}
 	}
 
-	return ARRAY_SIZE(stru_6FDEA708);
+	return ARRAY_SIZE(gTxtComponentItemTypeMap);
 }
 
 //D2Common.0x6FD912F0 (#10298)
@@ -2670,7 +2670,7 @@ void __stdcall INVENTORY_GetItemSaveGfxInfo(D2UnitStrc* pPlayer, uint8_t* a2, ui
 
 					const int nIndex = INVENTORY_GetComponentArrayIndexFromItemsTxtRecord(pItemsTxtRecord);
 
-					if (nIndex >= ARRAY_SIZE(stru_6FDEA708))
+					if (nIndex >= ARRAY_SIZE(gTxtComponentItemTypeMap))
 					{
 						if (nComponent < NUM_COMPONENTS)
 						{
@@ -2726,7 +2726,7 @@ void __stdcall INVENTORY_GetItemSaveGfxInfo(D2UnitStrc* pPlayer, uint8_t* a2, ui
 
 							const int nIndex = INVENTORY_GetComponentArrayIndexFromArmTypeTxtRecord(pArmTypeTxtRecord);
 
-							if (nIndex < ARRAY_SIZE(stru_6FDEA708))
+							if (nIndex < ARRAY_SIZE(gTxtComponentItemTypeMap))
 							{
 								a2[i] = nIndex;
 
@@ -2765,14 +2765,14 @@ void __fastcall INVENTORY_InitializeComponentArray()
 	{
 		gbComponentArrayInitialized = TRUE;
 
-		memset(stru_6FDEA708, 0x00, sizeof(stru_6FDEA708));
+		memset(gTxtComponentItemTypeMap, 0x00, sizeof(gTxtComponentItemTypeMap));
 
-		stru_6FDEA708[1].dwCode = ' til';
-		stru_6FDEA708[1].nItemType = ITEMTYPE_ARMOR;
-		stru_6FDEA708[2].dwCode = ' dem';
-		stru_6FDEA708[2].nItemType = ITEMTYPE_ARMOR;
-		stru_6FDEA708[3].dwCode = ' yvh';
-		stru_6FDEA708[3].nItemType = ITEMTYPE_ARMOR;
+		gTxtComponentItemTypeMap[1].dwCode = ' til';
+		gTxtComponentItemTypeMap[1].nItemType = ITEMTYPE_ARMOR;
+		gTxtComponentItemTypeMap[2].dwCode = ' dem';
+		gTxtComponentItemTypeMap[2].nItemType = ITEMTYPE_ARMOR;
+		gTxtComponentItemTypeMap[3].dwCode = ' yvh';
+		gTxtComponentItemTypeMap[3].nItemType = ITEMTYPE_ARMOR;
 
 		D2ItemDataTbl* pItemDataTbl = DATATBLS_GetItemDataTables();
 
@@ -2804,7 +2804,7 @@ void __fastcall INVENTORY_InitializeComponentArray()
 			int nCounter = 0;
 			while (nCounter < nCurrentTableEntries)
 			{
-				if (stru_6FDEA708[nCounter].dwCode == dwCode)
+				if (gTxtComponentItemTypeMap[nCounter].dwCode == dwCode)
 				{
 					break;
 				}
@@ -2816,20 +2816,20 @@ void __fastcall INVENTORY_InitializeComponentArray()
 			{
 				int nIndex = nCurrentTableEntries;
 
-				while (ITEMS_CheckType(stru_6FDE2820[nIndex].nItemType, ITEMTYPE_WEAPON) && ITEMS_CheckType(pItemsTxtRecord->wType[0], ITEMTYPE_WEAPON)
-					   || ITEMS_CheckType(stru_6FDE2820[nIndex].nItemType, ITEMTYPE_ANY_ARMOR) && ITEMS_CheckType(pItemsTxtRecord->wType[0], ITEMTYPE_ANY_ARMOR)
-					   || stru_6FDEA708[nIndex].dwCode)
+				while (ITEMS_CheckType(gComponentItemTypeMap[nIndex].nItemType, ITEMTYPE_WEAPON) && ITEMS_CheckType(pItemsTxtRecord->wType[0], ITEMTYPE_WEAPON)
+					   || ITEMS_CheckType(gComponentItemTypeMap[nIndex].nItemType, ITEMTYPE_ANY_ARMOR) && ITEMS_CheckType(pItemsTxtRecord->wType[0], ITEMTYPE_ANY_ARMOR)
+					   || gTxtComponentItemTypeMap[nIndex].dwCode)
 				{
 					++nIndex;
 				}
 
-				if (nIndex >= ARRAY_SIZE(stru_6FDEA708))
+				if (nIndex >= ARRAY_SIZE(gTxtComponentItemTypeMap))
 				{
 					nIndex = nCurrentTableEntries;
 				}
 
-				stru_6FDEA708[nIndex].dwCode = dwCode;
-				stru_6FDEA708[nIndex].nItemType = pItemsTxtRecord->wType[0];
+				gTxtComponentItemTypeMap[nIndex].dwCode = dwCode;
+				gTxtComponentItemTypeMap[nIndex].nItemType = pItemsTxtRecord->wType[0];
 
 				if (nCurrentTableEntries == nIndex)
 				{
@@ -2838,7 +2838,7 @@ void __fastcall INVENTORY_InitializeComponentArray()
 			}
 		}
 
-		gnComponentArrayRecordCount = ARRAY_SIZE(stru_6FDEA708);
+		gnComponentArrayRecordCount = ARRAY_SIZE(gTxtComponentItemTypeMap);
 	}
 }
 
@@ -2870,7 +2870,7 @@ void __fastcall sub_6FD917B0(D2UnitStrc* pUnit, uint8_t* a2, uint8_t* pColor, D2
 
 					const int nIndex = INVENTORY_GetComponentArrayIndexFromItemsTxtRecord(pItemsTxtRecord);
 
-					if (nIndex >= ARRAY_SIZE(stru_6FDEA708))
+					if (nIndex >= ARRAY_SIZE(gTxtComponentItemTypeMap))
 					{
 						a2[COMPOSIT_LEFTHAND] = -1;
 						pColor[COMPOSIT_LEFTHAND] = -1;
@@ -2894,7 +2894,7 @@ void __fastcall sub_6FD917B0(D2UnitStrc* pUnit, uint8_t* a2, uint8_t* pColor, D2
 
 					const int nIndex = INVENTORY_GetComponentArrayIndexFromItemsTxtRecord(pItemsTxtRecord);
 
-					if (nIndex >= ARRAY_SIZE(stru_6FDEA708))
+					if (nIndex >= ARRAY_SIZE(gTxtComponentItemTypeMap))
 					{
 						a2[COMPOSIT_RIGHTHAND] = -1;
 						pColor[COMPOSIT_RIGHTHAND] = -1;

--- a/source/D2Common/src/D2Inventory.cpp
+++ b/source/D2Common/src/D2Inventory.cpp
@@ -325,7 +325,7 @@ BOOL __fastcall INVENTORY_RemoveItem(D2UnitStrc* pItem)
 {
 	D2ItemExtraDataStrc* pItemExtraData = INVENTORY_GetItemExtraDataFromItem(pItem);
 
-	if (!pItemExtraData || !pItemExtraData->pParentInv || pItemExtraData->pParentInv->dwSignature != 0x1020304)
+	if (!pItemExtraData || !INVENTORY_GetPtrIfValid(pItemExtraData->pParentInv))
 	{
 		return FALSE;
 	}
@@ -489,7 +489,7 @@ D2InventoryStrc* __stdcall INVENTORY_AllocInventory(void* pMemPool, D2UnitStrc* 
 	{
 		memset(pInventory, 0x00, sizeof(D2InventoryStrc));
 
-		pInventory->dwSignature = 0x1020304;
+		pInventory->dwSignature = D2C_InventoryHeader;
 		pInventory->pMemPool = pMemPool;
 		pInventory->pOwner = pOwner;
 
@@ -506,7 +506,7 @@ D2InventoryStrc* __stdcall INVENTORY_AllocInventory(void* pMemPool, D2UnitStrc* 
 //D2Common.0x6FD8E520 (#10241)
 void __stdcall INVENTORY_FreeInventory(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		if (pInventory->pCursorItem)
 		{
@@ -587,7 +587,7 @@ D2UnitStrc* __stdcall INVENTORY_RemoveItemFromInventory(D2InventoryStrc* pInvent
 //D2Common.0x6FD8E6A0 (#10242)
 BOOL __stdcall INVENTORY_PlaceItemInSocket(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nUnused)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return FALSE;
 	}
@@ -639,7 +639,7 @@ BOOL __stdcall INVENTORY_PlaceItemInSocket(D2InventoryStrc* pInventory, D2UnitSt
 //D2Common.0x6FD8E7A0 (#10277)
 D2UnitStrc* __stdcall INVENTORY_GetFirstItem(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return pInventory->pFirstItem;
 	}
@@ -650,7 +650,7 @@ D2UnitStrc* __stdcall INVENTORY_GetFirstItem(D2InventoryStrc* pInventory)
 //D2Common.0x6FD8E7C0 (#10278)
 D2UnitStrc* __stdcall INVENTORY_GetLastItem(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return pInventory->pLastItem;
 	}
@@ -661,7 +661,7 @@ D2UnitStrc* __stdcall INVENTORY_GetLastItem(D2InventoryStrc* pInventory)
 //D2Common.0x6FD8E7E0 (#10245)
 BOOL __stdcall INVENTORY_GetFreePosition(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nInventoryRecordId, int* pFreeX, int* pFreeY, uint8_t nPage)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304 || !pItem || pItem->dwUnitType != UNIT_ITEM || !pItem->pItemData)
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !pItem || pItem->dwUnitType != UNIT_ITEM || !pItem->pItemData)
 	{
 		return FALSE;
 	}
@@ -964,7 +964,7 @@ BOOL __stdcall INVENTORY_PlaceItemAtFreePosition(D2InventoryStrc* pInventory, D2
 //D2Common.0x6FD8F250
 BOOL __fastcall INVENTORY_PlaceItemInGrid(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nXPos, int nYPos, int nInventoryGrid, int nInventoryRecordId, BOOL bUnused)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return FALSE;
 	}
@@ -1121,7 +1121,7 @@ BOOL __stdcall INVENTORY_CanItemBePlaced(D2InventoryStrc* pInventory, D2UnitStrc
 {
 	*pHoveredItems = 0;
 
-	if (!pInventory || pInventory->dwSignature != 0x1020304 || !pItem || pItem->dwUnitType != UNIT_ITEM || nPage == -1 || nXPos < 0 || nYPos < 0)
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !pItem || pItem->dwUnitType != UNIT_ITEM || nPage == -1 || nXPos < 0 || nYPos < 0)
 	{
 		return FALSE;
 	}
@@ -1184,7 +1184,7 @@ BOOL __stdcall INVENTORY_CanItemBePlaced(D2InventoryStrc* pInventory, D2UnitStrc
 //D2Common.0x6FD8F780 (#10248)
 BOOL __stdcall INVENTORY_CanItemsBeExchanged(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nXPos, int nYPos, int nInventoryRecordId, D2UnitStrc** ppExchangeItem, uint8_t nPage, BOOL bCheckIfCube)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304 || !pItem || pItem->dwUnitType != UNIT_ITEM || nPage == -1 || nXPos < 0 || nYPos < 0)
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !pItem || pItem->dwUnitType != UNIT_ITEM || nPage == -1 || nXPos < 0 || nYPos < 0)
 	{
 		return FALSE;
 	}
@@ -1268,7 +1268,7 @@ void __stdcall INVENTORY_Return(char* szFile, int nLine, D2InventoryStrc* pInven
 //D2Common.0x6FD8F980 (#10252)
 D2UnitStrc* __stdcall INVENTORY_GetItemFromInventoryPage(D2InventoryStrc* pInventory, int nGridX, int nGridY, int* pX, int* pY, int nInventoryRecordId, uint8_t nPage)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return nullptr;
 	}
@@ -1325,7 +1325,7 @@ BOOL __stdcall INVENTORY_PlaceItemInBodyLoc(D2InventoryStrc* pInventory, D2UnitS
 //D2Common.0x6FD8FAE0 (#10257)
 D2UnitStrc* __stdcall INVENTORY_GetItemFromBodyLoc(D2InventoryStrc* pInventory, int nBodyLoc)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304 && nBodyLoc >= 0 && nBodyLoc < 13)
+	if (INVENTORY_GetPtrIfValid(pInventory) && nBodyLoc >= 0 && nBodyLoc < 13)
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 		if (pInventoryGrid)
@@ -1340,7 +1340,7 @@ D2UnitStrc* __stdcall INVENTORY_GetItemFromBodyLoc(D2InventoryStrc* pInventory, 
 //D2Common.0x6FD8FB20 (#10255)
 void __stdcall INVENTORY_GetSecondWieldingWeapon(D2UnitStrc* pPlayer, D2InventoryStrc* pInventory, D2UnitStrc** ppItem, int nBodyLoc)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304 && !*ppItem && nBodyLoc >= 0 && nBodyLoc < 13)
+	if (INVENTORY_GetPtrIfValid(pInventory) && !*ppItem && nBodyLoc >= 0 && nBodyLoc < 13)
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 		if (pInventoryGrid)
@@ -1366,7 +1366,7 @@ void __stdcall INVENTORY_GetSecondWieldingWeapon(D2UnitStrc* pPlayer, D2Inventor
 //D2Common.0x6FD8FBB0 (#10256)
 BOOL __stdcall INVENTORY_CheckEquipmentForWeaponByClass(D2InventoryStrc* pInventory, int nWeaponClass)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 
@@ -1391,7 +1391,7 @@ BOOL __stdcall INVENTORY_CheckEquipmentForWeaponByClass(D2InventoryStrc* pInvent
 //D2Common.0x6FD8FC60 (#10258)
 D2UnitStrc* __stdcall INVENTORY_GetLeftHandWeapon(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304 && pInventory->dwLeftItemGUID != -1)
+	if (INVENTORY_GetPtrIfValid(pInventory) && pInventory->dwLeftItemGUID != -1)
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 		if (pInventoryGrid)
@@ -1416,7 +1416,7 @@ D2UnitStrc* __stdcall INVENTORY_GetLeftHandWeapon(D2InventoryStrc* pInventory)
 //D2Common.0x6FD8FD10 (#11301)
 D2UnitStrc* __stdcall INVENTORY_GetSecondaryWeapon(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304 && pInventory->dwLeftItemGUID != -1)
+	if (INVENTORY_GetPtrIfValid(pInventory) && pInventory->dwLeftItemGUID != -1)
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 		if (pInventoryGrid)
@@ -1451,7 +1451,7 @@ D2UnitStrc* __stdcall INVENTORY_GetSecondaryWeapon(D2InventoryStrc* pInventory)
 //D2Common.0x6FD8FDD0 (#10259)
 D2UnitStrc* __stdcall INVENTORY_GetCompositItem(D2InventoryStrc* pInventory, int nComponent)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return nullptr;
 	}
@@ -1498,7 +1498,7 @@ D2UnitStrc* __stdcall INVENTORY_GetCompositItem(D2InventoryStrc* pInventory, int
 //D2Common.0x6FD8FE80 (#10260)
 int __stdcall INVENTORY_GetBodyLocFromEquippedItem(D2InventoryStrc* pInventory, D2UnitStrc* pItem)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304 && pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pStaticPath->nXPos < 11)
+	if (INVENTORY_GetPtrIfValid(pInventory) && pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pStaticPath->nXPos < 11)
 	{
 		return pItem->pStaticPath->nXPos;
 	}
@@ -1509,7 +1509,7 @@ int __stdcall INVENTORY_GetBodyLocFromEquippedItem(D2InventoryStrc* pInventory, 
 //D2Common.0x6FD8FED0 (#11278)
 int __stdcall INVENTORY_GetItemsXPosition(D2InventoryStrc* pInventory, D2UnitStrc* pItem)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304 && pItem && pItem->dwUnitType == UNIT_ITEM)
+	if (INVENTORY_GetPtrIfValid(pInventory) && pItem && pItem->dwUnitType == UNIT_ITEM)
 	{
 		return pItem->pStaticPath->nXPos;
 	}
@@ -1520,7 +1520,7 @@ int __stdcall INVENTORY_GetItemsXPosition(D2InventoryStrc* pInventory, D2UnitStr
 //D2Common.0x6FD8FF20 (#10261)
 void __stdcall INVENTORY_SetCursorItem(D2InventoryStrc* pInventory, D2UnitStrc* pItem)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		if (pItem)
 		{
@@ -1541,7 +1541,7 @@ void __stdcall INVENTORY_SetCursorItem(D2InventoryStrc* pInventory, D2UnitStrc* 
 //D2Common.0x6FD8FF80 (#10262)
 D2UnitStrc* __stdcall INVENTORY_GetCursorItem(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return pInventory->pCursorItem;
 	}
@@ -1552,7 +1552,7 @@ D2UnitStrc* __stdcall INVENTORY_GetCursorItem(D2InventoryStrc* pInventory)
 //D2Common.0x6FD8FFA0 (#10263)
 D2UnitStrc* __stdcall INVENTORY_FindBackPackItemForStack(D2InventoryStrc* pInventory, D2UnitStrc* pStackable, D2UnitStrc* pCheckItem)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return nullptr;
 	}
@@ -1604,7 +1604,7 @@ D2UnitStrc* __stdcall INVENTORY_FindBackPackItemForStack(D2InventoryStrc* pInven
 //D2Common.0x6FD90080 (#10264)
 D2UnitStrc* __stdcall INVENTORY_FindEquippedItemForStack(D2InventoryStrc* pInventory, D2UnitStrc* pStackable, D2UnitStrc* pCheckItem)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return nullptr;
 	}
@@ -1645,7 +1645,7 @@ D2UnitStrc* __stdcall INVENTORY_FindEquippedItemForStack(D2InventoryStrc* pInven
 //D2Common.0x6FD90130 (#10265)
 D2UnitStrc* __stdcall INVENTORY_FindFillableBook(D2InventoryStrc* pInventory, D2UnitStrc* pScrolls, D2UnitStrc* pCheckItem)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return nullptr;
 	}
@@ -1716,7 +1716,7 @@ BOOL __stdcall INVENTORY_PlaceItemInBeltSlot(D2InventoryStrc* pInventory, D2Unit
 //D2Common.0x6FD902B0 (#10268)
 BOOL __stdcall INVENTORY_HasSimilarPotionInBelt(D2InventoryStrc* pInventory, D2UnitStrc* pPotion)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304 && pPotion && pPotion->dwUnitType == UNIT_ITEM)
+	if (INVENTORY_GetPtrIfValid(pInventory) && pPotion && pPotion->dwUnitType == UNIT_ITEM)
 	{
 		D2ItemsTxt* pItemsTxtRecord = DATATBLS_GetItemsTxtRecord(pPotion->dwClassId);
 		if (pItemsTxtRecord && pItemsTxtRecord->dwCode != ' csi' && pItemsTxtRecord->dwCode != ' cst')
@@ -1741,7 +1741,7 @@ BOOL __stdcall INVENTORY_HasSimilarPotionInBelt(D2InventoryStrc* pInventory, D2U
 //D2Common.0x6FD90340 (#10269)
 BOOL __stdcall INVENTORY_GetFreeBeltSlot(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int* pFreeSlotId)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304 || !pItem || pItem->dwUnitType != UNIT_ITEM || !ITEMS_CheckIfBeltable(pItem))
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !pItem || pItem->dwUnitType != UNIT_ITEM || !ITEMS_CheckIfBeltable(pItem))
 	{
 		return FALSE;
 	}
@@ -1822,7 +1822,7 @@ BOOL __stdcall INVENTORY_PlaceItemInFreeBeltSlot(D2InventoryStrc* pInventory, D2
 //D2Common.0x6FD90550 (#10271)
 D2UnitStrc* __stdcall INVENTORY_GetItemFromBeltSlot(D2InventoryStrc* pInventory, int nSlotId)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BELT, &gBeltInventoryGridInfo);
 		if (pInventoryGrid && nSlotId >= 0 && nSlotId < 16)
@@ -1837,7 +1837,7 @@ D2UnitStrc* __stdcall INVENTORY_GetItemFromBeltSlot(D2InventoryStrc* pInventory,
 //D2Common.0x6FD90590 (#10272)
 BOOL __stdcall INVENTORY_GetUseableItemFromBeltSlot(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nSlotId, D2UnitStrc** ppItem)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BELT, &gBeltInventoryGridInfo);
 		if (pInventoryGrid && pItem && pItem->dwUnitType == UNIT_ITEM && ITEMS_CheckIfBeltable(pItem))
@@ -1872,7 +1872,7 @@ BOOL __stdcall INVENTORY_GetUseableItemFromBeltSlot(D2InventoryStrc* pInventory,
 //D2Common.0x6FD90690 (#10273)
 BOOL __stdcall INVENTORY_GetEquippedShield(D2InventoryStrc* pInventory, D2UnitStrc** ppItem)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return FALSE;
 	}
@@ -1926,7 +1926,7 @@ BOOL __stdcall INVENTORY_GetEquippedShield(D2InventoryStrc* pInventory, D2UnitSt
 //D2Common.0x6FD90760 (#10274)
 BOOL __stdcall INVENTORY_GetEquippedWeapon(D2InventoryStrc* pInventory, D2UnitStrc** ppItem, int* pBodyLoc, BOOL* pIsLeftHandItem)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		*ppItem = nullptr;
 		return FALSE;
@@ -1977,7 +1977,7 @@ BOOL __stdcall INVENTORY_GetEquippedWeapon(D2InventoryStrc* pInventory, D2UnitSt
 //D2Common.0x6FD90850 (#10275)
 BOOL __stdcall INVENTORY_HasBodyArmorEquipped(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 		if (pInventoryGrid && pInventoryGrid->ppItems[BODYLOC_TORSO])
@@ -1992,7 +1992,7 @@ BOOL __stdcall INVENTORY_HasBodyArmorEquipped(D2InventoryStrc* pInventory)
 //D2Common.0x6FD908A0 (#10276)
 BOOL __stdcall INVENTORY_IsItemBodyLocFree(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nBodyLoc, int nInventoryRecordId)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304 && nBodyLoc >= 0 && nBodyLoc < 13)
+	if (INVENTORY_GetPtrIfValid(pInventory) && nBodyLoc >= 0 && nBodyLoc < 13)
 	{
 		D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 
@@ -2010,7 +2010,7 @@ BOOL __stdcall INVENTORY_IsItemBodyLocFree(D2InventoryStrc* pInventory, D2UnitSt
 //D2Common.0x6FD90910 (#10279)
 void __stdcall INVENTORY_RemoveInventoryItems(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		for (D2UnitStrc* pItem = pInventory->pFirstItem; pItem; pItem = pInventory->pFirstItem)
 		{
@@ -2022,7 +2022,7 @@ void __stdcall INVENTORY_RemoveInventoryItems(D2InventoryStrc* pInventory)
 //D2Common.0x6FD90940 (#10280)
 D2InventoryNodeStrc* __stdcall INVENTORY_GetTradeInventory(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return pInventory->pFirstNode;
 	}
@@ -2033,7 +2033,7 @@ D2InventoryNodeStrc* __stdcall INVENTORY_GetTradeInventory(D2InventoryStrc* pInv
 //D2Common.0x6FD90960 (#10281)
 void __stdcall INVENTORY_FreeTradeInventory(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		D2InventoryNodeStrc* pNextNode = nullptr;
 		for (D2InventoryNodeStrc* pNode = pInventory->pFirstNode; pNode; pNode = pNextNode)
@@ -2050,7 +2050,7 @@ void __stdcall INVENTORY_FreeTradeInventory(D2InventoryStrc* pInventory)
 //D2Common.0x6FD909B0 (#10282)
 BOOL __stdcall INVENTORY_CheckForItemInTradeInventory(D2InventoryStrc* pInventory, int nItemId)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		for (D2InventoryNodeStrc* pNode = pInventory->pFirstNode; pNode; pNode = pNode->pNext)
 		{
@@ -2109,7 +2109,7 @@ int __stdcall D2Common_10316(D2CorpseStrc* pCorpse)
 //D2Common.0x6FD90AC0 (#10284)
 int __stdcall INVENTORY_GetItemCount(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return pInventory->dwItemCount;
 	}
@@ -2120,7 +2120,7 @@ int __stdcall INVENTORY_GetItemCount(D2InventoryStrc* pInventory)
 //D2Common.0x6FD90AE0 (#10285)
 D2UnitStrc* __stdcall INVENTORY_GetBackPackItemByType(D2InventoryStrc* pInventory, int nItemType, D2UnitStrc* pCheckItem)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return nullptr;
 	}
@@ -2174,7 +2174,7 @@ D2UnitStrc* __stdcall INVENTORY_GetBackPackItemByType(D2InventoryStrc* pInventor
 //D2Common.0x6FD90BC0 (#10286)
 D2UnitStrc* __stdcall INVENTORY_GetEquippedItemByType(D2InventoryStrc* pInventory, int nItemType, D2UnitStrc* pCheckItem)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return nullptr;
 	}
@@ -2216,7 +2216,7 @@ D2UnitStrc* __stdcall INVENTORY_GetEquippedItemByType(D2InventoryStrc* pInventor
 D2UnitStrc* __stdcall INVENTORY_GetEquippedItemByCode(D2InventoryStrc* pInventory, int nItemCode, D2UnitStrc* pCheckItem)
 {
 	int nClassId = 0;
-	if (!pInventory || pInventory->dwSignature != 0x1020304 || !DATATBLS_GetItemRecordFromItemCode(nItemCode, &nClassId))
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !DATATBLS_GetItemRecordFromItemCode(nItemCode, &nClassId))
 	{
 		return nullptr;
 	}
@@ -2258,7 +2258,7 @@ D2UnitStrc* __stdcall INVENTORY_GetEquippedItemByCode(D2InventoryStrc* pInventor
 D2UnitStrc* __stdcall INVENTORY_GetBackPackItemByCode(D2InventoryStrc* pInventory, int nItemCode, D2UnitStrc* pCheckItem)
 {
 	int nClassId = 0;
-	if (!pInventory || pInventory->dwSignature != 0x1020304 || !DATATBLS_GetItemRecordFromItemCode(nItemCode, &nClassId))
+	if (!INVENTORY_GetPtrIfValid(pInventory) || !DATATBLS_GetItemRecordFromItemCode(nItemCode, &nClassId))
 	{
 		return nullptr;
 	}
@@ -2299,7 +2299,7 @@ D2UnitStrc* __stdcall INVENTORY_GetBackPackItemByCode(D2InventoryStrc* pInventor
 //D2Common.0x6FD90E20 (#10288)
 int __stdcall INVENTORY_GetSetItemEquipCountByFileIndex(D2InventoryStrc* pInventory, int nItemFileIndex)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return 0;
 	}
@@ -2337,7 +2337,7 @@ void __stdcall INVENTORY_UpdateWeaponGUIDOnInsert(D2InventoryStrc* pInventory, D
 				D2UnitStrc* pWeapon = INVENTORY_GetLeftHandWeapon(pInventory);
 				if (!pWeapon || !ITEMS_CheckItemTypeId(pWeapon, ITEMTYPE_WEAPON) || ITEMS_CheckItemTypeId(pWeapon, ITEMTYPE_MISSILE_POTION))
 				{
-					if (pInventory->dwSignature == 0x1020304)
+					if (INVENTORY_CheckSignature(pInventory))
 					{
 						pInventory->dwLeftItemGUID = pItem->dwUnitId;
 					}
@@ -2345,7 +2345,7 @@ void __stdcall INVENTORY_UpdateWeaponGUIDOnInsert(D2InventoryStrc* pInventory, D
 				}
 			}
 			
-			if (pInventory->dwSignature == 0x1020304 && pInventory->dwLeftItemGUID == pItem->dwUnitId)
+			if (INVENTORY_CheckSignature(pInventory) && pInventory->dwLeftItemGUID == pItem->dwUnitId)
 			{
 				pInventory->dwLeftItemGUID = -1;
 			}
@@ -2356,7 +2356,7 @@ void __stdcall INVENTORY_UpdateWeaponGUIDOnInsert(D2InventoryStrc* pInventory, D
 //D2Common.0x6FD90F80 (#10290)
 void __stdcall INVENTORY_UpdateWeaponGUIDOnRemoval(D2InventoryStrc* pInventory, D2UnitStrc* pItem)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304 && pItem && pItem->dwUnitType == UNIT_ITEM && ITEMS_CheckItemTypeId(pItem, ITEMTYPE_WEAPON))
+	if (INVENTORY_GetPtrIfValid(pInventory) && pItem && pItem->dwUnitType == UNIT_ITEM && ITEMS_CheckItemTypeId(pItem, ITEMTYPE_WEAPON))
 	{
 		if (pItem->dwUnitType == UNIT_ITEM && pInventory->dwLeftItemGUID == pItem->dwUnitId)
 		{
@@ -2397,7 +2397,7 @@ int __stdcall INVENTORY_GetWieldType(D2UnitStrc* pPlayer, D2InventoryStrc* pInve
 		D2UnitStrc* pRightHandItem = nullptr;
 		D2UnitStrc* pLeftHandItem = nullptr;
 
-		if (pInventory->dwSignature == 0x1020304)
+		if (INVENTORY_CheckSignature(pInventory))
 		{
 			D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 			if (pInventoryGrid)
@@ -2472,7 +2472,7 @@ int __stdcall INVENTORY_GetWieldType(D2UnitStrc* pPlayer, D2InventoryStrc* pInve
 //D2Common.0x6FD91140 (#10292)
 void __stdcall INVENTORY_SetOwnerId(D2InventoryStrc* pInventory, int nOwnerId)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		pInventory->dwOwnerId = nOwnerId;
 	}
@@ -2481,7 +2481,7 @@ void __stdcall INVENTORY_SetOwnerId(D2InventoryStrc* pInventory, int nOwnerId)
 //D2Common.0x6FD91160 (#10293)
 int __stdcall INVENTORY_GetOwnerId(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return pInventory->dwOwnerId;
 	}
@@ -2492,7 +2492,7 @@ int __stdcall INVENTORY_GetOwnerId(D2InventoryStrc* pInventory)
 //D2Common.0x6FD91190 (#10294)
 void __stdcall INVENTORY_CreateCorpseForPlayer(D2InventoryStrc* pInventory, int nUnitId, int a3, int a4)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		D2CorpseStrc* pCorpse = (D2CorpseStrc*)FOG_AllocServerMemory(pInventory->pMemPool, sizeof(D2CorpseStrc), __FILE__, __LINE__, 0);
 		pCorpse->unk0x00 = a4;
@@ -2521,7 +2521,7 @@ void __stdcall INVENTORY_CreateCorpseForPlayer(D2InventoryStrc* pInventory, int 
 //D2Common.0x6FD91210 (#10295)
 BOOL __stdcall INVENTORY_FreeCorpse(D2InventoryStrc* pInventory, int nUnitId, int a3)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304 && pInventory->pFirstCorpse)
+	if (INVENTORY_GetPtrIfValid(pInventory) && pInventory->pFirstCorpse)
 	{
 		D2CorpseStrc* pPreviousCorpse = nullptr;
 		D2CorpseStrc* pCorpse = pInventory->pFirstCorpse;
@@ -2568,7 +2568,7 @@ BOOL __stdcall INVENTORY_FreeCorpse(D2InventoryStrc* pInventory, int nUnitId, in
 //D2Common.0x6FD91290 (#10296)
 D2CorpseStrc* __stdcall INVENTORY_GetFirstCorpse(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return pInventory->pFirstCorpse;
 	}
@@ -2579,7 +2579,7 @@ D2CorpseStrc* __stdcall INVENTORY_GetFirstCorpse(D2InventoryStrc* pInventory)
 //D2Common.0x6FD912B0 (#10297)
 int __stdcall INVENTORY_GetCorpseCount(D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return pInventory->nCorpseCount;
 	}
@@ -2946,12 +2946,12 @@ int __stdcall D2Common_10299(D2UnitStrc* pUnit, int nBodyLoc, D2UnitStrc* pItem,
 					nOtherBodyLoc = BODYLOC_RARM;
 				}
 
-				if (pUnit->pInventory->dwSignature == 0x1020304 && nBodyLoc >= 0 && nBodyLoc < 13 && pInventoryGrid)
+				if (INVENTORY_CheckSignature(pUnit->pInventory) && nBodyLoc >= 0 && nBodyLoc < 13 && pInventoryGrid)
 				{
 					pItem1 = pInventoryGrid->ppItems[nBodyLoc];
 				}
 
-				if (pUnit->pInventory->dwSignature == 0x1020304 && nOtherBodyLoc >= 0 && nOtherBodyLoc < 13 && pInventoryGrid)
+				if (INVENTORY_CheckSignature(pUnit->pInventory) && nOtherBodyLoc >= 0 && nOtherBodyLoc < 13 && pInventoryGrid)
 				{
 					pItem2 = pInventoryGrid->ppItems[nOtherBodyLoc];
 				}
@@ -2970,12 +2970,12 @@ int __stdcall D2Common_10299(D2UnitStrc* pUnit, int nBodyLoc, D2UnitStrc* pItem,
 					nOtherBodyLoc = BODYLOC_SWRARM;
 				}
 
-				if (pUnit->pInventory->dwSignature == 0x1020304 && nBodyLoc >= 0 && nBodyLoc < 13 && pInventoryGrid)
+				if (INVENTORY_CheckSignature(pUnit->pInventory) && nBodyLoc >= 0 && nBodyLoc < 13 && pInventoryGrid)
 				{
 					pItem1 = pInventoryGrid->ppItems[nBodyLoc];
 				}
 
-				if (pUnit->pInventory->dwSignature == 0x1020304 && nOtherBodyLoc >= 0 && nOtherBodyLoc < 13 && pInventoryGrid)
+				if (INVENTORY_CheckSignature(pUnit->pInventory) && nOtherBodyLoc >= 0 && nOtherBodyLoc < 13 && pInventoryGrid)
 				{
 					pItem2 = pInventoryGrid->ppItems[nOtherBodyLoc];
 				}
@@ -2985,7 +2985,7 @@ int __stdcall D2Common_10299(D2UnitStrc* pUnit, int nBodyLoc, D2UnitStrc* pItem,
 			default:
 			{
 				D2UnitStrc* pInventoryItem = nullptr;
-				if (pUnit->pInventory->dwSignature == 0x1020304 && nBodyLoc >= 0 && nBodyLoc < 13 && pInventoryGrid)
+				if (INVENTORY_CheckSignature(pUnit->pInventory) && nBodyLoc >= 0 && nBodyLoc < 13 && pInventoryGrid)
 				{
 					pInventoryItem = pInventoryGrid->ppItems[nBodyLoc];
 				}
@@ -3038,7 +3038,7 @@ int __fastcall sub_6FD91D50(D2UnitStrc* pPlayer, int a2, int nBodyLoc, D2UnitStr
 		}
 
 		const int nInventoryRecord = UNITS_GetInventoryRecordId(pPlayer, 0, 1);
-		if (pPlayer->pInventory && pPlayer->pInventory->dwSignature == 0x1020304 && nBodyLoc >= 0 && nBodyLoc < 13)
+		if (INVENTORY_GetPtrIfValid(pPlayer->pInventory) && nBodyLoc >= 0 && nBodyLoc < 13)
 		{
 			D2InventoryGridStrc* pInventoryGrid = INVENTORY_GetGrid(pPlayer->pInventory, INVGRID_BODYLOC, &gBodyLocInventoryGridInfo);
 			if (pInventoryGrid && pInventoryGrid->ppItems[nBodyLoc] && INVENTORY_GetFreePosition(pPlayer->pInventory, pInventoryGrid->ppItems[nBodyLoc], nInventoryRecord, (int*)&a4, (int*)&pItem, 0))
@@ -3245,7 +3245,7 @@ int __stdcall INVENTORY_GetItemGUIDFromNode(D2InventoryNodeStrc* pNode)
 //D2Common.0x6FD92180 (#10300)
 BOOL __stdcall INVENTORY_RemoveAllItems(D2InventoryStrc* pInventory)
 {
-	if (!pInventory || pInventory->dwSignature != 0x1020304)
+	if (!INVENTORY_GetPtrIfValid(pInventory))
 	{
 		return FALSE;
 	}
@@ -3317,7 +3317,7 @@ BOOL __stdcall INVENTORY_CanItemsBeTraded(void* pMemPool, D2UnitStrc* pPlayer1, 
 //D2Common.0x6FD923C0
 BOOL __fastcall INVENTORY_CopyUnitItemsToTradeInventory(D2InventoryStrc* pTradeInventory, D2UnitStrc* pUnit)
 {
-	if (pTradeInventory && pTradeInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pTradeInventory))
 	{
 		const int nInventoryRecordId = UNITS_GetInventoryRecordId(pUnit, INVPAGE_INVENTORY, TRUE);
 		D2InventoryGridInfoStrc pInventoryGridInfo = {};
@@ -3325,7 +3325,7 @@ BOOL __fastcall INVENTORY_CopyUnitItemsToTradeInventory(D2InventoryStrc* pTradeI
 
 		D2InventoryGridStrc* pTradeInventoryGrid = INVENTORY_GetGrid(pTradeInventory, INVGRID_INVENTORY, &pInventoryGridInfo);
 
-		if (pTradeInventoryGrid && pUnit->pInventory && pUnit->pInventory->dwSignature == 0x1020304)
+		if (pTradeInventoryGrid && INVENTORY_GetPtrIfValid(pUnit->pInventory))
 		{
 			D2InventoryGridStrc* pUnitInventoryGrid = INVENTORY_GetGrid(pUnit->pInventory, INVGRID_INVENTORY, &pInventoryGridInfo);
 
@@ -3346,7 +3346,7 @@ BOOL __fastcall INVENTORY_CopyUnitItemsToTradeInventory(D2InventoryStrc* pTradeI
 //D2Common.0x6FD92490
 BOOL __fastcall INVENTORY_CanItemBePlacedInInventory(D2UnitStrc* pPlayer, D2UnitStrc* pItem, D2InventoryStrc* pInventory)
 {
-	if (pInventory && pInventory->dwSignature == 0x1020304)
+	if (INVENTORY_GetPtrIfValid(pInventory))
 	{
 		const int nInventoryRecordId = UNITS_GetInventoryRecordId(pPlayer, INVPAGE_INVENTORY, TRUE);
 		D2InventoryGridInfoStrc pInventoryGridInfo = {};

--- a/source/D2Common/src/D2Skills.cpp
+++ b/source/D2Common/src/D2Skills.cpp
@@ -633,7 +633,7 @@ D2SkillStrc* __fastcall SKILLS_GetHighestLevelSkillFromSkillId(D2UnitStrc* pUnit
 	{
 		for (D2SkillStrc* pSkill = pUnit->pSkills->pFirstSkill; pSkill; pSkill = pSkill->pNextSkill)
 		{
-			if (pSkill->pSkillsTxt->nSkillId == nSkillId && (!pHighestLevelSkill || pSkill->nOwnerGUID == -1 || pHighestLevelSkill->nOwnerGUID != -1 && pSkill->nSkillLevel > pHighestLevelSkill->nSkillLevel))
+			if (pSkill->pSkillsTxt->nSkillId == nSkillId && (!pHighestLevelSkill || pSkill->nOwnerGUID == D2UnitInvalidGUID || pHighestLevelSkill->nOwnerGUID != D2UnitInvalidGUID && pSkill->nSkillLevel > pHighestLevelSkill->nSkillLevel))
 			{
 				pHighestLevelSkill = pSkill;
 			}
@@ -790,7 +790,7 @@ D2SkillStrc* __fastcall SKILLS_GetUsedSkillFromSkillList(D2SkillListStrc* pSkill
 }
 
 //D2Common.0x6FDAFF40 (#10949)
-D2SkillStrc* __fastcall SKILLS_GetSkillById(D2UnitStrc* pUnit, int nSkillId, int nOwnerGUID)
+D2SkillStrc* __fastcall SKILLS_GetSkillById(D2UnitStrc* pUnit, int nSkillId, D2UnitGUID nOwnerGUID)
 {
 	return SKILLS_GetSkill(pUnit, nSkillId, nOwnerGUID);
 }
@@ -836,7 +836,7 @@ void __fastcall D2COMMON_SKILLS_RemoveSkill_6FDAFFF0(D2UnitStrc* pUnit, int nSki
 
 	if (const D2SkillStrc* pLeftSkill = pUnit->pSkills->pLeftSkill)
 	{
-		if (nSkillId == pLeftSkill->pSkillsTxt->nSkillId && pLeftSkill->nOwnerGUID == -1)
+		if (nSkillId == pLeftSkill->pSkillsTxt->nSkillId && pLeftSkill->nOwnerGUID == D2UnitInvalidGUID)
 		{
 			SKILLS_SetLeftActiveSkill(pUnit, SKILL_ATTACK, -1);
 		}
@@ -844,7 +844,7 @@ void __fastcall D2COMMON_SKILLS_RemoveSkill_6FDAFFF0(D2UnitStrc* pUnit, int nSki
 
 	if (const D2SkillStrc* pRightSkill = pUnit->pSkills->pRightSkill)
 	{
-		if (nSkillId == pRightSkill->pSkillsTxt->nSkillId && pRightSkill->nOwnerGUID == -1)
+		if (nSkillId == pRightSkill->pSkillsTxt->nSkillId && pRightSkill->nOwnerGUID == D2UnitInvalidGUID)
 		{
 			SKILLS_SetRightActiveSkill(pUnit, SKILL_ATTACK, -1);
 		}
@@ -852,7 +852,7 @@ void __fastcall D2COMMON_SKILLS_RemoveSkill_6FDAFFF0(D2UnitStrc* pUnit, int nSki
 
 	if (const D2SkillStrc* pUsedSkill = pUnit->pSkills->pUsedSkill)
 	{
-		if (nSkillId == pUsedSkill->pSkillsTxt->nSkillId && pUsedSkill->nOwnerGUID == -1)
+		if (nSkillId == pUsedSkill->pSkillsTxt->nSkillId && pUsedSkill->nOwnerGUID == D2UnitInvalidGUID)
 		{
 			SKILLS_SetUsedSkillInSkillList(pUnit->pSkills, nullptr);
 		}
@@ -861,7 +861,7 @@ void __fastcall D2COMMON_SKILLS_RemoveSkill_6FDAFFF0(D2UnitStrc* pUnit, int nSki
 	// Try to find the skill in the unit skills list
 	D2SkillStrc* pPreviousSkill = nullptr;
 	D2SkillStrc* pSkill = pUnit->pSkills->pFirstSkill;
-	while (pSkill && !(pSkill->pSkillsTxt->nSkillId == nSkillId && pSkill->nOwnerGUID == -1))
+	while (pSkill && !(pSkill->pSkillsTxt->nSkillId == nSkillId && pSkill->nOwnerGUID == D2UnitInvalidGUID))
 	{
 		pPreviousSkill = pSkill;
 		pSkill = pSkill->pNextSkill;
@@ -959,7 +959,7 @@ D2SkillStrc* __stdcall SKILLS_AddSkill(D2UnitStrc* pUnit, int nSkillId)
 			pSkill = UNITS_GetStartSkill(pUnit);
 			if (pSkill)
 			{
-				while (pSkill->pSkillsTxt != pSkillsTxtRecord || pSkill->nOwnerGUID != -1)
+				while (pSkill->pSkillsTxt != pSkillsTxtRecord || pSkill->nOwnerGUID != D2UnitInvalidGUID)
 				{
 					pSkill = pSkill->pNextSkill;
 					if (!pSkill)
@@ -1084,7 +1084,7 @@ void __stdcall SKILLS_AssignSkill(D2UnitStrc* pUnit, int nSkillId, int nSkillLev
 }
 
 //D2Common.0x6FDB05E0 (#10954)
-void __stdcall D2Common_10954(D2UnitStrc* pUnit, int nOwnerGUID, int nSkillId, int nSkillLevel, int nCharges, BOOL bFreeMemory)
+void __stdcall D2Common_10954(D2UnitStrc* pUnit, D2UnitGUID nOwnerGUID, int nSkillId, int nSkillLevel, int nCharges, BOOL bFreeMemory)
 {
 	D2SkillsTxt* pSkillsTxtRecord = NULL;
 	D2SkillListStrc* pSkillList = NULL;
@@ -1203,7 +1203,7 @@ void __stdcall D2Common_10954(D2UnitStrc* pUnit, int nOwnerGUID, int nSkillId, i
 }
 
 //D2Common.0x6FDB08C0 (#10957)
-int __stdcall SKILLS_GetOwnerGUIDFromSkill(D2SkillStrc* pSkill)
+D2UnitGUID __stdcall SKILLS_GetOwnerGUIDFromSkill(D2SkillStrc* pSkill)
 {
 	D2_ASSERT(pSkill);
 
@@ -1211,11 +1211,11 @@ int __stdcall SKILLS_GetOwnerGUIDFromSkill(D2SkillStrc* pSkill)
 }
 
 //D2Common.0x6FDB08F0 (#10955)
-BOOL __stdcall SKILLS_GetSkillInfo(D2SkillStrc* pSkill, int* pOwnerGUID, int* pSkillId, int* pSkillLevel, int* pCharges)
+BOOL __stdcall SKILLS_GetSkillInfo(D2SkillStrc* pSkill, D2UnitGUID* pOwnerGUID, int* pSkillId, int* pSkillLevel, int* pCharges)
 {
 	D2_ASSERT(pSkill);
 
-	if (pSkill->nOwnerGUID == -1)
+	if (pSkill->nOwnerGUID == D2UnitInvalidGUID)
 	{
 		return FALSE;
 	}
@@ -1247,7 +1247,7 @@ BOOL __stdcall SKILLS_SetCharges(D2SkillStrc* pSkill, int nCharges)
 {
 	D2_ASSERT(pSkill);
 
-	if (pSkill->nOwnerGUID == -1)
+	if (pSkill->nOwnerGUID == D2UnitInvalidGUID)
 	{
 		return FALSE;
 	}
@@ -1259,7 +1259,7 @@ BOOL __stdcall SKILLS_SetCharges(D2SkillStrc* pSkill, int nCharges)
 }
 
 //D2Common.0x6FDB09A0 (#10961)
-void __stdcall SKILLS_SetLeftActiveSkill(D2UnitStrc* pUnit, int nSkillId, int nOwnerGUID)
+void __stdcall SKILLS_SetLeftActiveSkill(D2UnitStrc* pUnit, int nSkillId, D2UnitGUID nOwnerGUID)
 {
 	D2SkillsTxt* pSkillsTxtRecord = DATATBLS_GetSkillsTxtRecord(nSkillId);
 	D2_ASSERT(pSkillsTxtRecord);
@@ -1293,7 +1293,7 @@ void __stdcall SKILLS_SetLeftActiveSkill(D2UnitStrc* pUnit, int nSkillId, int nO
 }
 
 //D2Common.0x6FDB0A30 (#10962)
-void __stdcall SKILLS_SetRightActiveSkill(D2UnitStrc* pUnit, int nSkillId, int nOwnerGUID)
+void __stdcall SKILLS_SetRightActiveSkill(D2UnitStrc* pUnit, int nSkillId, D2UnitGUID nOwnerGUID)
 {
 	D2SkillsTxt* pSkillsTxtRecord = NULL;
 	D2SkillStrc* pSkill = NULL;
@@ -1621,7 +1621,7 @@ BOOL __fastcall D2Common_SKILLMANA_CheckStat_6FDB0F50(D2UnitStrc* pUnit, D2Skill
 
 	D2_ASSERT(pSkill);
 
-	if (pSkill->nOwnerGUID == -1)
+	if (pSkill->nOwnerGUID == D2UnitInvalidGUID)
 	{
 		nSkillLevel = SKILLS_GetSkillLevel(pUnit, pSkill, TRUE) - 1;
 		D2_ASSERT(pSkill->pSkillsTxt);
@@ -1675,7 +1675,7 @@ BOOL __fastcall sub_6FDB1070(D2UnitStrc* pUnit, D2SkillStrc* pSkill)
 
 	if (pUnit && pSkill && pUnit->pInventory)
 	{
-		if (pSkill->nOwnerGUID != -1)
+		if (pSkill->nOwnerGUID != D2UnitInvalidGUID)
 		{
 			pItem = INVENTORY_GetFirstItem(pUnit->pInventory);
 
@@ -2003,7 +2003,7 @@ int __stdcall SKILLS_GetSkillLevel(D2UnitStrc* pUnit, D2SkillStrc* pSkill, BOOL 
 	if (pUnit && pSkill)
 	{
 		nSkillLevel = pSkill->nSkillLevel;
-		if (bBonus && pSkill->nOwnerGUID == -1)
+		if (bBonus && pSkill->nOwnerGUID == D2UnitInvalidGUID)
 		{
 			nSkillLevel += SKILLS_GetBonusSkillLevel(pUnit, pSkill);
 		}
@@ -2035,12 +2035,12 @@ int __stdcall SKILLS_GetBonusSkillLevelFromSkillId(D2UnitStrc* pUnit, int nSkill
 	{
 		pSkill = pUnit->pSkills->pFirstSkill;
 
-		while (pSkill && (pSkill->pSkillsTxt->nSkillId != nSkillId || pSkill->nOwnerGUID != -1))
+		while (pSkill && (pSkill->pSkillsTxt->nSkillId != nSkillId || pSkill->nOwnerGUID != D2UnitInvalidGUID))
 		{
 			pSkill = pSkill->pNextSkill;
 		}
 
-		if (pSkill && pSkill->nOwnerGUID == -1)
+		if (pSkill && pSkill->nOwnerGUID == D2UnitInvalidGUID)
 		{
 			return SKILLS_GetBonusSkillLevel(pUnit, pSkill);
 		}
@@ -2073,7 +2073,7 @@ void __stdcall D2Common_11030(D2UnitStrc* pUnit, int nSkillId, int a3)
 			SKILLS_AssignSkill(pUnit, nSkillId, 0, 0, __FILE__, __LINE__);
 		}
 
-		if (pSkill->nOwnerGUID == -1)
+		if (pSkill->nOwnerGUID == D2UnitInvalidGUID)
 		{
 			pSkill->nLevelBonus = a3;
 			SKILLS_RefreshSkill(pUnit, nSkillId);
@@ -2102,7 +2102,7 @@ void __stdcall D2Common_11031(D2UnitStrc* pUnit, int nSkillId, int a3)
 		SKILLS_AssignSkill(pUnit, nSkillId, 0, 0, __FILE__, __LINE__);
 	}
 
-	if (pSkill->nOwnerGUID == -1)
+	if (pSkill->nOwnerGUID == D2UnitInvalidGUID)
 	{
 		pSkill->nLevelBonus += a3;
 		if (pSkill->nLevelBonus < 0)
@@ -2285,7 +2285,7 @@ int __stdcall SKILLS_GetRequiredLevelBasedOnCurrent(D2UnitStrc* pUnit, int nSkil
 		if (pUnit->pSkills)
 		{
 			pSkill = pUnit->pSkills->pFirstSkill;
-			while (pSkill && (pSkill->pSkillsTxt->nSkillId != nSkillId || pSkill->nOwnerGUID != -1))
+			while (pSkill && (pSkill->pSkillsTxt->nSkillId != nSkillId || pSkill->nOwnerGUID != D2UnitInvalidGUID))
 			{
 				pSkill = pSkill->pNextSkill;
 			}
@@ -2371,7 +2371,7 @@ BOOL __stdcall SKILLS_CheckRequiredSkills(D2UnitStrc* pUnit, int nSkillId)
 }
 
 //D2Common.0x6FDB1F80
-D2SkillStrc* __fastcall SKILLS_GetSkill(D2UnitStrc* pUnit, int nSkillId, int nOwnerGUID)
+D2SkillStrc* __fastcall SKILLS_GetSkill(D2UnitStrc* pUnit, int nSkillId, D2UnitGUID nOwnerGUID)
 {
 	D2SkillStrc* pSkill = NULL;
 

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -949,7 +949,7 @@ void __stdcall STATLIST_FreeStatListEx(D2UnitStrc* pUnit)
 }
 
 //D2Common.0x6FDB7140 (#10470)
-D2StatListStrc* __stdcall STATLIST_AllocStatList(void* pMemPool, uint32_t fFilter, uint32_t dwTimeout, int nUnitType, int nUnitGUID)
+D2StatListStrc* __stdcall STATLIST_AllocStatList(void* pMemPool, uint32_t fFilter, uint32_t dwTimeout, int nUnitType, D2UnitGUID nUnitGUID)
 {
 	D2StatListStrc* pStatList = D2_CALLOC_STRC_SERVER(pMemPool, D2StatListStrc);
 
@@ -993,7 +993,7 @@ int __stdcall STATLIST_GetOwnerType(D2StatListStrc* pStatList)
 }
 
 //D2Common.0x6FD912D0 (#10472)
-int __stdcall STATLIST_GetOwnerGUID(D2StatListStrc* pStatList)
+D2UnitGUID __stdcall STATLIST_GetOwnerGUID(D2StatListStrc* pStatList)
 {
 	if (pStatList)
 	{

--- a/source/D2Common/src/Items/ItemMods.cpp
+++ b/source/D2Common/src/Items/ItemMods.cpp
@@ -827,7 +827,7 @@ D2StatListStrc* __fastcall ITEMMODS_GetOrCreateStatList(D2UnitStrc* pUnit, D2Uni
 		}
 		else
 		{
-			nItemGUID = -1;
+			nItemGUID = D2UnitInvalidGUID;
 			pMemPool = NULL;
 		}
 

--- a/source/D2Common/src/Items/Items.cpp
+++ b/source/D2Common/src/Items/Items.cpp
@@ -27,7 +27,7 @@ void __stdcall ITEMS_AllocItemData(void* pMemPool, D2UnitStrc* pItem)
 		}
 		memset(pItem->pItemData, 0x00, sizeof(D2ItemDataStrc));
 
-		pItem->pItemData->dwOwnerGUID = -1;
+		pItem->pItemData->dwOwnerGUID = D2UnitInvalidGUID;
 	}
 }
 
@@ -3482,7 +3482,7 @@ void __stdcall ITEMS_SetRealmData(D2UnitStrc* pItem, int a2, int a3)
 }
 
 //D2Common.0x6FD9E0A0 (#10734)
-void __stdcall ITEMS_SetOwnerId(D2UnitStrc* pItem, int nOwnerGUID)
+void __stdcall ITEMS_SetOwnerId(D2UnitStrc* pItem, D2UnitGUID nOwnerGUID)
 {
 	D2_ASSERT(pItem);
 	D2_ASSERT(pItem->dwUnitType == UNIT_ITEM);

--- a/source/D2Common/src/Items/Items.cpp
+++ b/source/D2Common/src/Items/Items.cpp
@@ -907,12 +907,9 @@ uint8_t __stdcall ITEMS_GetComponent(D2UnitStrc* pItem)
 //D2Common.0x6FD99500 (#10749)
 void __stdcall ITEMS_GetDimensions(D2UnitStrc* pItem, uint8_t* pWidth, uint8_t* pHeight, char* szFile, int nLine)
 {
-	D2ItemsTxt* pItemsTxtRecord = NULL;
-
 	if (pItem && pItem->dwUnitType == UNIT_ITEM)
 	{
-		pItemsTxtRecord = DATATBLS_GetItemsTxtRecord(pItem->dwClassId);
-		if (pItemsTxtRecord)
+		if (D2ItemsTxt* pItemsTxtRecord = DATATBLS_GetItemsTxtRecord(pItem->dwClassId))
 		{
 			*pWidth = pItemsTxtRecord->nInvWidth;
 			*pHeight = pItemsTxtRecord->nInvHeight;

--- a/source/D2Common/src/Items/Items.cpp
+++ b/source/D2Common/src/Items/Items.cpp
@@ -47,9 +47,9 @@ void __stdcall ITEMS_FreeItemData(void* pMemPool, D2UnitStrc* pItem)
 //D2Common.0x6FD98430 (#10689)
 uint8_t __stdcall ITEMS_GetBodyLocation(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->nBodyLoc;
+		return pItemData->nBodyLoc;
 	}
 
 	return BODYLOC_NONE;
@@ -58,21 +58,18 @@ uint8_t __stdcall ITEMS_GetBodyLocation(D2UnitStrc* pItem)
 //D2Common.0x6FD98450 (#10690)
 void __stdcall ITEMS_SetBodyLocation(D2UnitStrc* pItem, uint8_t nBodyLoc)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM)
+	if (D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem))
 	{
-		if (pItem->pItemData)
-		{
-			pItem->pItemData->nBodyLoc = nBodyLoc;
-		}
+		pItemData->nBodyLoc = nBodyLoc;
 	}
 }
 
 //D2Common.0x6FD98470 (#10691)
 D2SeedStrc* __stdcall ITEMS_GetItemSeed(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem))
 	{
-		return &pItem->pItemData->pSeed;
+		return &pItemData->pSeed;
 	}
 	
 	return NULL;
@@ -81,18 +78,18 @@ D2SeedStrc* __stdcall ITEMS_GetItemSeed(D2UnitStrc* pItem)
 //D2Common.0x6FD98490 (#10692)
 void __stdcall ITEMS_InitItemSeed(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem))
 	{
-		SEED_InitSeed(&pItem->pItemData->pSeed);
+		SEED_InitSeed(&pItemData->pSeed);
 	}
 }
 
 //D2Common.0x6FD984B0 (#10693)
 int __stdcall ITEMS_GetItemStartSeed(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->dwInitSeed;
+		return pItemData->dwInitSeed;
 	}
 	
 	return 0;
@@ -110,9 +107,9 @@ void __stdcall ITEMS_SetItemStartSeed(D2UnitStrc* pItem, int nSeed)
 //D2Common.0x6FD98550 (#10695)
 int __stdcall ITEMS_GetItemQuality(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->dwQualityNo;
+		return pItemData->dwQualityNo;
 	}
 
 	return ITEMQUAL_NORMAL;
@@ -121,18 +118,18 @@ int __stdcall ITEMS_GetItemQuality(D2UnitStrc* pItem)
 //D2Common.0x6FD98580 (#10696)
 void __stdcall ITEMS_SetItemQuality(D2UnitStrc* pItem, int nQuality)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->dwQualityNo = nQuality;
+		pItemData->dwQualityNo = nQuality;
 	}
 }
 
 //D2Common.0x6FD985A0 (#10699)
 uint16_t __stdcall ITEMS_GetPrefixId(D2UnitStrc* pItem, int nPrefixNo)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->wMagicPrefix[nPrefixNo];
+		return pItemData->wMagicPrefix[nPrefixNo];
 	}
 
 	return 0;
@@ -141,18 +138,18 @@ uint16_t __stdcall ITEMS_GetPrefixId(D2UnitStrc* pItem, int nPrefixNo)
 //D2Common.0x6FD985D0 (#10700)
 void __stdcall ITEMS_AssignPrefix(D2UnitStrc* pItem, uint16_t nPrefix, int nPrefixNo)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->wMagicPrefix[nPrefixNo] = nPrefix;
+		pItemData->wMagicPrefix[nPrefixNo] = nPrefix;
 	}
 }
 
 //D2Common.0x6FD98600 (#10697)
 uint16_t __stdcall ITEMS_GetAutoAffix(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->wAutoAffix;
+		return pItemData->wAutoAffix;
 	}
 
 	return 0;
@@ -161,18 +158,18 @@ uint16_t __stdcall ITEMS_GetAutoAffix(D2UnitStrc* pItem)
 //D2Common.0x6FD98630 (#10698)
 void __stdcall ITEMS_SetAutoAffix(D2UnitStrc* pItem, uint16_t nAffix)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->wAutoAffix = nAffix;
+		pItemData->wAutoAffix = nAffix;
 	}
 }
 
 //D2Common.0x6FD98650 (#10701)
 uint16_t __stdcall ITEMS_GetSuffixId(D2UnitStrc* pItem, int nSuffixNo)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->wMagicSuffix[nSuffixNo];
+		return pItemData->wMagicSuffix[nSuffixNo];
 	}
 
 	return 0;
@@ -181,18 +178,18 @@ uint16_t __stdcall ITEMS_GetSuffixId(D2UnitStrc* pItem, int nSuffixNo)
 //D2Common.0x6FD98680 (#10702)
 void __stdcall ITEMS_AssignSuffix(D2UnitStrc* pItem, uint16_t nSuffix, int nSuffixNo)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->wMagicSuffix[nSuffixNo] = nSuffix;
+		pItemData->wMagicSuffix[nSuffixNo] = nSuffix;
 	}
 }
 
 //D2Common.0x6FD986B0 (#10703)
 uint16_t __stdcall ITEMS_GetRarePrefixId(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->wRarePrefix;
+		return pItemData->wRarePrefix;
 	}
 
 	return 0;
@@ -201,18 +198,18 @@ uint16_t __stdcall ITEMS_GetRarePrefixId(D2UnitStrc* pItem)
 //D2Common.0x6FD986E0 (#10704)
 void __stdcall ITEMS_AssignRarePrefix(D2UnitStrc* pItem, uint16_t nPrefix)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->wRarePrefix = nPrefix;
+		pItemData->wRarePrefix = nPrefix;
 	}
 }
 
 //D2Common.0x6FD98700 (#10705)
 uint16_t __stdcall ITEMS_GetRareSuffixId(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->wRareSuffix;
+		return pItemData->wRareSuffix;
 	}
 
 	return 0;
@@ -221,18 +218,18 @@ uint16_t __stdcall ITEMS_GetRareSuffixId(D2UnitStrc* pItem)
 //D2Common.0x6FD98730 (#10706)
 void __stdcall ITEMS_AssignRareSuffix(D2UnitStrc* pItem, uint16_t nSuffix)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->wRareSuffix = nSuffix;
+		pItemData->wRareSuffix = nSuffix;
 	}
 }
 
 //D2Common.0x6FD98750 (#10707)
 BOOL __stdcall ITEMS_CheckItemFlag(D2UnitStrc* pItem, uint32_t dwFlag, int nLine, char* szFile)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->dwItemFlags & dwFlag;
+		return pItemData->dwItemFlags & dwFlag;
 	}
 
 	return 0;
@@ -241,15 +238,15 @@ BOOL __stdcall ITEMS_CheckItemFlag(D2UnitStrc* pItem, uint32_t dwFlag, int nLine
 //D2Common.0x6FD98780 (#10708)
 void __stdcall ITEMS_SetItemFlag(D2UnitStrc* pItem, uint32_t dwFlag, BOOL bSet)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
 		if (bSet)
 		{
-			pItem->pItemData->dwItemFlags |= dwFlag;
+			pItemData->dwItemFlags |= dwFlag;
 		}
 		else
 		{
-			pItem->pItemData->dwItemFlags &= ~dwFlag;
+			pItemData->dwItemFlags &= ~dwFlag;
 		}
 	}
 }
@@ -257,9 +254,9 @@ void __stdcall ITEMS_SetItemFlag(D2UnitStrc* pItem, uint32_t dwFlag, BOOL bSet)
 //D2Common.0x6FD987C0 (#10709)
 uint32_t __stdcall ITEMS_GetItemFlags(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->dwItemFlags;
+		return pItemData->dwItemFlags;
 	}
 
 	return 0;
@@ -268,9 +265,9 @@ uint32_t __stdcall ITEMS_GetItemFlags(D2UnitStrc* pItem)
 //D2Common.0x6FD987E0 (#10710)
 BOOL __stdcall ITEMS_CheckItemCMDFlag(D2UnitStrc* pItem, int nFlag)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->dwCommandFlags & nFlag;
+		return pItemData->dwCommandFlags & nFlag;
 	}
 
 	return 0;
@@ -279,15 +276,15 @@ BOOL __stdcall ITEMS_CheckItemCMDFlag(D2UnitStrc* pItem, int nFlag)
 //D2Common.0x6FD98810 (#10711)
 void __stdcall ITEMS_SetItemCMDFlag(D2UnitStrc* pItem, int nFlag, BOOL bSet)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
 		if (bSet)
 		{
-			pItem->pItemData->dwCommandFlags |= nFlag;
+			pItemData->dwCommandFlags |= nFlag;
 		}
 		else
 		{
-			pItem->pItemData->dwCommandFlags &= ~nFlag;
+			pItemData->dwCommandFlags &= ~nFlag;
 		}
 	}
 }
@@ -295,9 +292,9 @@ void __stdcall ITEMS_SetItemCMDFlag(D2UnitStrc* pItem, int nFlag, BOOL bSet)
 //D2Common.0x6FD98850 (#10712)
 uint32_t __stdcall ITEMS_GetItemCMDFlags(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->dwCommandFlags;
+		return pItemData->dwCommandFlags;
 	}
 
 	return 0;
@@ -306,13 +303,13 @@ uint32_t __stdcall ITEMS_GetItemCMDFlags(D2UnitStrc* pItem)
 //D2Common.0x6FD98870 (#10717)
 int __stdcall ITEMS_GetItemLevel(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		if (pItem->pItemData->dwItemLevel < 1)
+		if (pItemData->dwItemLevel < 1)
 		{
-			pItem->pItemData->dwItemLevel = 1;
+			pItemData->dwItemLevel = 1;
 		}
-		return pItem->pItemData->dwItemLevel;
+		return pItemData->dwItemLevel;
 	}
 
 	return 1;
@@ -321,22 +318,22 @@ int __stdcall ITEMS_GetItemLevel(D2UnitStrc* pItem)
 //D2Common.0x6FD988B0 (#10718)
 void __stdcall ITEMS_SetItemLevel(D2UnitStrc* pItem, int nItemLevel)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
 		if (nItemLevel < 1)
 		{
 			nItemLevel = 1;
 		}
-		pItem->pItemData->dwItemLevel = nItemLevel;
+		pItemData->dwItemLevel = nItemLevel;
 	}
 }
 
 //D2Common.0x6FD988E0 (#10719)
 uint8_t __stdcall ITEMS_GetInvPage(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->nInvPage;
+		return pItemData->nInvPage;
 	}
 
 	return -1;
@@ -345,18 +342,18 @@ uint8_t __stdcall ITEMS_GetInvPage(D2UnitStrc* pItem)
 //D2Common.0x6FD98900 (#10720)
 void __stdcall ITEMS_SetInvPage(D2UnitStrc* pItem, uint8_t nPage)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->nInvPage = nPage;
+		pItemData->nInvPage = nPage;
 	}
 }
 
 //D2Common.0x6FD98920 (#10721)
 uint8_t __stdcall ITEMS_GetCellOverlap(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->nCellOverlap;
+		return pItemData->nCellOverlap;
 	}
 
 	return -1;
@@ -365,18 +362,18 @@ uint8_t __stdcall ITEMS_GetCellOverlap(D2UnitStrc* pItem)
 //D2Common.0x6FD98940 (#10722)
 void __stdcall ITEMS_SetCellOverlap(D2UnitStrc* pItem, int nCellOverlap)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->nCellOverlap = nCellOverlap;
+		pItemData->nCellOverlap = nCellOverlap;
 	}
 }
 
 //D2Common.0x6FD98960 (#10853)
 uint8_t __stdcall ITEMS_GetItemCell(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->nItemCell;
+		return pItemData->nItemCell;
 	}
 
 	return -1;
@@ -385,18 +382,18 @@ uint8_t __stdcall ITEMS_GetItemCell(D2UnitStrc* pItem)
 //D2Common.0x6FD98980 (#10854)
 void __stdcall ITEMS_SetItemCell(D2UnitStrc* pItem, int nItemCell)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->nItemCell = nItemCell;
+		pItemData->nItemCell = nItemCell;
 	}
 }
 
 //D2Common.0x6FD989A0 (#10723)
 char* __stdcall ITEMS_GetEarName(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->szPlayerName;
+		return pItemData->szPlayerName;
 	}
 
 	return NULL;
@@ -407,11 +404,11 @@ void __stdcall ITEMS_SetEarName(D2UnitStrc* pItem, char* szName)
 {
 	int nCounter = 0;
 
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
 		do
 		{
-			pItem->pItemData->szPlayerName[nCounter] = szName[nCounter];
+			pItemData->szPlayerName[nCounter] = szName[nCounter];
 			++nCounter;
 		}
 		while (szName[nCounter -1]);
@@ -421,9 +418,9 @@ void __stdcall ITEMS_SetEarName(D2UnitStrc* pItem, char* szName)
 //D2Common.0x6FD989F0 (#10725)
 uint8_t __stdcall ITEMS_GetEarLevel(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->nEarLvl;
+		return pItemData->nEarLvl;
 	}
 
 	return 1;
@@ -432,18 +429,18 @@ uint8_t __stdcall ITEMS_GetEarLevel(D2UnitStrc* pItem)
 //D2Common.0x6FD98A10 (#10726)
 void __stdcall ITEMS_SetEarLevel(D2UnitStrc* pItem, uint8_t nLevel)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->nEarLvl = nLevel;
+		pItemData->nEarLvl = nLevel;
 	}
 }
 
 //D2Common.0x6FD98A30 (#10727)
 uint8_t __stdcall ITEMS_GetVarGfxIndex(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->nInvGfxIdx;
+		return pItemData->nInvGfxIdx;
 	}
 
 	return 0;
@@ -452,9 +449,9 @@ uint8_t __stdcall ITEMS_GetVarGfxIndex(D2UnitStrc* pItem)
 //D2Common.0x6FD98A50 (#10728)
 void __stdcall ITEMS_SetVarGfxIndex(D2UnitStrc* pItem, uint8_t nIndex)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->nInvGfxIdx = nIndex;
+		pItemData->nInvGfxIdx = nIndex;
 	}
 }
 
@@ -1228,19 +1225,20 @@ int __fastcall ITEMS_GetRequiredLevel(D2UnitStrc* pItem, D2UnitStrc* pPlayer)
 	int nRequiredLevel = 0;
 	int nCraftBonus = 0;
 	D2StatStrc pStat[64] = {};
-
-	if (!pItem || pItem->dwUnitType != UNIT_ITEM || !pItem->pItemData)
+	
+	D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem);
+	if (!pItemData)
 	{
 		return 0;
 	}
 
 	nRequiredLevel = 0;
-	switch (pItem->pItemData->dwQualityNo)
+	switch (pItemData->dwQualityNo)
 	{
 	case ITEMQUAL_MAGIC:
-		pPrefixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItem->pItemData->wMagicPrefix[0]);
-		pSuffixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItem->pItemData->wMagicSuffix[0]);
-		pAutoAffixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItem->pItemData->wAutoAffix);
+		pPrefixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItemData->wMagicPrefix[0]);
+		pSuffixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItemData->wMagicSuffix[0]);
+		pAutoAffixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItemData->wAutoAffix);
 
 		if (pPrefixTxtRecord)
 		{
@@ -1272,8 +1270,8 @@ int __fastcall ITEMS_GetRequiredLevel(D2UnitStrc* pItem, D2UnitStrc* pPlayer)
 	case ITEMQUAL_RARE:
 		for(int i = 0; i < 3; ++i)
 		{
-			pPrefixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItem->pItemData->wMagicPrefix[i]);
-			pSuffixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItem->pItemData->wMagicSuffix[i]);
+			pPrefixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItemData->wMagicPrefix[i]);
+			pSuffixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItemData->wMagicSuffix[i]);
 
 			if (pPrefixTxtRecord)
 			{
@@ -1294,7 +1292,7 @@ int __fastcall ITEMS_GetRequiredLevel(D2UnitStrc* pItem, D2UnitStrc* pPlayer)
 			}
 		}
 
-		pAutoAffixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItem->pItemData->wAutoAffix);
+		pAutoAffixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItemData->wAutoAffix);
 		if (pAutoAffixTxtRecord)
 		{
 			nLevelRequirement = pAutoAffixTxtRecord->nClass != -1 && pPlayer && pAutoAffixTxtRecord->nClass == pPlayer->dwClassId ? pAutoAffixTxtRecord->nClassLevelReq : pAutoAffixTxtRecord->nLevelReq;
@@ -1308,8 +1306,8 @@ int __fastcall ITEMS_GetRequiredLevel(D2UnitStrc* pItem, D2UnitStrc* pPlayer)
 		nCraftBonus = 10;
 		for (int i = 0; i < 3; ++i)
 		{
-			pPrefixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItem->pItemData->wMagicPrefix[i]);
-			pSuffixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItem->pItemData->wMagicSuffix[i]);
+			pPrefixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItemData->wMagicPrefix[i]);
+			pSuffixTxtRecord = DATATBLS_GetMagicAffixTxtRecord(pItemData->wMagicSuffix[i]);
 
 			if (pPrefixTxtRecord)
 			{
@@ -1340,9 +1338,9 @@ int __fastcall ITEMS_GetRequiredLevel(D2UnitStrc* pItem, D2UnitStrc* pPlayer)
 		}
 		break;
 	case ITEMQUAL_UNIQUE:
-		if (pItem->pItemData->dwFileIndex >= 0 && pItem->pItemData->dwFileIndex < sgptDataTables->nUniqueItemsTxtRecordCount)
+		if (pItemData->dwFileIndex >= 0 && pItemData->dwFileIndex < sgptDataTables->nUniqueItemsTxtRecordCount)
 		{
-			pUniqueItemsTxtRecord = &sgptDataTables->pUniqueItemsTxt[pItem->pItemData->dwFileIndex];
+			pUniqueItemsTxtRecord = &sgptDataTables->pUniqueItemsTxt[pItemData->dwFileIndex];
 			if (pUniqueItemsTxtRecord)
 			{
 				if (pPlayer)
@@ -1971,7 +1969,6 @@ int __fastcall ITEMS_CalculateTransactionCost(D2UnitStrc* pPlayer, D2UnitStrc* p
 	D2ItemsTxt* pUberItemsTxtRecord = NULL;
 	D2ItemsTxt* pItemsTxtRecord = NULL;
 	D2BooksTxt* pBooksTxtRecord = NULL;
-	D2ItemDataStrc* pItemData = NULL;
 	D2NpcTxt* pNpcTxtRecord = NULL;
 	D2UnitStrc* pSocketable = NULL;
 	int nSocketableCost = 0;
@@ -2001,13 +1998,11 @@ int __fastcall ITEMS_CalculateTransactionCost(D2UnitStrc* pPlayer, D2UnitStrc* p
 	int nRep = 0;
 
 	int v30 = 0, v27 = 0, v22 = 0, v23 = 0; //TODO: Rename
-
-	if (!pPlayer || !pItem || pItem->dwUnitType != UNIT_ITEM || !pItem->pItemData)
+	D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem);
+	if (!pPlayer || !pItemData)
 	{
 		return 0x7FFFFFFF;
 	}
-
-	pItemData = pItem->pItemData;
 
 	nLevel = STATLIST_GetUnitStatUnsigned(pPlayer, STAT_LEVEL, 0);
 
@@ -2754,9 +2749,9 @@ int __stdcall ITEMS_GetSpellIcon(D2UnitStrc* pItem)
 
 	if (ITEMS_CheckItemTypeId(pItem, ITEMTYPE_SCROLL) || ITEMS_CheckItemTypeId(pItem, ITEMTYPE_BOOK))
 	{
-		if (pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+		if (D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem))
 		{
-			wBookId = pItem->pItemData->wMagicSuffix[0];
+			wBookId = pItemData->wMagicSuffix[0];
 		}
 		else
 		{
@@ -3441,28 +3436,24 @@ BOOL __stdcall ITEMS_IsNotQuestItemByItemId(int nItemId)
 //D2Common.0x6FD9DEE0 (#10732)
 int __stdcall ITEMS_GetFileIndex(D2UnitStrc* pItem)
 {
-	D2_ASSERT(pItem);
-	D2_ASSERT(pItem->dwUnitType == UNIT_ITEM);
-	D2_ASSERT(pItem->pItemData);
+	D2_ASSERT(ITEMS_GetItemData(pItem));
 	return pItem->pItemData->dwFileIndex;
 }
 
 //D2Common.0x6FD9DF60 (#10733)
 void __stdcall ITEMS_SetFileIndex(D2UnitStrc* pItem, uint32_t dwFileIndex)
 {
-	D2_ASSERT(pItem);
-	D2_ASSERT(pItem->dwUnitType == UNIT_ITEM);
-	D2_ASSERT(pItem->pItemData);
+	D2_ASSERT(ITEMS_GetItemData(pItem));
 	pItem->pItemData->dwFileIndex = dwFileIndex;
 }
 
 //D2Common.0x6FD9DFE0 (#11244)
 void __stdcall ITEMS_GetRealmData(D2UnitStrc* pItem, int* pRealmData0, int* pRealmData1)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		*pRealmData0 = pItem->pItemData->dwRealmData[0];
-		*pRealmData1 = pItem->pItemData->dwRealmData[1];
+		*pRealmData0 = pItemData->dwRealmData[0];
+		*pRealmData1 = pItemData->dwRealmData[1];
 	}
 	else
 	{
@@ -3474,28 +3465,24 @@ void __stdcall ITEMS_GetRealmData(D2UnitStrc* pItem, int* pRealmData0, int* pRea
 //D2Common.0x6FD9E070 (#11245)
 void __stdcall ITEMS_SetRealmData(D2UnitStrc* pItem, int a2, int a3)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->dwRealmData[0] = a2;
-		pItem->pItemData->dwRealmData[1] = a3;
+		pItemData->dwRealmData[0] = a2;
+		pItemData->dwRealmData[1] = a3;
 	}
 }
 
 //D2Common.0x6FD9E0A0 (#10734)
 void __stdcall ITEMS_SetOwnerId(D2UnitStrc* pItem, D2UnitGUID nOwnerGUID)
 {
-	D2_ASSERT(pItem);
-	D2_ASSERT(pItem->dwUnitType == UNIT_ITEM);
-	D2_ASSERT(pItem->pItemData);
+	D2_ASSERT(ITEMS_GetItemData(pItem));
 	pItem->pItemData->dwOwnerGUID = nOwnerGUID;
 }
 
 //D2Common.0x6FD9E120 (#10735)
 int __stdcall ITEMS_GetOwnerId(D2UnitStrc* pItem)
 {
-	D2_ASSERT(pItem);
-	D2_ASSERT(pItem->dwUnitType == UNIT_ITEM);
-	D2_ASSERT(pItem->pItemData);
+	D2_ASSERT(ITEMS_GetItemData(pItem));
 	return pItem->pItemData->dwOwnerGUID;
 }
 
@@ -3638,7 +3625,11 @@ uint32_t __stdcall ITEMS_GetTransmogrify(D2UnitStrc* pItem)
 //D2Common.0x6FD9E550 (#10826)
 int __stdcall ITEMS_IsMagSetRarUniCrfOrTmp(D2UnitStrc* pItem)
 {
-	return pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData && pItem->pItemData->dwQualityNo >= ITEMQUAL_MAGIC && pItem->pItemData->dwQualityNo <= ITEMQUAL_TEMPERED;
+	if (D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem))
+	{
+		return pItemData->dwQualityNo >= ITEMQUAL_MAGIC && pItemData->dwQualityNo <= ITEMQUAL_TEMPERED;
+	}
+	return false;
 }
 
 //D2Common.0x6FD9E580 (#10740)
@@ -4496,15 +4487,17 @@ uint32_t __stdcall ITEMS_GetSetItemsMask(D2UnitStrc* pPlayer, D2UnitStrc* pSetIt
 //D2Common.0x6FD9FD80 (#10838)
 D2SetItemsTxt* __stdcall ITEMS_GetSetItemsTxtRecordFromItem(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData && pItem->pItemData->dwQualityNo == ITEMQUAL_SET)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		if (pItem->pItemData->dwFileIndex >= 0 && pItem->pItemData->dwFileIndex < sgptDataTables->nSetItemsTxtRecordCount)
+		if (pItemData->dwQualityNo == ITEMQUAL_SET
+			&& pItemData->dwFileIndex >= 0
+			&& pItemData->dwFileIndex < sgptDataTables->nSetItemsTxtRecordCount)
 		{
-			return &sgptDataTables->pSetItemsTxt[pItem->pItemData->dwFileIndex];
+			return &sgptDataTables->pSetItemsTxt[pItemData->dwFileIndex];
 		}
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 //D2Common.0x6FD9FE20 (#10839)
@@ -4526,14 +4519,15 @@ BOOL __stdcall ITEMS_CanBeEquipped(D2UnitStrc* pItem)
 //D2Common.0x6FD9FE70 (#10840)
 BOOL __stdcall ITEMS_IsCharmUsable(D2UnitStrc* pItem, D2UnitStrc* pPlayer)
 {
-	if (!pItem || pItem->dwUnitType == UNIT_ITEM && (pItem->pItemData && (pItem->pItemData->dwItemFlags & IFLAG_BROKEN || pItem->pItemData->dwItemFlags & IFLAG_NOEQUIP)))
+	D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem);
+	if (pItemData->dwItemFlags & IFLAG_BROKEN || pItemData->dwItemFlags & IFLAG_NOEQUIP)
 	{
 		return FALSE;
 	}
 	
 	if (ITEMS_CheckItemTypeId(pItem, ITEMTYPE_CHARM))
 	{
-		if (pItem->dwUnitType == UNIT_ITEM && pItem->pItemData->nInvPage == INVPAGE_INVENTORY)
+		if (pItem->dwUnitType == UNIT_ITEM && pItemData->nInvPage == INVPAGE_INVENTORY)
 		{
 			return ITEMS_CheckRequirements(pItem, pPlayer, FALSE, NULL, NULL, NULL) != 0;
 		}
@@ -4634,19 +4628,14 @@ int __stdcall ITEMS_GetBonusManaBasedOnClass(D2UnitStrc* pPlayer, int nValue)
 //D2Common.0x6FDA0030 (#10875)
 uint16_t __stdcall ITEMS_GetItemFormat(D2UnitStrc* pItem)
 {
-	D2_ASSERT(pItem);
-	D2_ASSERT(pItem->dwUnitType == UNIT_ITEM);
-	D2_ASSERT(pItem->pItemData);
-
+	D2_ASSERT(ITEMS_GetItemData(pItem));
 	return pItem->pItemData->wItemFormat;
 }
 
 //D2Common.0x6FDA00B0 (#10876)
 void __stdcall ITEMS_SetItemFormat(D2UnitStrc* pItem, uint16_t nItemFormat)
 {
-	D2_ASSERT(pItem);
-	D2_ASSERT(pItem->dwUnitType == UNIT_ITEM);
-	D2_ASSERT(pItem->pItemData);
+	D2_ASSERT(ITEMS_GetItemData(pItem));
 	pItem->pItemData->wItemFormat = nItemFormat;
 }
 
@@ -4732,9 +4721,9 @@ int __stdcall ITEMS_HasUsedCharges(D2UnitStrc* pItem, BOOL* pHasChargedSkills)
 //D2Common.0x6FDA0340 (#10880)
 BOOL __stdcall ITEMS_IsEthereal(D2UnitStrc* pItem)
 {
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		return pItem->pItemData->dwItemFlags & IFLAG_ETHEREAL;
+		return pItemData->dwItemFlags & IFLAG_ETHEREAL;
 	}
 
 	return 0;
@@ -4821,22 +4810,22 @@ size_t __stdcall ITEMS_DecodeItemFromBitstream(D2UnitStrc* pItem, uint8_t* pBits
 		dwFlags &= ~IFLAG_LOWQUALITY;
 	}
 
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData)
+	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
-		pItem->pItemData->dwItemFlags = dwFlags;
+		pItemData->dwItemFlags = dwFlags;
 
-		pItem->pItemData->dwItemFlags &= ~IFLAG_INIT;
+		pItemData->dwItemFlags &= ~IFLAG_INIT;
 
-		pItem->pItemData->dwItemLevel = 1;
+		pItemData->dwItemLevel = 1;
 
 		for (int i = 0; i < 3; ++i)
 		{
-			pItem->pItemData->wMagicPrefix[i] = 0;
-			pItem->pItemData->wMagicSuffix[i] = 0;
+			pItemData->wMagicPrefix[i] = 0;
+			pItemData->wMagicSuffix[i] = 0;
 		}
 
-		pItem->pItemData->wRarePrefix = 0;
-		pItem->pItemData->wRareSuffix = 0;
+		pItemData->wRarePrefix = 0;
+		pItemData->wRareSuffix = 0;
 	}
 
 	if (dwFlags & IFLAG_COMPACTSAVE)
@@ -4867,7 +4856,6 @@ int __fastcall ITEMS_DecodeItemBitstreamCompact(D2UnitStrc* pItem, D2BitBufferSt
 {
 	D2ItemStatCostTxt* pItemStatCostTxtRecord = NULL;
 	D2ItemsTxt* pItemsTxtRecord = NULL;
-	D2ItemDataStrc* pItemData = NULL;
 	D2StatListStrc* pStatList = NULL;
 	int nBits = 0;
 	int nItemId = 0;
@@ -4876,9 +4864,7 @@ int __fastcall ITEMS_DecodeItemBitstreamCompact(D2UnitStrc* pItem, D2BitBufferSt
 	char szChar = 0;
 	uint8_t nAnimMode = 0;
 
-	D2_ASSERT(pItem);
-	D2_ASSERT(pItem->dwUnitType == UNIT_ITEM);
-	pItemData = pItem->pItemData;
+	D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem);
 	D2_ASSERT(pItemData);
 
 	pItemData->wItemFormat = (uint16_t)BITMANIP_Read(pBuffer, 10);
@@ -5035,9 +5021,7 @@ int __fastcall ITEMS_DecodeItemBitstreamComplete(D2UnitStrc* pItem, D2BitBufferS
 	BOOL bError = FALSE;
 	BOOL b109 = FALSE;
 
-	D2_ASSERT(pItem);
-	D2_ASSERT(pItem->dwUnitType == UNIT_ITEM);
-	pItemData = pItem->pItemData;
+	pItemData = ITEMS_GetItemData(pItem);
 	D2_ASSERT(pItemData);
 
 	pItemData->wItemFormat = (uint16_t)BITMANIP_Read(pBuffer, 10);
@@ -6418,7 +6402,6 @@ void __fastcall ITEMS_SerializeItemCompact(D2UnitStrc* pItem, D2BitBufferStrc* p
 size_t __fastcall ITEMS_SerializeItem(D2UnitStrc* pItem, D2BitBufferStrc* pBuffer, BOOL bServer, BOOL bSaveItemInv, BOOL bGamble)
 {
 	D2ItemsTxt* pItemsTxtRecord = NULL;
-	D2ItemDataStrc* pItemData = NULL;
 	uint32_t nItemFlags = 0;
 
 	if (!pItem || pItem->dwUnitType != UNIT_ITEM)
@@ -6426,7 +6409,7 @@ size_t __fastcall ITEMS_SerializeItem(D2UnitStrc* pItem, D2BitBufferStrc* pBuffe
 		return 0;
 	}
 
-	pItemData = pItem->pItemData;
+	D2ItemDataStrc* pItemData = pItem->pItemData;
 	if (pItemData)
 	{
 		nItemFlags = pItemData->dwItemFlags;
@@ -6518,7 +6501,6 @@ void __fastcall ITEMS_SerializeItemComplete(D2UnitStrc* pItem, D2BitBufferStrc* 
 	D2ItemsTxt* pItemsTxtRecord = NULL;
 	D2StatListStrc* pStatListEx = NULL;
 	D2UnitStrc* pInventoryItem = NULL;
-	D2ItemDataStrc* pItemData = NULL;
 	char* szPlayerName = NULL;
 	int nMagicPrefixOffset = 0;
 	int nAutoMagicOffset = 0;
@@ -6559,10 +6541,7 @@ void __fastcall ITEMS_SerializeItemComplete(D2UnitStrc* pItem, D2BitBufferStrc* 
 	int nStatValues[511] = {};
 	D2StatStrc pStat[511] = {};
 
-
-	D2_ASSERT(pItem);
-	D2_ASSERT(pItem->dwUnitType == UNIT_ITEM);
-	pItemData = pItem->pItemData;
+	D2ItemDataStrc* pItemData = ITEMS_GetItemData(pItem);
 	D2_ASSERT(pItemData);
 
 	nItemFormat = pItemData->wItemFormat;
@@ -7455,20 +7434,10 @@ D2ItemStatCostTxt* __fastcall ITEMS_GetItemStatCostTxtRecord(int nStatId)
 //D2Common.0x6FDA42E0 (#10837)
 int __stdcall ITEMS_GetNoOfSetItemsFromItem(D2UnitStrc* pItem)
 {
-	D2SetItemsTxt* pSetItemsTxtRecord = NULL;
-
-	if (pItem && pItem->dwUnitType == UNIT_ITEM && pItem->pItemData && pItem->pItemData->dwQualityNo == ITEMQUAL_SET)
+	if (D2SetItemsTxt* pSetItemsTxtRecord = ITEMS_GetSetItemsTxtRecordFromItem(pItem))
 	{
-		if (pItem->pItemData->dwFileIndex >= 0 && pItem->pItemData->dwFileIndex < sgptDataTables->nSetItemsTxtRecordCount)
-		{
-			pSetItemsTxtRecord = &sgptDataTables->pSetItemsTxt[pItem->pItemData->dwFileIndex];
-			if (pSetItemsTxtRecord)
-			{
-				return pSetItemsTxtRecord->nSetItems;
-			}
-		}
+		return pSetItemsTxtRecord->nSetItems;
 	}
-
 	return -1;
 }
 

--- a/source/D2Common/src/Items/Items.cpp
+++ b/source/D2Common/src/Items/Items.cpp
@@ -4264,7 +4264,7 @@ int __stdcall ITEMS_GetAllRepairCosts(D2GameStrc* pGame, D2UnitStrc* pUnit, int 
 		return 0;
 	}
 
-	while (nBodyLoc < 13)
+	while (nBodyLoc < NUM_BODYLOC)
 	{
 		pItem = INVENTORY_GetItemFromBodyLoc(pUnit->pInventory, nBodyLoc);
 		if (pItem)

--- a/source/D2Common/src/Path/Path.cpp
+++ b/source/D2Common/src/Path/Path.cpp
@@ -1102,7 +1102,7 @@ void __stdcall PATH_SetTargetUnit(D2DynamicPathStrc* pDynamicPath, D2UnitStrc* p
 }
 
 //D2Common.0x6FDA9F60 (#10171)
-void __stdcall PATH_GetTargetTypeAndGUID(D2DynamicPathStrc* pDynamicPath, int* pTargetType, int* pTargetGUID)
+void __stdcall PATH_GetTargetTypeAndGUID(D2DynamicPathStrc* pDynamicPath, int* pTargetType, D2UnitGUID* pTargetGUID)
 {
 	D2_ASSERT(pDynamicPath->pTargetUnit);
 

--- a/source/D2Common/src/Units/Missile.cpp
+++ b/source/D2Common/src/Units/Missile.cpp
@@ -32,7 +32,7 @@ void __stdcall MISSILE_AllocMissileData(D2UnitStrc* pMissile)
 	{
 		pMissile->pMissileData = (D2MissileDataStrc*)FOG_AllocServerMemory(pMissile->pMemoryPool, sizeof(D2MissileDataStrc), __FILE__, __LINE__, 0);
 		memset(pMissile->pMissileData, 0x00, sizeof(D2MissileDataStrc));
-		pMissile->pMissileData->dwOwnerGUID = -1;
+		pMissile->pMissileData->dwOwnerGUID = D2UnitInvalidGUID;
 	}
 }
 
@@ -220,7 +220,7 @@ void __stdcall MISSILE_SetOwner(D2UnitStrc* pMissile, D2UnitStrc* pOwner)
 				}
 				else
 				{
-					pMissile->pMissileData->dwOwnerGUID = -1;
+					pMissile->pMissileData->dwOwnerGUID = D2UnitInvalidGUID;
 				}
 			}
 		}
@@ -442,13 +442,13 @@ void __stdcall MISSILE_SetHomeType(D2UnitStrc* pMissile, D2UnitStrc* pTarget)
 		else
 		{
 			pMissile->pMissileData->nHomeType = 0;
-			pMissile->pMissileData->dwHomeGUID = -1;
+			pMissile->pMissileData->dwHomeGUID = D2UnitInvalidGUID;
 		}
 	}
 }
 
 //D2Common.0x6FDBA550 (#11145)
-void __stdcall MISSILE_GetHomeType(D2UnitStrc* pMissile, int* nHomeType, int* nHomeGUID)
+void __stdcall MISSILE_GetHomeType(D2UnitStrc* pMissile, int* nHomeType, D2UnitGUID* nHomeGUID)
 {
 	if (pMissile && pMissile->dwUnitType == UNIT_MISSILE && pMissile->pMissileData)
 	{
@@ -458,7 +458,7 @@ void __stdcall MISSILE_GetHomeType(D2UnitStrc* pMissile, int* nHomeType, int* nH
 	else
 	{
 		*nHomeType = 0;
-		*nHomeGUID = -1;
+		*nHomeGUID = D2UnitInvalidGUID;
 	}
 }
 

--- a/source/D2Common/src/Units/Units.cpp
+++ b/source/D2Common/src/Units/Units.cpp
@@ -645,7 +645,7 @@ void __stdcall UNITS_SetTargetUnitForDynamicUnit(D2UnitStrc* pUnit, D2UnitStrc* 
 int __stdcall UNITS_GetTargetTypeFromDynamicUnit(D2UnitStrc* pUnit)
 {
 	int nUnitType = 0;
-	int nUnitId = 0;
+	D2UnitGUID nUnitId = 0;
 	D2_ASSERT(pUnit);
 	D2_ASSERT((pUnit->dwUnitType == UNIT_PLAYER) || (pUnit->dwUnitType == UNIT_MONSTER) || (pUnit->dwUnitType == UNIT_MISSILE));
 
@@ -654,10 +654,10 @@ int __stdcall UNITS_GetTargetTypeFromDynamicUnit(D2UnitStrc* pUnit)
 }
 
 //D2Common.0x6FDBE3A0 (#10346)
-int __stdcall UNITS_GetTargetGUIDFromDynamicUnit(D2UnitStrc* pUnit)
+D2UnitGUID __stdcall UNITS_GetTargetGUIDFromDynamicUnit(D2UnitStrc* pUnit)
 {
 	int nUnitType = 0;
-	int nUnitId = 0;
+	D2UnitGUID nUnitId = 0;
 	D2_ASSERT(pUnit);
 	D2_ASSERT((pUnit->dwUnitType == UNIT_PLAYER) || (pUnit->dwUnitType == UNIT_MONSTER) || (pUnit->dwUnitType == UNIT_MISSILE));
 
@@ -2047,7 +2047,7 @@ int __stdcall UNITS_GetNewDirection(D2UnitStrc* pUnit)
 }
 
 //D2Common.0x6FDBFF20 (#10416)
-void __stdcall UNITS_StoreOwnerTypeAndGUID(D2UnitStrc* pUnit, int nOwnerType, int nOwnerId)
+void __stdcall UNITS_StoreOwnerTypeAndGUID(D2UnitStrc* pUnit, int nOwnerType, D2UnitGUID nOwnerId)
 {
 	UNITS_StoreOwnerInfo(pUnit, nOwnerType, nOwnerId);
 }
@@ -3418,7 +3418,7 @@ void __stdcall UNITS_GetSwitchRightSkillDataResetRightSkill(D2UnitStrc* pUnit, i
 
 		pUnit->pPlayerData->nRightSkillId = 0;
 		pUnit->pPlayerData->nRightSkillFlags = -1;
-		pUnit->pPlayerData->nWeaponGUID = -1;
+		pUnit->pPlayerData->nWeaponGUID = D2UnitInvalidGUID;
 		pUnit->pPlayerData->unk0x94[0] = 0;
 	}
 	else
@@ -3440,7 +3440,7 @@ void __stdcall UNITS_GetSwitchLeftSkillDataResetLeftSkill(D2UnitStrc* pUnit, int
 
 		pUnit->pPlayerData->nLeftSkillId = 0;
 		pUnit->pPlayerData->nLeftSkillFlags = -1;
-		pUnit->pPlayerData->nWeaponGUID = -1;
+		pUnit->pPlayerData->nWeaponGUID = D2UnitInvalidGUID;
 		pUnit->pPlayerData->unk0x94[0] = 0;
 	}
 	else
@@ -3529,7 +3529,7 @@ void __stdcall UNITS_SetWeaponGUID(D2UnitStrc* pUnit, D2UnitStrc* pWeapon)
 }
 
 //D2Common.0x6FDC25B0 (#10456)
-int __stdcall UNITS_GetWeaponGUID(D2UnitStrc* pUnit)
+D2UnitGUID __stdcall UNITS_GetWeaponGUID(D2UnitStrc* pUnit)
 {
 	D2_ASSERT(pUnit);
 	D2_ASSERT(pUnit->dwUnitType == UNIT_PLAYER);
@@ -4159,7 +4159,7 @@ D2UnitStrc* __stdcall D2Common_10407(D2RoomStrc* pRoom, int nX, int nY, int (__f
 }
 
 //D2Common.0x6FDC3680 (#10419)
-void __fastcall UNITS_SetInteractData(D2UnitStrc* pUnit, int nSkillId, int nUnitType, int nUnitGUID)
+void __fastcall UNITS_SetInteractData(D2UnitStrc* pUnit, int nSkillId, int nUnitType, D2UnitGUID nUnitGUID)
 {
 	if (pUnit && pUnit->dwUnitType == UNIT_PLAYER && pUnit->pPlayerData)
 	{

--- a/source/D2CommonDefinitions/include/D2Structs.h
+++ b/source/D2CommonDefinitions/include/D2Structs.h
@@ -5,6 +5,8 @@
 
 #include "D2QuestDataEx.h"
 
+typedef uint32_t D2UnitGUID;
+static const D2UnitGUID D2UnitInvalidGUID = (D2UnitGUID)-1;
 
 #pragma pack(1)
 
@@ -294,13 +296,13 @@ struct D2AiControlStrc
 	AIPARAMFN pAiParamFn;					//0x04
 	uint16_t nAiFlags;							//0x08
 	uint8_t unk0x0A[2];						//0x0A
-	uint32_t dwOwnerGUID;						//0x0C
+	D2UnitGUID dwOwnerGUID;						//0x0C
 	uint32_t dwOwnerType;						//0x10
 	int32_t dwAiParam[3];						//0x14
 	D2AiCmdStrc* pCurrentCmd;				//0x20
 	D2AiCmdStrc* pLastCmd;					//0x24
 	D2GameStrc* pGame;						//0x28
-	uint32_t dwOwnerGUIDEx;					//0x2C
+	D2UnitGUID dwOwnerGUIDEx;				//0x2C
 	uint32_t dwOwnerTypeEx;					//0x30
 	D2MinionListStrc* pMinionList;			//0x34
 	D2MapAIStrc* pMapAi;					//0x38
@@ -561,7 +563,7 @@ struct D2ClientStrc
 	D2ClientInfoStrc* pClientInfo;			//0x68
 	uint8_t unk0x6C[256];						//0x6C
 	uint32_t dwUnitType;						//0x16C
-	uint32_t dwUnitGUID;						//0x170
+	D2UnitGUID dwUnitGUID;						//0x170
 	D2UnitStrc* pPlayer;					//0x174
 	uint32_t __178;							//0x178
 	D2SaveHeaderStrc* pSaveHeader;			//0x17C
@@ -1147,7 +1149,7 @@ struct D2MercDataStrc
 
 struct D2MinionListStrc
 {
-	uint32_t dwMinionGUID;						//0x00
+	D2UnitGUID dwMinionGUID;						//0x00
 	D2MinionListStrc* pNext;				//0x04
 };
 
@@ -1210,7 +1212,7 @@ struct D2NpcControlStrc
 struct D2NpcGambleStrc
 {
 	D2InventoryStrc* pInventory;			//0x00
-	uint32_t dwGUID;							//0x04
+	D2UnitGUID dwGUID;							//0x04
 	D2NpcGambleStrc* pNext;					//0x08
 };
 
@@ -1275,7 +1277,7 @@ struct D2NpcRecordStrc
 			uint32_t dwTicks;					//0x28
 			D2UnitProxyStrc pProxy;			//0x2C
 			uint32_t dwUnk;					//0x3C
-			uint32_t dwNPCGUID;				//0x40
+			D2UnitGUID dwNPCGUID;				//0x40
 		};
 		//D2NPCTradeStrc pTrade;            //0x20
 	//};

--- a/source/D2CommonDefinitions/include/D2Structs.h
+++ b/source/D2CommonDefinitions/include/D2Structs.h
@@ -5,8 +5,8 @@
 
 #include "D2QuestDataEx.h"
 
-typedef uint32_t D2UnitGUID;
-static const D2UnitGUID D2UnitInvalidGUID = (D2UnitGUID)-1;
+using D2UnitGUID = uint32_t;
+constexpr D2UnitGUID D2UnitInvalidGUID = (D2UnitGUID)-1;
 
 #pragma pack(1)
 


### PR DESCRIPTION
Cleaned up the content of `D2Inventory.cpp` a bit, took this opportunity to add the `D2UnitGUID` type to ensure we use the same type everywhere (we had a mix of signed and unsigned)