### PR TITLE
More cleaning of DrlgRoomTile.cpp

### DIFF
--- a/source/D2Common/include/Drlg/D2DrlgDrlg.h
+++ b/source/D2Common/include/Drlg/D2DrlgDrlg.h
@@ -99,6 +99,7 @@ enum D2DrlgLevelFlags
 
 enum D2MapTileFlags
 {
+	MAPTILE_FLAGS_NONE = 0,
 	MAPTILE_UNK_0x1 = 0x000001,
 	MAPTILE_WALL_EXIT = 0x000002, // warps, door exit, 
 	MAPTILE_TREES = 0x000004, // Could also be delimiting an enclosure inside another area. Probably misnamed because not only trees ?

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -56,7 +56,7 @@ void __fastcall DRLGROOMTILE_LoadInitRoomTiles(D2RoomExStrc* pRoomEx, D2DrlgGrid
 //D2Common.0x6FD89360
 BOOL __fastcall DRLGROOMTILE_AddWarp(D2RoomExStrc* pRoomEx, int nX, int nY, uint32_t nPackedTileInformation, int nTileType);
 //D2Common.0x6FD89410
-void __fastcall DRLGROOMTILE_LoadWallWarpTiles(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int a3, int a4);
+void __fastcall DRLGROOMTILE_LoadWallWarpTiles(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, uint32_t nPackedTileInformation, int nTileType);
 //D2Common.0x6FD89590
 void __fastcall DRLGROOMTILE_LoadFloorWarpTiles(D2RoomExStrc* pRoomEx, int nX, int nY, unsigned int dwFlags, int a5);
 //D2Common.0x6FD897E0

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -54,7 +54,7 @@ void __fastcall DRLGROOMTILE_InitTileShadow(D2RoomExStrc* pRoomEx, int nX, int n
 //D2Common.0x6FD89000
 void __fastcall DRLGROOMTILE_LoadInitRoomTiles(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pDrlgCoordIndex, D2DrlgGridStrc* pDrlgOutdoorRoom, BOOL bFillBlanks, BOOL bKillEdgeX, BOOL bKillEdgeY);
 //D2Common.0x6FD89360
-BOOL __fastcall DRLGROOMTILE_AddWarp(D2RoomExStrc* pRoomEx, int nX, int nY, int a4, int a5);
+BOOL __fastcall DRLGROOMTILE_AddWarp(D2RoomExStrc* pRoomEx, int nX, int nY, uint32_t nPackedTileInformation, int nTileType);
 //D2Common.0x6FD89410
 void __fastcall DRLGROOMTILE_LoadWallWarpTiles(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int a3, int a4);
 //D2Common.0x6FD89590

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -58,9 +58,9 @@ BOOL __fastcall DRLGROOMTILE_AddWarp(D2RoomExStrc* pRoomEx, int nX, int nY, uint
 //D2Common.0x6FD89410
 void __fastcall DRLGROOMTILE_LoadWallWarpTiles(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, uint32_t nPackedTileInformation, int nTileType);
 //D2Common.0x6FD89590
-void __fastcall DRLGROOMTILE_LoadFloorWarpTiles(D2RoomExStrc* pRoomEx, int nX, int nY, unsigned int dwFlags, int a5);
+void __fastcall DRLGROOMTILE_LoadFloorWarpTiles(D2RoomExStrc* pRoomEx, int nX, int nY, uint32_t nPackedTileInformation, int nTileType);
 //D2Common.0x6FD897E0
-D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_GetLinkedTileData(D2RoomExStrc* pRoomEx, BOOL bFloor, int nTileFlags, int nX, int nY, D2RoomExStrc** ppRoomEx);
+D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_GetLinkedTileData(D2RoomExStrc* pRoomEx, BOOL bFloor, uint32_t nPackedTileInformation, int nX, int nY, D2RoomExStrc** ppRoomEx);
 //D2Common.0x6FD89930
 void __fastcall DRLGROOMTILE_AddLinkedTileData(void* pMemPool, D2RoomExStrc* pRoomEx, int a3, unsigned int a4, int nX, int nY);
 //D2Common.0x6FD89AF0

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -91,6 +91,34 @@ D2TileLibraryEntryStrc* __fastcall DRLGROOMTILE_GetTileCache(D2RoomExStrc* pRoom
 	}
 }
 
+// Helper function
+static void DRLGROOMTILE_InitTileDataDefaults(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int nX, int nY, uint32_t nPackedTileInformation, int nTileType, D2TileLibraryEntryStrc* pTileLibraryEntry)
+{
+	pTileData->pTile = pTileLibraryEntry;
+	pTileData->nTileType = nTileType;
+	pTileData->dwFlags = MAPTILE_FLAGS_NONE;
+	pTileData->unk0x24 = 0;
+	pTileData->nGreen = 0xFF;
+	pTileData->nBlue = 0xFF;
+	pTileData->nRed = 0xFF;
+
+	if (pRoomEx)
+	{
+		pTileData->nPosX = nX - pRoomEx->nTileXPos;
+		pTileData->nPosY = nY - pRoomEx->nTileYPos;
+
+		int nPosX = nX;
+		int nPosY = nY + 1;
+
+		DUNGEON_ExpandTileCoords(&nPosX, &nPosY);
+
+		pTileData->nWidth = nPosX;
+		pTileData->nHeight = nPosY + 40;
+	}
+
+	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nPackedTileInformation, nTileType, nX, nY);
+}
+
 //D2Common.0x6FD889C0
 D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc** ppTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry, int nTileType)
 {
@@ -107,27 +135,7 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitWallTileData(D2RoomExStrc* pRoom
 
 	++pRoomEx->pTileGrid->nWalls;
 
-	pTileData->nPosX = nX - pRoomEx->nTileXPos;
-	pTileData->nPosY = nY - pRoomEx->nTileYPos;
-
-	int nPosX = nX;
-	int nPosY = nY + 1;
-
-	DUNGEON_ExpandTileCoords(&nPosX, &nPosY);
-
-	pTileData->nWidth = nPosX;
-	pTileData->nHeight = nPosY + 40;
-
-	pTileData->dwFlags = 0;
-	pTileData->unk0x24 = 0;
-	pTileData->nTileType = nTileType;
-
-	pTileData->pTile = pTileLibraryEntry;
-	pTileData->nGreen = -1;
-	pTileData->nBlue = -1;
-	pTileData->nRed = -1;
-
-	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nPackedTileInformation, nTileType, nX, nY);
+	DRLGROOMTILE_InitTileDataDefaults(pRoomEx, pTileData, nX, nY, nPackedTileInformation, nTileType, pTileLibraryEntry);
 
 	if (nTileType == TILETYPE_RIGHTPARTOFNORTHCORNERWALL)
 	{
@@ -379,29 +387,7 @@ void __fastcall DRLGROOMTILE_AddTilePresetUnits(D2RoomExStrc* pRoomEx, D2DrlgTil
 //D2Common.0x6FD88DD0
 void __fastcall DRLGROOMTILE_InitTileData(D2RoomExStrc* pRoomEx, D2DrlgTileDataStrc* pTileData, int nX, int nY, uint32_t nPackedTileInformation, D2TileLibraryEntryStrc* pTileLibraryEntry)
 {
-	pTileData->pTile = pTileLibraryEntry;
-	pTileData->nTileType = TILETYPE_FLOORS;
-	pTileData->dwFlags = 0;
-	pTileData->unk0x24 = 0;
-	pTileData->nGreen = 0xFF;
-	pTileData->nBlue = 0xFF;
-	pTileData->nRed = 0xFF;
-
-	if (pRoomEx)
-	{
-		pTileData->nPosX = nX - pRoomEx->nTileXPos;
-		pTileData->nPosY = nY - pRoomEx->nTileYPos;
-
-		int nPosX = nX;
-		int nPosY = nY + 1;
-
-		DUNGEON_ExpandTileCoords(&nPosX, &nPosY);
-
-		pTileData->nWidth = nPosX;
-		pTileData->nHeight = nPosY + 40;
-	}
-
-	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nPackedTileInformation, TILETYPE_FLOORS, nX, nY);
+	DRLGROOMTILE_InitTileDataDefaults(pRoomEx, pTileData, nX, nY, nPackedTileInformation, TILETYPE_FLOORS, pTileLibraryEntry);
 }
 
 //D2Common.0x6FD88E60
@@ -420,28 +406,7 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitFloorTileData(D2RoomExStrc* pRoo
 
 	++pRoomEx->pTileGrid->nFloors;
 
-	pTileData->pTile = pTileLibraryEntry;
-	pTileData->nTileType = TILETYPE_FLOORS;
-	pTileData->dwFlags = 0;
-	pTileData->unk0x24 = 0;
-	pTileData->nGreen = -1;
-	pTileData->nBlue = -1;
-	pTileData->nRed = -1;
-
-
-	pTileData->nPosX = nX - pRoomEx->nTileXPos;
-	pTileData->nPosY = nY - pRoomEx->nTileYPos;
-
-	int nPosX = nX;
-	int nPosY = nY + 1;
-
-	DUNGEON_ExpandTileCoords(&nPosX, &nPosY);
-
-	pTileData->nWidth = nPosX;
-	pTileData->nHeight = nPosY + 40;
-
-	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nPackedTileInformation, TILETYPE_FLOORS, nX, nY);
-
+	DRLGROOMTILE_InitTileData(pRoomEx, pTileData, nX, nY, nPackedTileInformation, pTileLibraryEntry);
 	return pTileData;
 }
 
@@ -460,27 +425,8 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_InitShadowTileData(D2RoomExStrc* pRo
 	}
 
 	++pRoomEx->pTileGrid->nShadows;
-	pTileData->nPosX = nX - pRoomEx->nTileXPos;
-	pTileData->nPosY = nY - pRoomEx->nTileYPos;
 
-	int nPosX = nX;
-	int nPosY = nY + 1;
-
-	DUNGEON_ExpandTileCoords(&nPosX, &nPosY);
-
-	pTileData->nTileType = TILETYPE_SHADOWS;
-
-	pTileData->nWidth = nPosX;
-	pTileData->nHeight = nPosY + 40;
-
-	pTileData->dwFlags = 0;
-	pTileData->unk0x24 = 0;
-	pTileData->nGreen = -1;
-	pTileData->nBlue = -1;
-	pTileData->nRed = -1;
-	pTileData->pTile = pTileLibraryEntry;
-
-	DRLGROOMTILE_InitializeTileDataFlags(pRoomEx, pTileData, nPackedTileInformation, TILETYPE_SHADOWS, nX, nY);
+	DRLGROOMTILE_InitTileDataDefaults(pRoomEx, pTileData, nX, nY, nPackedTileInformation, TILETYPE_SHADOWS, pTileLibraryEntry);
 
 	return pTileData;
 }

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -748,13 +748,13 @@ void __fastcall DRLGROOMTILE_LoadFloorWarpTiles(D2RoomExStrc* pRoomEx, int nX, i
 }
 
 //D2Common.0x6FD897E0
-D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_GetLinkedTileData(D2RoomExStrc* pRoomEx, BOOL bFloor, int nTileFlags, int nX, int nY, D2RoomExStrc** ppRoomEx)
+D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_GetLinkedTileData(D2RoomExStrc* pRoomEx, BOOL bFloor, uint32_t nPackedTileInformation, int nX, int nY, D2RoomExStrc** ppRoomEx)
 {
-	D2RoomExStrc* pNearRoomEx = NULL;
+	D2C_PackedTileInformation nTileInformation{ nPackedTileInformation };
 
 	for (int i = 0; i < pRoomEx->nRoomsNear; ++i)
 	{
-		pNearRoomEx = pRoomEx->ppRoomsNear[i];
+		D2RoomExStrc* pNearRoomEx = pRoomEx->ppRoomsNear[i];
 
 		if (pNearRoomEx != pRoomEx && pNearRoomEx->pTileGrid && DRLGROOM_AreXYInsideCoordinatesOrOnBorder(&pNearRoomEx->pDrlgCoord, nX, nY))
 		{
@@ -766,9 +766,9 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_GetLinkedTileData(D2RoomExStrc* pRoo
 					{
 						if (pNearRoomEx->nTileXPos + pTileData->nPosX == nX && pNearRoomEx->nTileYPos + pTileData->nPosY == nY)
 						{
-							if (pTileData->nTileType != TILETYPE_LEFTPARTOFNORTHCORNERWALL && (pTileData->nTileType == TILETYPE_SHADOWS || !(nTileFlags & 0x8000000)))
+							if (pTileData->nTileType != TILETYPE_LEFTPARTOFNORTHCORNERWALL && (pTileData->nTileType == TILETYPE_SHADOWS || !nTileInformation.bShadow))
 							{
-								if (!(pTileData->dwFlags & 0x1C000) || ((((unsigned int)pTileData->dwFlags >> 14) & 7) - 1 == (((unsigned int)nTileFlags >> 18) & 3)))
+								if ((pTileData->dwFlags & MAPTILE_WALL_LAYER_MASK) == 0 || GetMapTileLayer(pTileData->dwFlags) == nTileInformation.nWallLayer)
 								{
 									*ppRoomEx = pRoomEx->ppRoomsNear[i];
 									return pTileData;
@@ -781,8 +781,8 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_GetLinkedTileData(D2RoomExStrc* pRoo
 		}
 	}
 
-	*ppRoomEx = NULL;
-	return NULL;
+	*ppRoomEx = nullptr;
+	return nullptr;
 }
 
 //D2Common.0x6FD89930

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -652,16 +652,15 @@ void __fastcall DRLGROOMTILE_LoadInitRoomTiles(D2RoomExStrc* pRoomEx, D2DrlgGrid
 }
 
 //D2Common.0x6FD89360
-BOOL __fastcall DRLGROOMTILE_AddWarp(D2RoomExStrc* pRoomEx, int nX, int nY, int nTileFlags, int nType)
+BOOL __fastcall DRLGROOMTILE_AddWarp(D2RoomExStrc* pRoomEx, int nX, int nY, uint32_t nPackedTileInformation, int nTileType)
 {
-	D2LvlWarpTxt* pLvlWarpTxtRecord = DRLGWARP_GetLvlWarpTxtRecordFromWarpIdAndDirection(pRoomEx->pLevel, ((unsigned int)nTileFlags >> 20) & 0x3F, (((nType != 11) - 1) & 6) + 108);
-	int nPosX = 0;
-	int nPosY = 0;
-
+	D2C_PackedTileInformation nTileInformation{ nPackedTileInformation };
+	D2LvlWarpTxt* pLvlWarpTxtRecord = DRLGWARP_GetLvlWarpTxtRecordFromWarpIdAndDirection(pRoomEx->pLevel, nTileInformation.nTileStyle, nTileType == TILETYPE_SPECIALTILES_11 ? 'r' : 'l');
+	
 	if (pLvlWarpTxtRecord)
 	{
-		nPosX = nX - pRoomEx->nTileXPos;
-		nPosY = nY - pRoomEx->nTileYPos;
+		int nPosX = nX - pRoomEx->nTileXPos;
+		int nPosY = nY - pRoomEx->nTileYPos;
 
 		if (nPosX != pRoomEx->nTileWidth && nPosY != pRoomEx->nTileHeight)
 		{
@@ -670,7 +669,7 @@ BOOL __fastcall DRLGROOMTILE_AddWarp(D2RoomExStrc* pRoomEx, int nX, int nY, int 
 			nPosX += pLvlWarpTxtRecord->dwOffsetX;
 			nPosY += pLvlWarpTxtRecord->dwOffsetY;
 
-			DRLGROOM_AllocPresetUnit(pRoomEx, pRoomEx->pLevel->pDrlg->pMempool, UNIT_TILE, pLvlWarpTxtRecord->dwLevelId, 0, nPosX, nPosY);
+			DRLGROOM_AllocPresetUnit(pRoomEx, pRoomEx->pLevel->pDrlg->pMempool, UNIT_TILE, pLvlWarpTxtRecord->dwLevelId, OBJMODE_NEUTRAL, nPosX, nPosY);
 
 			return TRUE;
 		}


### PR DESCRIPTION
This is a follow-up of #72.
Mostly using the new `D2C_PackedTileInformation` and a bit of refactoring to reduce code complexity.