### PR TITLE
DRLG: Tile packed info

### DIFF
--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -44,7 +44,7 @@ void __fastcall DRLGROOMTILE_InitializeTileDataFlags(D2RoomExStrc* pRoomEx, D2Dr
 //D2Common.0x6FD88BE0
 void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, uint32_t nPackedTileInformation, int nX, int nY, int a6);
 //D2Common.0x6FD88DD0
-void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int nX, int nY, int a5, D2TileLibraryEntryStrc* pTileLibraryEntry);
+void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry);
 //D2Common.0x6FD88E60
 D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry);
 //D2Common.0x6FD88F10

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -36,7 +36,7 @@ union D2C_PackedTileInformation
 #pragma pack()
 
 //D2Common.0x6FD88860
-D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoomEx, int a2, unsigned int a3);
+D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoomEx, int a2, uint32_t nPackedTileInformation);
 //D2Common.0x6FD889C0
 D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry, int a7);
 //D2Common.0x6FD88AC0

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -5,20 +5,35 @@
 
 #pragma pack(1)
 
-enum D2C_PackedTileInformationMasks
+union D2C_PackedTileInformation
 {
-	PACKEDTILEINFO_ROOF = 0b00,
-	PACKEDTILEINFO_WALL = 0b01,
-	PACKEDTILEINFO_FLOOR = 0b10,
-	PACKEDTILEINFO_STRUCTUREPARTMASK = PACKEDTILEINFO_ROOF | PACKEDTILEINFO_WALL | PACKEDTILEINFO_FLOOR,
-	PACKEDTILEINFO_ANIMATEDTILE = 1 << 27,
+	uint32_t nPackedValue;
+	struct {
+		// If not wall nor floor, then it is a roof.
+		uint32_t bIsWall           : 1; // BIT(0)     Is this a wall.
+		uint32_t bIsFloor          : 1; // BIT(1)     Is this a floor.
+		uint32_t bLOS              : 1; // BIT(2)     code-generated; added on edges
+		uint32_t bEnclosed         : 1; // BIT(3)     seems to delimit an enclosure inside another area, or trees
+		uint32_t bExit             : 1; // BIT(4)     arch or doorway or gateway in a wall
+		uint32_t bUnk0x20          : 1; // BIT(5)     Unknown flag
+		uint32_t bLayerBelow       : 1; // BIT(6)     only floor
+		uint32_t bLayerAbove       : 1; // BIT(7)     wall & floor
+		uint32_t nTileSequence     : 8; // BIT(8-15)  AKA tile subindex
+		uint32_t bFillLOS          : 1; // BIT(16)    all tiles will get wall collision
+		uint32_t bUnwalkable       : 1; // BIT(17) 
+		uint32_t nWallLayer        : 2; // BIT(18-19) code-generated; set when at least Floor2 or Wall2  // (nLayer - 1) << 0x12
+		//uint32_t bOverlappedLayer3 : 1; // BIT(19)    code-generated; set when has more walls, incl' of other orientations than usual; obj, shd, tree, roof, lower
+		uint32_t nTileStyle        : 6; // BIT(20-25) AKA tile index
+		uint32_t bRevealHidden     : 1; // BIT(26)    looks like an upper wall brought to a layer in front
+		uint32_t bShadow           : 1; // BIT(27)    this layer is a shadow layer
+		uint32_t bLinkage          : 1; // BIT(28)    near wp, lvl links, paths // will never get hidden
+		uint32_t bObjectWall       : 1; // BIT(29)    wall tiles with props; may be block reverb / other sounds (crates, barrels, tables etc.)
+		uint32_t bUnk0x40000000    : 1; // BIT(30)    Unknown flag
+		uint32_t bHidden           : 1; // BIT(31) 
+	};
 };
 
 #pragma pack()
-
-// Helper functions
-static uint32_t GetTileStyleFromPackedTileInformation(uint32_t nTileInformation) { return (nTileInformation >> 20) & 0x3F; }
-static uint32_t GetTileSequenceFromPackedTileInformation(uint32_t nTileInformation) { return BYTE1(nTileInformation); }
 
 //D2Common.0x6FD88860
 D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoomEx, int a2, unsigned int a3);

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -46,7 +46,7 @@ void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTil
 //D2Common.0x6FD88DD0
 void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int nX, int nY, int a5, D2TileLibraryEntryStrc* pTileLibraryEntry);
 //D2Common.0x6FD88E60
-D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, int a5, D2TileLibraryEntryStrc* pTileLibraryEntry);
+D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry);
 //D2Common.0x6FD88F10
 D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitShadowTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, int a5, D2TileLibraryEntryStrc* pTileLibraryEntry);
 //D2Common.0x6FD88FD0

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -42,7 +42,7 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoom
 //D2Common.0x6FD88AC0
 void __fastcall DRLGROOMTILE_InitializeTileDataFlags(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, uint32_t nPackedTileInformation, int a4, int nX, int nY);
 //D2Common.0x6FD88BE0
-void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int a2, int nX, int nY, int a6);
+void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, uint32_t nPackedTileInformation, int nX, int nY, int a6);
 //D2Common.0x6FD88DD0
 void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int nX, int nY, int a5, D2TileLibraryEntryStrc* pTileLibraryEntry);
 //D2Common.0x6FD88E60

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -40,7 +40,7 @@ D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoom
 //D2Common.0x6FD889C0
 D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, unsigned int a5, D2TileLibraryEntryStrc* pTileLibraryEntry, int a7);
 //D2Common.0x6FD88AC0
-void __fastcall DRLGROOMTILE_InitializeTileDataFlags(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int a3, int a4, int nX, int nY);
+void __fastcall DRLGROOMTILE_InitializeTileDataFlags(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, uint32_t nPackedTileInformation, int a4, int nX, int nY);
 //D2Common.0x6FD88BE0
 void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int a2, int nX, int nY, int a6);
 //D2Common.0x6FD88DD0

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -48,7 +48,7 @@ void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataS
 //D2Common.0x6FD88E60
 D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry);
 //D2Common.0x6FD88F10
-D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitShadowTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, int a5, D2TileLibraryEntryStrc* pTileLibraryEntry);
+D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitShadowTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry);
 //D2Common.0x6FD88FD0
 void __fastcall sub_6FD88FD0(D2RoomExStrc* pRoomEx, int nX, int nY, int a5);
 //D2Common.0x6FD89000

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -38,7 +38,7 @@ union D2C_PackedTileInformation
 //D2Common.0x6FD88860
 D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoomEx, int a2, unsigned int a3);
 //D2Common.0x6FD889C0
-D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, unsigned int a5, D2TileLibraryEntryStrc* pTileLibraryEntry, int a7);
+D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry, int a7);
 //D2Common.0x6FD88AC0
 void __fastcall DRLGROOMTILE_InitializeTileDataFlags(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, uint32_t nPackedTileInformation, int a4, int nX, int nY);
 //D2Common.0x6FD88BE0

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -50,7 +50,7 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoo
 //D2Common.0x6FD88F10
 D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitShadowTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry);
 //D2Common.0x6FD88FD0
-void __fastcall sub_6FD88FD0(D2RoomExStrc* pRoomEx, int nX, int nY, int a5);
+void __fastcall DRLGROOMTILE_InitTileShadow(D2RoomExStrc* pRoomEx, int nX, int nY, uint32_t nPackedTileInformation);
 //D2Common.0x6FD89000
 void __fastcall DRLGROOMTILE_LoadInitRoomTiles(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pDrlgCoordIndex, D2DrlgGridStrc* pDrlgOutdoorRoom, BOOL bFillBlanks, BOOL bKillEdgeX, BOOL bKillEdgeY);
 //D2Common.0x6FD89360

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -461,14 +461,9 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoo
 }
 
 //D2Common.0x6FD88F10
-D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitShadowTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, int nTileFlags, D2TileLibraryEntryStrc* pTileLibraryEntry)
+D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitShadowTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry)
 {
-	D2DrlgTileDataStrc* pTileData = NULL;
-
-	int nPosX = 0;
-	int nPosY = 0;
-
-	pTileData = &pRoomEx->pTileGrid->pTiles.pRoofTiles[pRoomEx->pTileGrid->nShadows];
+	D2DrlgTileDataStrc* pTileData = &pRoomEx->pTileGrid->pTiles.pRoofTiles[pRoomEx->pTileGrid->nShadows];
 	if (ppTileData)
 	{
 		pTileData->unk0x20 = *ppTileData;
@@ -483,8 +478,8 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitShadowTileData(D2RoomExStrc* pRo
 	pTileData->nPosX = nX - pRoomEx->nTileXPos;
 	pTileData->nPosY = nY - pRoomEx->nTileYPos;
 
-	nPosX = nX;
-	nPosY = nY + 1;
+	int nPosX = nX;
+	int nPosY = nY + 1;
 
 	DUNGEON_ExpandTileCoords(&nPosX, &nPosY);
 
@@ -500,7 +495,7 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitShadowTileData(D2RoomExStrc* pRo
 	pTileData->nRed = -1;
 	pTileData->pTile = pTileLibraryEntry;
 
-	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nTileFlags, 13, nX, nY);
+	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nPackedTileInformation, TILETYPE_SHADOWS, nX, nY);
 
 	return pTileData;
 }

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -29,9 +29,9 @@ struct D2UnkDrlgRoomTileStrc
 
 struct D2UnkDrlgRoomTileStrc2
 {
-	int field_0;
-	int field_4;
-	int field_8;
+	int nTileStyle;
+	int nTileSequence;
+	BOOL bIsRightWallWithDoor;
 	int nUnitId;
 	int nUnitType;
 	int nX;
@@ -239,8 +239,7 @@ void __fastcall DRLGROOMTILE_InitializeTileDataFlags(D2RoomExStrc* pRoomEx, D2Dr
 }
 
 //D2Common.0x6FD88BE0
-//TODO: v6, v10, v26
-void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int nTileFlags, int nX, int nY, int nTileType)
+void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, uint32_t nPackedTileInformation, int nX, int nY, int nTileType)
 {
 	static const D2UnkDrlgRoomTileStrc stru_6FDD0DA8[] =
 	{
@@ -285,78 +284,74 @@ void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTil
 
 	static const D2UnkDrlgRoomTileStrc2 stru_6FDD0F68[] =
 	{
-		{ 7, 0, 1, OBJECT_DOORGATERIGHT, UNIT_OBJECT, 5, 0 },
-		{ 7, 0, 0, OBJECT_DOORGATELEFT, UNIT_OBJECT, 0, 5 },
-		{ 5, 0, 1, OBJECT_DOORWOODENRIGHT, UNIT_OBJECT, 0, 0 },
-		{ 5, 0, 0, OBJECT_DOORWOODENLEFT, UNIT_OBJECT, 0, 0 },
-		{ 6, 0, 1, OBJECT_DOORMONASTERYDOUBLERIGHT, UNIT_OBJECT, 5, -2 },
-		{ 4, 0, 1, OBJECT_DOORCOURTYARDRIGHT, UNIT_OBJECT, 1, 2 },
-		{ 4, 0, 0, OBJECT_DOORCOURTYARDLEFT, UNIT_OBJECT, 0, 0 },
-		{ 4, 3, 1, OBJECT_DOORCATHEDRALDOUBLE, UNIT_OBJECT, 1, 0 },
-		{ 1, 2, 0, OBJECT_DOORCATHEDRALLEFT, UNIT_OBJECT, 0, 3 },
-		{ 1, 2, 1, OBJECT_DOORCATHEDRALRIGHT, UNIT_OBJECT, 3, 0 },
-		{ 0, 0, 1, OBJECT_DOORWOODENRIGHT, UNIT_OBJECT, 0, 0 },
-		{ 0, 0, 0, OBJECT_DOORWOODENLEFT2, UNIT_OBJECT, 0, 0 },
-		{ 2, 0, 1, OBJECT_ANDARIELS_DOOR, UNIT_OBJECT, 5, 0 },
-		{ 0, 1, 1, OBJECT_IRONGRATEDOORRIGHT, UNIT_OBJECT, 2, 0 },
-		{ 0, 1, 0, OBJECT_IRONGRATEDOORLEFT, UNIT_OBJECT, 0, 2 },
-		{ 5, 0, 1, OBJECT_WOODENGRATEDOORRIGHT, UNIT_OBJECT, 2, 0 },
-		{ 4, 0, 0, OBJECT_WOODENGRATEDOORLEFT, UNIT_OBJECT, 0, 2 },
-		{ 0, 0, 1, OBJECT_WOODENDOORRIGHT, UNIT_OBJECT, 2, 0 },
-		{ 0, 0, 0, OBJECT_WOODENDOORLEFT, UNIT_OBJECT, 0, 2 },
-		{ 2, 4, 1, OBJECT_TOMBDOORRIGHT, UNIT_OBJECT, 1, 0 },
-		{ 2, 1, 0, OBJECT_TOMBDOORLEFT, UNIT_OBJECT, 0, 2 },
-		{ 0, 1, 1, OBJECT_SLIMEDOOR1, UNIT_OBJECT, 0, 0 },
-		{ 0, 1, 0, OBJECT_SLIMEDOOR2, UNIT_OBJECT, 0, 0 },
-		{ 3, 3, 0, OBJECT_HARROGATH_TOWN_MAIN_GATE, UNIT_OBJECT, -2, 4 },
+		{ 7, 0, true,  OBJECT_DOORGATERIGHT, UNIT_OBJECT, 5, 0 },
+		{ 7, 0, false, OBJECT_DOORGATELEFT, UNIT_OBJECT, 0, 5 },
+		{ 5, 0, true,  OBJECT_DOORWOODENRIGHT, UNIT_OBJECT, 0, 0 },
+		{ 5, 0, false, OBJECT_DOORWOODENLEFT, UNIT_OBJECT, 0, 0 },
+		{ 6, 0, true,  OBJECT_DOORMONASTERYDOUBLERIGHT, UNIT_OBJECT, 5, -2 },
+		{ 4, 0, true,  OBJECT_DOORCOURTYARDRIGHT, UNIT_OBJECT, 1, 2 },
+		{ 4, 0, false, OBJECT_DOORCOURTYARDLEFT, UNIT_OBJECT, 0, 0 },
+		{ 4, 3, true,  OBJECT_DOORCATHEDRALDOUBLE, UNIT_OBJECT, 1, 0 },
+		{ 1, 2, false, OBJECT_DOORCATHEDRALLEFT, UNIT_OBJECT, 0, 3 },
+		{ 1, 2, true,  OBJECT_DOORCATHEDRALRIGHT, UNIT_OBJECT, 3, 0 },
+		{ 0, 0, true,  OBJECT_DOORWOODENRIGHT, UNIT_OBJECT, 0, 0 },
+		{ 0, 0, false, OBJECT_DOORWOODENLEFT2, UNIT_OBJECT, 0, 0 },
+		{ 2, 0, true,  OBJECT_ANDARIELS_DOOR, UNIT_OBJECT, 5, 0 },
+		{ 0, 1, true,  OBJECT_IRONGRATEDOORRIGHT, UNIT_OBJECT, 2, 0 },
+		{ 0, 1, false, OBJECT_IRONGRATEDOORLEFT, UNIT_OBJECT, 0, 2 },
+		{ 5, 0, true,  OBJECT_WOODENGRATEDOORRIGHT, UNIT_OBJECT, 2, 0 },
+		{ 4, 0, false, OBJECT_WOODENGRATEDOORLEFT, UNIT_OBJECT, 0, 2 },
+		{ 0, 0, true,  OBJECT_WOODENDOORRIGHT, UNIT_OBJECT, 2, 0 },
+		{ 0, 0, false, OBJECT_WOODENDOORLEFT, UNIT_OBJECT, 0, 2 },
+		{ 2, 4, true,  OBJECT_TOMBDOORRIGHT, UNIT_OBJECT, 1, 0 },
+		{ 2, 1, false, OBJECT_TOMBDOORLEFT, UNIT_OBJECT, 0, 2 },
+		{ 0, 1, true,  OBJECT_SLIMEDOOR1, UNIT_OBJECT, 0, 0 },
+		{ 0, 1, false, OBJECT_SLIMEDOOR2, UNIT_OBJECT, 0, 0 },
+		{ 3, 3, false, OBJECT_HARROGATH_TOWN_MAIN_GATE, UNIT_OBJECT, -2, 4 },
 
-		{ 2, 1, 0, MONSTER_BARRICADETOWER, UNIT_MONSTER, 1, 2 },
-		{ 2, 1, 1, MONSTER_BARRICADETOWER, UNIT_MONSTER, 2, 1 },
-		{ 2, 6, 0, MONSTER_BARRICADETOWER, UNIT_MONSTER, 1, 1 },
-		{ 2, 2, 0, MONSTER_BARRICADEDOOR2, UNIT_MONSTER, 0, 1 },
-		{ 2, 3, 1, MONSTER_BARRICADEDOOR1, UNIT_MONSTER, 1, 0 },
-		{ 26, 0, 0, MONSTER_PRISONDOOR, UNIT_MONSTER, 0, 1 },
-		{ 2, 4, 1, MONSTER_BARRICADEWALL1, UNIT_MONSTER, 0, 0 },
-		{ 2, 4, 0, MONSTER_BARRICADEWALL2, UNIT_MONSTER, 0, 0 },
+		{ 2,  1, false, MONSTER_BARRICADETOWER, UNIT_MONSTER, 1, 2 },
+		{ 2,  1, true,  MONSTER_BARRICADETOWER, UNIT_MONSTER, 2, 1 },
+		{ 2,  6, false, MONSTER_BARRICADETOWER, UNIT_MONSTER, 1, 1 },
+		{ 2,  2, false, MONSTER_BARRICADEDOOR2, UNIT_MONSTER, 0, 1 },
+		{ 2,  3, true,  MONSTER_BARRICADEDOOR1, UNIT_MONSTER, 1, 0 },
+		{ 26, 0, false, MONSTER_PRISONDOOR, UNIT_MONSTER, 0, 1 },
+		{ 2,  4, true,  MONSTER_BARRICADEWALL1, UNIT_MONSTER, 0, 0 },
+		{ 2,  4, false, MONSTER_BARRICADEWALL2, UNIT_MONSTER, 0, 0 },
 
-		{ 29, 0, 1, OBJECT_PERMANENT_TOWN_PORTAL, UNIT_OBJECT, 2, 0 },
-		{ 29, 0, 0, OBJECT_PERMANENT_TOWN_PORTAL, UNIT_OBJECT, 0, 2 },
+		{ 29, 0, true,  OBJECT_PERMANENT_TOWN_PORTAL, UNIT_OBJECT, 2, 0 },
+		{ 29, 0, false, OBJECT_PERMANENT_TOWN_PORTAL, UNIT_OBJECT, 0, 2 },
 	};
 
-	int nUnitId = 0;
-	int nPosX = 0;
-	int nPosY = 0;
-	int v26 = 0;
-	int v10 = 0;
-	int v6 = 0;
+	BOOL bIsRightWallWithDoor = 0;
 
 	if (pTileData)
 	{
-		if (pTileData->dwFlags & 0x20)
+		if (pTileData->dwFlags & MAPTILE_HASPRESETUNITS)
 		{
 			return;
 		}
 
-		v6 = pTileData->nTileType == TILETYPE_RIGHTWALLWITHDOOR;
+		bIsRightWallWithDoor = pTileData->nTileType == TILETYPE_RIGHTWALLWITHDOOR;
 	}
 	else
 	{
-		v6 = nTileType == TILETYPE_RIGHTWALLWITHDOOR;
+		bIsRightWallWithDoor = nTileType == TILETYPE_RIGHTWALLWITHDOOR;
 	}
 
 	for (int i = 0; i < ARRAY_SIZE(stru_6FDD0DA8); ++i)
 	{
 		if (stru_6FDD0DA8[i].nLevelId == pRoomEx->pLevel->nLevelId)
 		{
-			v10 = ((unsigned int)nTileFlags >> 20) & 0x3F;
-			v26 = BYTE1(nTileFlags);
+			D2C_PackedTileInformation nTileInformation{ nPackedTileInformation };
+			const uint32_t nTileStyle = nTileInformation.nTileStyle;
+			const uint32_t nTileSequence = nTileInformation.nTileSequence;
 
 			for (int j = stru_6FDD0DA8[i].nArrayStartId; j <= stru_6FDD0DA8[i].nArrayEndId; ++j)
 			{
-				if (v10 == stru_6FDD0F68[j].field_0 && v26 == stru_6FDD0F68[j].field_4 && v6 == stru_6FDD0F68[j].field_8)
+				if (nTileStyle == stru_6FDD0F68[j].nTileStyle && nTileSequence == stru_6FDD0F68[j].nTileSequence && bIsRightWallWithDoor == stru_6FDD0F68[j].bIsRightWallWithDoor)
 				{
-					nPosX = nX - pRoomEx->nTileXPos;
-					nPosY = nY - pRoomEx->nTileYPos;
+					int nPosX = nX - pRoomEx->nTileXPos;
+					int nPosY = nY - pRoomEx->nTileYPos;
 
 					DUNGEON_ExpandCoords(&nPosX, &nPosY);
 
@@ -365,7 +360,7 @@ void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTil
 
 					if (nPosX >= 0 && nPosY >= 0 && nPosX < 5 * pRoomEx->nTileWidth && nPosY < 5 * pRoomEx->nTileHeight)
 					{
-						nUnitId = stru_6FDD0F68[j].nUnitId;
+						const int nUnitId = stru_6FDD0F68[j].nUnitId;
 
 						switch (stru_6FDD0F68[j].nUnitType)
 						{
@@ -387,7 +382,7 @@ void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTil
 
 						if (pTileData)
 						{
-							pTileData->dwFlags |= 0x20;
+							pTileData->dwFlags |= MAPTILE_HASPRESETUNITS;
 						}
 					}
 					return;

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -154,87 +154,87 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoom
 }
 
 //D2Common.0x6FD88AC0
-void __fastcall DRLGROOMTILE_InitializeTileDataFlags(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int nTileFlags, int nType, int nX, int nY)
+void __fastcall DRLGROOMTILE_InitializeTileDataFlags(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, uint32_t nTileFlags, int nType, int nX, int nY)
 {
-	int nFlags = 0;
+	const D2C_PackedTileInformation nTileInfo{ nTileFlags };
 
-	if (pRoomEx && (nType == 9 || nType == 8))
+	if (pRoomEx && (nType == TILETYPE_RIGHTWALLWITHDOOR || nType == TILETYPE_LEFTWALLWITHDOOR))
 	{
 		DRLGROOMTILE_AddTilePresetUnits(pRoomEx, pTileData, nTileFlags, nX, nY, 0);
 	}
 
-	if (nType != 13)
+	if (nType != TILETYPE_SHADOWS)
 	{
-		pTileData->dwFlags |= ((((unsigned int)nTileFlags >> 18) & 3) + 1) << 14;
+		pTileData->dwFlags |= (nTileInfo.nWallLayer + 1) << MAPTILE_WALL_LAYER_BIT;
 	}
 
-	if (nType == 14)
+	if (nType == TILETYPE_TREES)
 	{
-		pTileData->dwFlags |= 4;
+		pTileData->dwFlags |= MAPTILE_TREES;
 	}
-	else if (nType == 11 || nType == 10 || nType == 9 || nType == 8)
+	else if (nType == TILETYPE_SPECIALTILES_11 || nType == TILETYPE_SPECIALTILES_10 || nType == TILETYPE_RIGHTWALLWITHDOOR || nType == TILETYPE_LEFTWALLWITHDOOR)
 	{
-		pTileData->dwFlags |= 2;
-	}
-
-	if (nTileFlags & 0x80)
-	{
-		pTileData->dwFlags |= 1;
+		pTileData->dwFlags |= MAPTILE_WALL_EXIT;
 	}
 
-	if (nTileFlags & 0x10000000)
+	if (nTileInfo.bLayerAbove)
 	{
-		pTileData->dwFlags |= 0x102;
+		pTileData->dwFlags |= MAPTILE_UNK_0x1;
 	}
 
-	if (nTileFlags & 0x20000)
+	if (nTileInfo.bLinkage)
 	{
-		pTileData->dwFlags |= 0x40;
+		pTileData->dwFlags |= MAPTILE_FLOOR_LINKER_PATH | MAPTILE_WALL_EXIT;
 	}
 
-	if (nTileFlags & 0x10000)
+	if (nTileInfo.bUnwalkable)
 	{
-		pTileData->dwFlags |= 0x80;
+		pTileData->dwFlags |= MAPTILE_UNWALKABLE;
 	}
 
-	if (nTileFlags & 8)
+	if (nTileInfo.bFillLOS)
 	{
-		pTileData->dwFlags |= 4;
+		pTileData->dwFlags |= MAPTILE_FILL_LOS;
 	}
 
-	if (nTileFlags >= 0)
+	if (nTileInfo.bEnclosed)
 	{
-		pTileData->dwFlags &= 0xF7;
+		pTileData->dwFlags |= MAPTILE_TREES;
+	}
+
+	if (nTileInfo.bHidden)
+	{
+		pTileData->dwFlags &= (~MAPTILE_HIDDEN);
 	}
 	else
 	{
-		pTileData->dwFlags |= 8;
+		pTileData->dwFlags |= MAPTILE_HIDDEN;
 	}
 
-	if (nTileFlags & 0x4000000)
+	if (nTileInfo.bRevealHidden)
 	{
-		pTileData->dwFlags |= 0x20C;
+		pTileData->dwFlags |= MAPTILE_UNK_0x200 | MAPTILE_TREES | MAPTILE_HIDDEN;
 	}
 
-	if (nTileFlags & 0x20000000)
+	if (nTileInfo.bObjectWall)
 	{
-		pTileData->dwFlags |= 0x800;
+		pTileData->dwFlags |= MAPTILE_OBJECT_WALL;
 	}
 
-	if (nTileFlags & 4)
+	if (nTileInfo.bLOS)
 	{
-		pTileData->dwFlags |= 0x2000;
+		pTileData->dwFlags |= MAPTILE_LOS;
 	}
 
-	nFlags = D2CMP_10079_GetTileFlags(pTileData->pTile);
-	if (nFlags & 1)
+	uint16_t nFlags = D2CMP_10079_GetTileFlags(pTileData->pTile);
+	if (nFlags & TILE_FLAGS_OTHER)
 	{
-		pTileData->dwFlags |= 4;
+		pTileData->dwFlags |= MAPTILE_TREES;
 	}
 
-	if (nFlags & 4)
+	if (nFlags & TILE_FLAGS_WOOD_OBJ)
 	{
-		pTileData->dwFlags |= 0x800;
+		pTileData->dwFlags |= MAPTILE_OBJECT_WALL;
 	}
 }
 

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -486,9 +486,9 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitShadowTileData(D2RoomExStrc* pRo
 }
 
 //D2Common.0x6FD88FD0
-void __fastcall sub_6FD88FD0(D2RoomExStrc* pRoomEx, int nX, int nY, int nTileFlags)
+void __fastcall DRLGROOMTILE_InitTileShadow(D2RoomExStrc* pRoomEx, int nX, int nY, uint32_t nPackedTileInformation)
 {
-	DRLGROOMTILE_InitShadowTileData(pRoomEx, 0, nX, nY, nTileFlags, DRLGROOMTILE_GetTileCache(pRoomEx, 13, nTileFlags));
+	DRLGROOMTILE_InitShadowTileData(pRoomEx, nullptr, nX, nY, nPackedTileInformation, DRLGROOMTILE_GetTileCache(pRoomEx, TILETYPE_SHADOWS, nPackedTileInformation));
 }
 
 //D2Common.0x6FD89000

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -104,13 +104,9 @@ D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoom
 }
 
 //D2Common.0x6FD889C0
-D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, unsigned int nTileFlags, D2TileLibraryEntryStrc* pTileLibraryEntry, int nTileType)
+D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry, int nTileType)
 {
-	D2DrlgTileDataStrc* pTileData = NULL;
-	int nPosX = 0;
-	int nPosY = 0;
-
-	pTileData = &pRoomEx->pTileGrid->pTiles.pWallTiles[pRoomEx->pTileGrid->nWalls];
+	D2DrlgTileDataStrc* pTileData = pTileData = &pRoomEx->pTileGrid->pTiles.pWallTiles[pRoomEx->pTileGrid->nWalls];
 	if (ppTileData)
 	{
 		pTileData->unk0x20 = *ppTileData;
@@ -118,7 +114,7 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoom
 	}
 	else
 	{
-		pTileData->unk0x20 = NULL;
+		pTileData->unk0x20 = nullptr;
 	}
 
 	++pRoomEx->pTileGrid->nWalls;
@@ -126,8 +122,8 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoom
 	pTileData->nPosX = nX - pRoomEx->nTileXPos;
 	pTileData->nPosY = nY - pRoomEx->nTileYPos;
 
-	nPosX = nX;
-	nPosY = nY + 1;
+	int nPosX = nX;
+	int nPosY = nY + 1;
 
 	DUNGEON_ExpandTileCoords(&nPosX, &nPosY);
 
@@ -143,11 +139,11 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoom
 	pTileData->nBlue = -1;
 	pTileData->nRed = -1;
 
-	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nTileFlags, nTileType, nX, nY);
+	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nPackedTileInformation, nTileType, nX, nY);
 
 	if (nTileType == TILETYPE_RIGHTPARTOFNORTHCORNERWALL)
 	{
-		DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, DRLGROOMTILE_InitWallTileData(pRoomEx, ppTileData, nX, nY, nTileFlags, DRLGROOMTILE_GetTileCache(pRoomEx, 4, nTileFlags), 4), nTileFlags, 4, nX, nY);
+		DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, DRLGROOMTILE_InitWallTileData(pRoomEx, ppTileData, nX, nY, nPackedTileInformation, DRLGROOMTILE_GetTileCache(pRoomEx, TILETYPE_LEFTPARTOFNORTHCORNERWALL, nPackedTileInformation), TILETYPE_LEFTPARTOFNORTHCORNERWALL), nPackedTileInformation, TILETYPE_LEFTPARTOFNORTHCORNERWALL, nX, nY);
 	}
 
 	return pTileData;

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -186,7 +186,7 @@ void __fastcall DRLGROOMTILE_InitializeTileDataFlags(D2RoomExStrc* pRoomEx, D2Dr
 		pTileData->dwFlags |= MAPTILE_TREES;
 	}
 
-	if (nTileInfo.bHidden)
+	if (!nTileInfo.bHidden)
 	{
 		pTileData->dwFlags &= (~MAPTILE_HIDDEN);
 	}

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -41,30 +41,17 @@ struct D2UnkDrlgRoomTileStrc2
 
 
 //D2Common.0x6FD88860
-D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoomEx, int nType, unsigned int nTileFlags)
+D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoomEx, int nType, uint32_t nPackedTileInformation)
 {
 	D2TileLibraryEntryStrc* ppTileLibraryEntries[40] = {};
-	unsigned int nMax = 0;
-	int nEntries = 0;
-	int nRand = 0;
-	int nId = 0;
-	uint8_t nSequence = 0;
-	uint8_t nStyle = 0;
 
-	if (nTileFlags)
-	{
-		nStyle = (nTileFlags >> 20) & 63;
-		nSequence = BYTE1(nTileFlags);
-	}
-	else
-	{
-		nStyle = 0;
-		nSequence = 0;
-	}
+	D2C_PackedTileInformation nTileInformation{ nPackedTileInformation };
+	const uint32_t nStyle = nTileInformation.nTileStyle;
+	const uint32_t nSequence = nTileInformation.nTileSequence;
 
-	nEntries = D2CMP_10088_GetTiles(pRoomEx->pTiles, nType, nStyle, nSequence, ppTileLibraryEntries, ARRAY_SIZE(ppTileLibraryEntries));
-	if (nEntries)
+	if (int nEntries = D2CMP_10088_GetTiles(pRoomEx->pTiles, nType, nStyle, nSequence, ppTileLibraryEntries, ARRAY_SIZE(ppTileLibraryEntries)))
 	{
+		int nMax = 0;
 		for (int i = 0; i < nEntries; ++i)
 		{
 			if (!ppTileLibraryEntries[i])
@@ -75,7 +62,8 @@ D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoom
 			nMax += D2CMP_10081_GetTileRarity(ppTileLibraryEntries[i]);
 		}
 
-		nRand = SEED_RollLimitedRandomNumber(&pRoomEx->pSeed, nMax) + 1;
+		int nId = 0;
+		int32_t nRand = SEED_RollLimitedRandomNumber(&pRoomEx->pSeed, nMax) + 1;
 		if (nMax)
 		{
 			while (nEntries > 1 && nRand > 0)
@@ -94,7 +82,7 @@ D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoom
 	}
 	else
 	{
-		if (!D2CMP_10088_GetTiles(pRoomEx->pTiles, 10, 0, 0, ppTileLibraryEntries, ARRAY_SIZE(ppTileLibraryEntries)))
+		if (!D2CMP_10088_GetTiles(pRoomEx->pTiles, TILETYPE_SPECIALTILES_10, 0, 0, ppTileLibraryEntries, ARRAY_SIZE(ppTileLibraryEntries)))
 		{
 			FOG_10025("nSize", __FILE__, __LINE__);
 		}

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -420,14 +420,9 @@ void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataS
 }
 
 //D2Common.0x6FD88E60
-D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, int nTileFlags, D2TileLibraryEntryStrc* pTileLibraryEntry)
+D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry)
 {
-	D2DrlgTileDataStrc* pTileData = NULL;
-
-	int nPosX = 0;
-	int nPosY = 0;
-
-	pTileData = &pRoomEx->pTileGrid->pTiles.pFloorTiles[pRoomEx->pTileGrid->nFloors];
+	D2DrlgTileDataStrc* pTileData = &pRoomEx->pTileGrid->pTiles.pFloorTiles[pRoomEx->pTileGrid->nFloors];
 	if (ppTileData)
 	{
 		pTileData->unk0x20 = *ppTileData;
@@ -435,7 +430,7 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoo
 	}
 	else
 	{
-		pTileData->unk0x20 = NULL;
+		pTileData->unk0x20 = nullptr;
 	}
 
 	++pRoomEx->pTileGrid->nFloors;
@@ -452,15 +447,15 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoo
 	pTileData->nPosX = nX - pRoomEx->nTileXPos;
 	pTileData->nPosY = nY - pRoomEx->nTileYPos;
 
-	nPosX = nX;
-	nPosY = nY + 1;
+	int nPosX = nX;
+	int nPosY = nY + 1;
 
 	DUNGEON_ExpandTileCoords(&nPosX, &nPosY);
 
 	pTileData->nWidth = nPosX;
 	pTileData->nHeight = nPosY + 40;
 
-	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nTileFlags, 0, nX, nY);
+	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nPackedTileInformation, TILETYPE_FLOORS, nX, nY);
 
 	return pTileData;
 }

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -389,11 +389,8 @@ void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTil
 }
 
 //D2Common.0x6FD88DD0
-void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int nX, int nY, int nTileFlags, D2TileLibraryEntryStrc* pTileLibraryEntry)
+void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry)
 {
-	int nPosX = 0;
-	int nPosY = 0;
-
 	pTileData->pTile = pTileLibraryEntry;
 	pTileData->nTileType = TILETYPE_FLOORS;
 	pTileData->dwFlags = 0;
@@ -407,8 +404,8 @@ void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataS
 		pTileData->nPosX = nX - pRoomEx->nTileXPos;
 		pTileData->nPosY = nY - pRoomEx->nTileYPos;
 
-		nPosX = nX;
-		nPosY = nY + 1;
+		int nPosX = nX;
+		int nPosY = nY + 1;
 
 		DUNGEON_ExpandTileCoords(&nPosX, &nPosY);
 
@@ -416,7 +413,7 @@ void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataS
 		pTileData->nHeight = nPosY + 40;
 	}
 
-	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nTileFlags, 0, nX, nY);
+	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nPackedTileInformation, TILETYPE_FLOORS, nX, nY);
 }
 
 //D2Common.0x6FD88E60

--- a/source/D2Common/src/Drlg/DrlgTileSub.cpp
+++ b/source/D2Common/src/Drlg/DrlgTileSub.cpp
@@ -419,7 +419,7 @@ void __fastcall sub_6FD8ACE0(void* pMemPool, int nX, int nY, D2UnkOutdoorStrc2* 
 			nFlags = DRLGGRID_GetGridEntry(&pLvlSubTxtRecord->pShadowGrid, i + pSubstGroup->field_0 + a7, j + pSubstGroup->field_4);
 			if (nFlags & 0x8000000)
 			{
-				sub_6FD88FD0(a4->pRoomEx, nX + i + a4->pRoomEx->nTileXPos, nY + j + a4->pRoomEx->nTileYPos, nFlags);
+				DRLGROOMTILE_InitTileShadow(a4->pRoomEx, nX + i + a4->pRoomEx->nTileXPos, nY + j + a4->pRoomEx->nTileYPos, nFlags);
 			}
 		}
 	}


### PR DESCRIPTION
Based on Mentor's notes, I added added a bitfield named `D2C_PackedTileInformation` to make it easier to manipulate the DRLG tile grids information.

I started cleaning and rewriting `DrlgRoomTile.cpp` functions and fixed some bugs in `DRLGROOMTILE_LoadInitRoomTiles`. It has been checked to be working (but its callees may have bugs).