### PR TITLE
Add D2Lang.Unicode::toUnicode

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -37,7 +37,7 @@ EXPORTS
 ;   D2LANG_10048 @10048 ; ?sys2Unicode@Unicode@@SIPAU1@PAU1@PBDH@Z
 ;   D2LANG_10049 @10049 ; ?sysWidth@Unicode@@SIKPBU1@H@Z
     ?toLower@Unicode@@QBE?AU1@XZ @10050 ; Unicode::toLower
-;   D2LANG_10051 @10051 ; ?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z
+    ?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z @10051 ; Unicode::toUnicode
     ?toUpper@Unicode@@QBE?AU1@XZ @10052 ; Unicode::toUpper
     ?toUtf@Unicode@@SIPADPADPBU1@H@Z @10053 ; Unicode::toUtf
 ;   D2LANG_10054 @10054 ; ?unicode2Sys@Unicode@@SIPADPADPBU1@H@Z

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -166,6 +166,22 @@ struct D2LANG_DLL_DECL Unicode {
       const Unicode* substr);
 
   /**
+   * Converts a null-terminated UTF-8 string into a null-terminated
+   * UCS-2 string. The count indicates the capacity of the destination
+   * in terms of UCS-2 characters. Returns the pointer to the
+   * destination string.
+   *
+   * Vanilla bug: Specifying INT_MIN for the count results in
+   * undefined behavior. Do not specify INT_MIN as the count.
+   *
+   * D2Lang.0x6FC12A40 (#10051) ?toUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z
+   */
+  static Unicode* __fastcall toUnicode(
+      Unicode* dest,
+      const char* src,
+      int count);
+
+  /**
    * Converts a null-terminated UCS-2 string into a null-terminated
    * UTF-8 string. The count indicates the capacity of the destination
    * in terms of UTF-8 code units. Returns the pointer to the

--- a/source/D2Lang/tests/D2LangTests.cpp
+++ b/source/D2Lang/tests/D2LangTests.cpp
@@ -328,3 +328,40 @@ TEST_CASE("Unicode::toUtf")
         CHECK(strncmp(dest, utf8JpDiablo, 6) == 0);
     }
 }
+
+TEST_CASE("Unicode::toUnicode")
+{
+    constexpr size_t dest_capacity = 256;
+    Unicode dest[dest_capacity];
+
+    // The official name of Diablo in Japanese
+    constexpr char* utf8JpDiablo = "\xE3\x83\x87\xE3\x82\xA3\xE3\x82\xA2\xE3\x83\x96\xE3\x83\xAD";
+    constexpr wchar_t* utf16JpDiablo = L"\u30C7\u30A3\u30A2\u30D6\u30ED";
+
+    SUBCASE("Empty")
+    {
+        CHECK(Unicode::toUnicode(dest, "", dest_capacity) == dest);
+        CHECK(wcscmp((wchar_t*)dest, L"") == 0);
+    }
+    SUBCASE("Convert ASCII text")
+    {
+        Unicode::toUnicode(dest, "Diablo", dest_capacity);
+        wprintf(L"%ls\n", (wchar_t*)dest);
+        CHECK(wcscmp((wchar_t*)dest, L"Diablo") == 0);
+    }
+    SUBCASE("Partially convert ASCII text")
+    {
+        Unicode::toUnicode(dest, "Diablo", 4);
+        CHECK(wcscmp((wchar_t*)dest, L"Dia") == 0);
+    }
+    SUBCASE("Convert Japanese text")
+    {
+        Unicode::toUnicode(dest, utf8JpDiablo, dest_capacity);
+        CHECK(wcscmp((wchar_t*)dest, utf16JpDiablo) == 0);
+    }
+    SUBCASE("Partially convert Japanese text")
+    {
+        Unicode::toUnicode(dest, utf8JpDiablo, 3);
+        CHECK(wcsncmp((wchar_t*)dest, utf16JpDiablo, 2) == 0);
+    }
+}


### PR DESCRIPTION
These changes add the D2Lang.Unicode::toUnicode function.

The function converts a UTF-8 string into a UCS-2 string.

My own testing confirms that the function produces the same results as its vanilla counterpart.