### PR TITLE
Add D2Lang.Unicode::strncat

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -27,7 +27,7 @@ EXPORTS
     ?strcpy@Unicode@@SIPAU1@PAU1@PBU1@@Z @10038 ; Unicode::strcpy
     ?stricmp@Unicode@@SIHPBU1@0@Z @10039 ; Unicode::stricmp
     ?strlen@Unicode@@SIHPBU1@@Z @10040 ; Unicode::strlen
-;   D2LANG_10041 @10041 ; ?strncat@Unicode@@SIPAU1@PAU1@PBU1@H@Z
+    ?strncat@Unicode@@SIPAU1@PAU1@PBU1@H@Z @10041 ; Unicode::strncat
     ?strncmp@Unicode@@SIHPBU1@0I@Z @10042 ; Unicode::strncmp
 ;   D2LANG_10043 @10043 ; ?strncoll@Unicode@@SIHPBU1@0H@Z
 ;   D2LANG_10044 @10044 ; ?strncpy@Unicode@@SIPAU1@PAU1@PBU1@H@Z

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -134,6 +134,20 @@ struct D2LANG_DLL_DECL Unicode {
    */
   static int __fastcall strlen(const Unicode* str);
 
+  /**
+   * Appends a null-terminated string to the end of a destination
+   * null-terminated string. The maximum number of characters appended
+   * is specified as the count. The destination string will always
+   * append a terminating null character, so that (count + 1)
+   * characters can be written.
+   *
+   * D2Lang.0x6FC11420 (#10041) ?strncat@Unicode@@SIPAU1@PAU1@PBU1@H@Z
+   */
+  static Unicode* __fastcall strncat(
+      Unicode* dest,
+      const Unicode* src,
+      int count);
+
   /*
    * Compares two null-terminated strings or substrings
    * lexicographically. Returns -1, 0, or 1, depending on the results

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -117,6 +117,25 @@ int __fastcall Unicode::strlen(const Unicode* str) {
   return i;
 }
 
+Unicode* __fastcall Unicode::strncat(
+    Unicode* dest,
+    const Unicode* src,
+    int count) {
+  int i_dest = 0;
+  while (dest[i_dest].ch != L'\0') {
+    ++i_dest;
+  }
+
+  int i_src;
+  for (i_src = 0; i_src != count && src[i_src].ch != L'\0'; ++i_src) {
+    dest[i_dest + i_src] = src[i_src];
+  }
+
+  dest[i_dest + i_src] = L'\0';
+
+  return dest;
+}
+
 int __fastcall Unicode::strncmp(
     const Unicode* str1,
     const Unicode* str2,

--- a/source/D2Lang/tests/D2LangTests.cpp
+++ b/source/D2Lang/tests/D2LangTests.cpp
@@ -167,6 +167,46 @@ TEST_CASE("Unicode::stricmp")
     }
 }
 
+TEST_CASE("Unicode::strncat")
+{
+    SUBCASE("Concatenate empty on empty")
+    {
+        Unicode dest[256];
+        Unicode::strncat(dest, D2_USTR(L""), INT_MAX);
+        CHECK(wcscmp((wchar_t*)dest, L"") == 0);
+    }
+    SUBCASE("Concatenate text on empty")
+    {
+        Unicode dest[256];
+        Unicode::strncat(dest, D2_USTR(L"Diablo"), INT_MAX);
+        CHECK(wcscmp((wchar_t*)dest, L"Diablo") == 0);
+    }
+    SUBCASE("Concatenate text on not empty")
+    {
+        Unicode dest[256] = { L'3', L':', L' ' };
+        Unicode::strncat(dest, D2_USTR(L"Mephisto, "), INT_MAX);
+        Unicode::strncat(dest, D2_USTR(L"Diablo, "), INT_MAX);
+        Unicode::strncat(dest, D2_USTR(L"and Baal"), INT_MAX);
+        CHECK(wcscmp((wchar_t*)dest, L"3: Mephisto, Diablo, and Baal") == 0);
+    }
+    SUBCASE("Concatenate at correct index")
+    {
+        Unicode dest[256];
+        Unicode::strncat(dest, D2_USTR(L"Diablo"), INT_MAX);
+        dest[3] = L'\0';
+        Unicode::strncat(dest, D2_USTR(L"mond"), INT_MAX);
+        CHECK(wcscmp((wchar_t*)dest, L"Diamond") == 0);
+    }
+    SUBCASE("Concatenate partial text")
+    {
+        Unicode dest[256];
+        Unicode::strncat(dest, D2_USTR(L"Diablo"), INT_MAX);
+        dest[3] = L'\0';
+        Unicode::strncat(dest, D2_USTR(L"mond"), 3);
+        CHECK(wcscmp((wchar_t*)dest, L"Diamon") == 0);
+    }
+}
+
 TEST_CASE("Unicode::strncmp")
 {
     const size_t strLenDiablo2 = wcslen(L"Diablo2");


### PR DESCRIPTION
These changes add the D2Lang.Unicode::strncat function.

The function concatenates a Unicode string to the end of another Unicode string, writing at most `count` number of characters.

My own testing confirms that the function produces the same results as its vanilla counterpart.