### PR TITLE
Add D2Lang.Unicode::sprintf

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -19,7 +19,7 @@ EXPORTS
     ?isWhitespace@Unicode@@QBEHXZ @10030 ; Unicode::isWhitespace
     ?isWordEnd@Unicode@@SIHPBU1@I@Z @10031 ; Unicode::isWordEnd
 ;   D2LANG_10032 @10032 ; ?loadSysMap@Unicode@@SIHPAUHD2ARCHIVE__@@PBD@Z
-;   D2LANG_10033 @10033 ; ?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ
+    ?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ @10033 ; Unicode::sprintf
     ?strcat@Unicode@@SIPAU1@PAU1@PBU1@@Z @10034 ; Unicode::strcat
     ?strchr@Unicode@@SIPAU1@PBU1@U1@@Z @10035 ; Unicode::strchr
     ?strcmp@Unicode@@SIHPBU1@0@Z @10036 ; Unicode::strcmp

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -79,6 +79,24 @@ struct D2LANG_DLL_DECL Unicode {
   static BOOL __fastcall isWordEnd(const Unicode* str, size_t index);
 
   /**
+   * Performs string conversions on the supplied parameters, similar
+   * to standard C's printf.
+   *
+   * Only the conversion specifiers %%, %d, %u, and %s are supported.
+   * %s represents a pointer to a null-terminated Unicode string. To
+   * specify an unsupported conversion specifier will result in an
+   * assertion error. Flags, minimum field width, precision, and
+   * length modifiers are not supported.
+   *
+   * D2Lang.0x6FC0B250 (#10033) ?sprintf@Unicode@@SAXHPAU1@PBU1@ZZ
+   */
+  static void __cdecl sprintf(
+      int buffer_size,
+      Unicode* buffer,
+      const Unicode* format,
+      ...);
+
+  /**
    * Appends a null-terminated string to the end of a null-terminated
    * destination string. Returns the destination string.
    *

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -71,6 +71,7 @@ void __cdecl Unicode::sprintf(
         && format[i_format].ch != L'\0') {
       if (i_buffer >= buffer_size) {
         buffer[i_buffer - 1].ch = L'\0';
+        va_end(args);
         return;
       }
 
@@ -82,11 +83,13 @@ void __cdecl Unicode::sprintf(
 
     if (i_buffer >= buffer_size) {
       buffer[i_buffer - 1].ch = L'\0';
+      va_end(args);
       return;
     }
 
     if (format[i_format].ch == L'\0') {
       buffer[i_buffer].ch = L'\0';
+      va_end(args);
       return;
     }
 
@@ -104,11 +107,13 @@ void __cdecl Unicode::sprintf(
          * No conversion specifier found or % is the last character.
          */
         Unicode::strcpy(&buffer[i_buffer], percent_sign);
+        va_end(args);
         return;
       }
 
       case L'%': {
         if (i_buffer + 1 >= buffer_size) {
+          va_end(args);
           return;
         }
 
@@ -134,9 +139,12 @@ void __cdecl Unicode::sprintf(
         int itoa_length;
         for (itoa_length = 0;
             itoa_unicode[itoa_length].ch != L'\0';
-            ++itoa_length);
+            ++itoa_length) {
+          /* Left empty on purpose. */
+        }
 
         if ((i_buffer + itoa_length + 1) >= buffer_size) {
+          va_end(args);
           return;
         }
 
@@ -153,6 +161,7 @@ void __cdecl Unicode::sprintf(
               &buffer[i_buffer],
               arg_value.s,
               buffer_size - (i_buffer + 1));
+          va_end(args);
           return;
         }
 
@@ -168,6 +177,7 @@ void __cdecl Unicode::sprintf(
               &buffer[i_buffer],
               arg_value.s,
               buffer_size - (i_buffer + 1));
+          va_end(args);
           return;
         }
 
@@ -193,6 +203,8 @@ void __cdecl Unicode::sprintf(
       }
     }
   }
+
+  va_end(args);
 }
 
 Unicode* __fastcall Unicode::strcat(Unicode* dest, const Unicode* src) {

--- a/source/D2Lang/tests/D2LangTests.cpp
+++ b/source/D2Lang/tests/D2LangTests.cpp
@@ -31,6 +31,94 @@ TEST_CASE("Unicode::directionality")
     }
 }
 
+TEST_CASE("Unicode::sprintf")
+{
+    SUBCASE("Empty")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(256, dest, D2_USTR(L""));
+        CHECK(wcscmp((wchar_t*)dest, L"") == 0);
+    }
+    SUBCASE("Empty with args")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(256, dest, D2_USTR(L""), 123, L"456", 789u);
+        CHECK(wcscmp((wchar_t*)dest, L"") == 0);
+    }
+    SUBCASE("Copy string")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(256, dest, D2_USTR(L"Diablo"));
+        CHECK(wcscmp((wchar_t*)dest, L"Diablo") == 0);
+    }
+    SUBCASE("Format %")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(256, dest, D2_USTR(L"%%%%%%%%%%"));
+        CHECK(wcscmp((wchar_t*)dest, L"%%%%%") == 0);
+    }
+    SUBCASE("Format int")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(256, dest, D2_USTR(L"%d"), -2000000000);
+        CHECK(wcscmp((wchar_t*)dest, L"-2000000000") == 0);
+    }
+    SUBCASE("Format unsigned int")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(256, dest, D2_USTR(L"%u"), 4000000000u);
+        CHECK(wcscmp((wchar_t*)dest, L"4000000000") == 0);
+    }
+    SUBCASE("Format string")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(256, dest, D2_USTR(L"%s"), D2_USTR(L"Diablo"));
+        CHECK(wcscmp((wchar_t*)dest, L"Diablo") == 0);
+    }
+    SUBCASE("Format combination")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(
+                256,
+                dest,
+                D2_USTR(L"%s (%u + %d)"),
+                D2_USTR(L"Diablo"),
+                3u,
+                -1);
+        CHECK(wcscmp((wchar_t*)dest, L"Diablo (3 + -1)") == 0);
+    }
+    SUBCASE("Copy truncated string")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(4, dest, D2_USTR(L"Diablo"));
+        CHECK(wcscmp((wchar_t*)dest, L"Dia") == 0);
+    }
+    SUBCASE("Format truncated %")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(4, dest, D2_USTR(L"%%%%%%%%%%"));
+        CHECK(wcscmp((wchar_t*)dest, L"%%%") == 0);
+    }
+    SUBCASE("Format truncated int")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(4, dest, D2_USTR(L"%d"), -2000000000);
+        CHECK(wcscmp((wchar_t*)dest, L"") == 0);
+    }
+    SUBCASE("Format truncated unsigned int")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(4, dest, D2_USTR(L"%u"), 4000000000u);
+        CHECK(wcscmp((wchar_t*)dest, L"") == 0);
+    }
+    SUBCASE("Format truncated string")
+    {
+        Unicode dest[256];
+        Unicode::sprintf(4, dest, D2_USTR(L"%s"), D2_USTR(L"Diablo"));
+        CHECK(wcscmp((wchar_t*)dest, L"Dia") == 0);
+    }
+}
+
 TEST_CASE("Unicode::isWordEnd")
 {
     SUBCASE("Index 0")
@@ -386,7 +474,6 @@ TEST_CASE("Unicode::toUnicode")
     SUBCASE("Convert ASCII text")
     {
         Unicode::toUnicode(dest, "Diablo", dest_capacity);
-        wprintf(L"%ls\n", (wchar_t*)dest);
         CHECK(wcscmp((wchar_t*)dest, L"Diablo") == 0);
     }
     SUBCASE("Partially convert ASCII text")


### PR DESCRIPTION
These changes add the D2Lang.Unicode::sprintf function.

The function is very similar in behavior to the C standard `sprintf`, but limited to conversion specifiers `%%`, `%d`, `%u`, and `%s`.

The newly added tests pass for both the D2Moo and vanilla 1.10f DLLs. The test was done by changing D2LangTest in CMake to dynamically link to D2Lang.dll and swapping out the appropriate files.