### PR TITLE
End of DrlgRoomTile rewrite

### DIFF
--- a/source/D2Common/include/Drlg/D2DrlgDrlg.h
+++ b/source/D2Common/include/Drlg/D2DrlgDrlg.h
@@ -155,7 +155,7 @@ struct D2RoomExStrc
 		};
 		D2DrlgCoordStrc pDrlgCoord;			//0x04
 	};
-	uint32_t dwFlags;						//0x14 ROOMEXFLAG_ANIMATED_FLOOR
+	uint32_t dwFlags;						//0x14 D2RoomExFlags
 	uint32_t dwOtherFlags;					//0x18
 	int32_t nType;							//0x1C
 	union

--- a/source/D2Common/include/Drlg/D2DrlgDrlg.h
+++ b/source/D2Common/include/Drlg/D2DrlgDrlg.h
@@ -118,6 +118,7 @@ enum D2MapTileFlags
 	MAPTILE_WALL_LAYER_MASK = 0b111 << MAPTILE_WALL_LAYER_BIT, // 3bits value indicating the wall layer + 1 (0 indicates no wall?)
 };
 // Helper function
+inline bool HasMapTileLayer(uint32_t nMapTileFlags) { return (nMapTileFlags & MAPTILE_WALL_LAYER_MASK) != 0; }
 inline int GetMapTileLayer(uint32_t nMapTileFlags) { return (nMapTileFlags & MAPTILE_WALL_LAYER_MASK) >> MAPTILE_WALL_LAYER_BIT - 1; }
 
 struct D2DrlgCoordStrc

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -64,7 +64,7 @@ D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_GetLinkedTileData(D2RoomExStrc* pRoo
 //D2Common.0x6FD89930
 void __fastcall DRLGROOMTILE_AddLinkedTileData(void* pMemPool, D2RoomExStrc* pRoomEx, int nTileType, uint32_t nPackedTileInformation, int nX, int nY);
 //D2Common.0x6FD89AF0
-void __fastcall DRLGROOMTILE_LinkedTileDataManager(void* pMemPool, D2RoomExStrc* pRoomEx1, D2RoomExStrc* pRoomEx2, D2DrlgTileDataStrc* pTileData, int a5, unsigned int a6, int nX, int nY);
+void __fastcall DRLGROOMTILE_LinkedTileDataManager(void* pMemPool, D2RoomExStrc* pRoomEx1, D2RoomExStrc* pRoomEx2, D2DrlgTileDataStrc* pTileData, int nTileType, uint32_t nPackedTileInformation, int nX, int nY);
 //D2Common.0x6FD89CC0
 void __fastcall DRLGROOMTILE_GetCreateLinkedTileData(void* pMemPool, D2RoomExStrc* pRoomEx, int a3, unsigned int a4, int nX, int nY);
 //D2Common.0x6FD89E30

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -66,7 +66,7 @@ void __fastcall DRLGROOMTILE_AddLinkedTileData(void* pMemPool, D2RoomExStrc* pRo
 //D2Common.0x6FD89AF0
 void __fastcall DRLGROOMTILE_LinkedTileDataManager(void* pMemPool, D2RoomExStrc* pRoomEx1, D2RoomExStrc* pRoomEx2, D2DrlgTileDataStrc* pTileData, int nTileType, uint32_t nPackedTileInformation, int nX, int nY);
 //D2Common.0x6FD89CC0
-void __fastcall DRLGROOMTILE_GetCreateLinkedTileData(void* pMemPool, D2RoomExStrc* pRoomEx, int a3, unsigned int a4, int nX, int nY);
+void __fastcall DRLGROOMTILE_GetCreateLinkedTileData(void* pMemPool, D2RoomExStrc* pRoomEx, int nTileType, uint32_t nPackedTileInformation, int nX, int nY);
 //D2Common.0x6FD89E30
 void __fastcall DRLGROOMTILE_CountAllTileTypes(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pDrlgCoordIndex, BOOL bCheckCoordinatesValidity, BOOL bKillEdgeX, BOOL bKillEdgeY);
 //D2Common.0x6FD89F00

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -25,7 +25,7 @@ union D2C_PackedTileInformation
 		//uint32_t bOverlappedLayer3 : 1; // BIT(19)    code-generated; set when has more walls, incl' of other orientations than usual; obj, shd, tree, roof, lower
 		uint32_t nTileStyle        : 6; // BIT(20-25) AKA tile index
 		uint32_t bRevealHidden     : 1; // BIT(26)    looks like an upper wall brought to a layer in front
-		uint32_t bShadow           : 1; // BIT(27)    this layer is a shadow layer
+		uint32_t bShadow           : 1; // BIT(27)    this layer is a shadow layer | Lectem's note: seems to be roof instead ? Or are shadow tiles interpreted as roof tiles ?
 		uint32_t bLinkage          : 1; // BIT(28)    near wp, lvl links, paths // will never get hidden
 		uint32_t bObjectWall       : 1; // BIT(29)    wall tiles with props; may be block reverb / other sounds (crates, barrels, tables etc.)
 		uint32_t bUnk0x40000000    : 1; // BIT(30)    Unknown flag
@@ -68,7 +68,7 @@ void __fastcall DRLGROOMTILE_LinkedTileDataManager(void* pMemPool, D2RoomExStrc*
 //D2Common.0x6FD89CC0
 void __fastcall DRLGROOMTILE_GetCreateLinkedTileData(void* pMemPool, D2RoomExStrc* pRoomEx, int nTileType, uint32_t nPackedTileInformation, int nX, int nY);
 //D2Common.0x6FD89E30
-void __fastcall DRLGROOMTILE_CountAllTileTypes(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pDrlgCoordIndex, BOOL bCheckCoordinatesValidity, BOOL bKillEdgeX, BOOL bKillEdgeY);
+void __fastcall DRLGROOMTILE_CountAllTileTypes(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pTileInfoGrid, BOOL bCheckCoordinatesValidity, BOOL bKillEdgeX, BOOL bKillEdgeY);
 //D2Common.0x6FD89F00
 void __fastcall DRLGROOMTILE_CountWallWarpTiles(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pDrlgCoordIndex, D2DrlgGridStrc* pOutdoorRoom, BOOL bKillEdgeX, BOOL bKillEdgeY);
 //D2Common.0x6FD89FA0

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -70,7 +70,7 @@ void __fastcall DRLGROOMTILE_GetCreateLinkedTileData(void* pMemPool, D2RoomExStr
 //D2Common.0x6FD89E30
 void __fastcall DRLGROOMTILE_CountAllTileTypes(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pTileInfoGrid, BOOL bCheckCoordinatesValidity, BOOL bKillEdgeX, BOOL bKillEdgeY);
 //D2Common.0x6FD89F00
-void __fastcall DRLGROOMTILE_CountWallWarpTiles(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pDrlgCoordIndex, D2DrlgGridStrc* pOutdoorRoom, BOOL bKillEdgeX, BOOL bKillEdgeY);
+void __fastcall DRLGROOMTILE_CountWallWarpTiles(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pTileInfoGrid, D2DrlgGridStrc* pTileTypeGrid, BOOL bKillEdgeX, BOOL bKillEdgeY);
 //D2Common.0x6FD89FA0
 void __fastcall DRLGROOMTILE_InitRoomGrids(D2RoomExStrc* pRoomEx);
 //D2Common.0x6FD89FD0

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -80,7 +80,7 @@ void __fastcall DRLGROOMTILE_AllocTileGrid(D2RoomExStrc* pRoomEx);
 //D2Common.0x6FD8A050
 void __fastcall DRLGROOMTILE_AllocTileData(D2RoomExStrc* pRoomEx);
 //D2Common.0x6FD8A130
-void __fastcall DRLGROOMTILE_ReallocRoofTileGrid(void* pMemPool, D2DrlgTileGridStrc* pTileGrid, int nRoofs);
+void __fastcall DRLGROOMTILE_ReallocRoofTileGrid(void* pMemPool, D2DrlgTileGridStrc* pTileGrid, int nAdditionalRoofs);
 //D2Common.0x6FD8A1B0 (#10017)
 D2COMMON_DLL_DECL int __fastcall DRLGROOMTILE_GetNumberOfShadowsFromRoom(D2RoomStrc* pRoom);
 //D2Common.0x6FD8A1D0

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -62,7 +62,7 @@ void __fastcall DRLGROOMTILE_LoadFloorWarpTiles(D2RoomExStrc* pRoomEx, int nX, i
 //D2Common.0x6FD897E0
 D2DrlgTileDataStrc* __fastcall DRLGROOMTILE_GetLinkedTileData(D2RoomExStrc* pRoomEx, BOOL bFloor, uint32_t nPackedTileInformation, int nX, int nY, D2RoomExStrc** ppRoomEx);
 //D2Common.0x6FD89930
-void __fastcall DRLGROOMTILE_AddLinkedTileData(void* pMemPool, D2RoomExStrc* pRoomEx, int a3, unsigned int a4, int nX, int nY);
+void __fastcall DRLGROOMTILE_AddLinkedTileData(void* pMemPool, D2RoomExStrc* pRoomEx, int nTileType, uint32_t nPackedTileInformation, int nX, int nY);
 //D2Common.0x6FD89AF0
 void __fastcall DRLGROOMTILE_LinkedTileDataManager(void* pMemPool, D2RoomExStrc* pRoomEx1, D2RoomExStrc* pRoomEx2, D2DrlgTileDataStrc* pTileData, int a5, unsigned int a6, int nX, int nY);
 //D2Common.0x6FD89CC0

--- a/source/D2Common/include/Drlg/D2DrlgRoomTile.h
+++ b/source/D2Common/include/Drlg/D2DrlgRoomTile.h
@@ -86,6 +86,6 @@ D2COMMON_DLL_DECL int __fastcall DRLGROOMTILE_GetNumberOfShadowsFromRoom(D2RoomS
 //D2Common.0x6FD8A1D0
 void __fastcall DRLGROOMTILE_FreeTileGrid(D2RoomExStrc* pRoomEx);
 //D2Common.0x6FD8A2E0
-void __fastcall sub_6FD8A2E0(D2RoomExStrc* pRoomEx, int a2);
+void __fastcall DRLGROOMTILE_FreeRoom(D2RoomExStrc* pRoomEx, BOOL bKeepRoom);
 //D2Common.0x6FD8A380
 void __fastcall DRLGROOMTILE_LoadDT1FilesForRoom(D2RoomExStrc* pRoomEx);

--- a/source/D2Common/src/Drlg/DrlgActivate.cpp
+++ b/source/D2Common/src/Drlg/DrlgActivate.cpp
@@ -171,7 +171,7 @@ void __fastcall DRLGACTIVATE_RoomExStatusUnset_Untile(D2RoomExStrc* pRoomEx)
 		{
 			if (DRLG_IsOnClient(pRoomEx->pLevel->pDrlg))
 			{
-				sub_6FD8A2E0(pRoomEx, false);
+				DRLGROOMTILE_FreeRoom(pRoomEx, false);
 			}
 		}
 	}

--- a/source/D2Common/src/Drlg/DrlgDrlgRoom.cpp
+++ b/source/D2Common/src/Drlg/DrlgDrlgRoom.cpp
@@ -48,7 +48,7 @@ void __fastcall sub_6FD77280(D2RoomExStrc* pRoomEx, BOOL bClient, uint32_t nFlag
 
 	if (pRoomEx->dwFlags & ROOMEXFLAG_HAS_ROOM)
 	{
-		sub_6FD8A2E0(pRoomEx, bClient == 0);
+		DRLGROOMTILE_FreeRoom(pRoomEx, bClient == 0);
 	}
 }
 

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -1018,33 +1018,31 @@ void __fastcall DRLGROOMTILE_CountAllTileTypes(D2RoomExStrc* pRoomEx, D2DrlgGrid
 }
 
 //D2Common.0x6FD89F00
-void __fastcall DRLGROOMTILE_CountWallWarpTiles(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pDrlgCoordIndex, D2DrlgGridStrc* pOutdoorRoom, BOOL bKillEdgeX, BOOL bKillEdgeY)
+void __fastcall DRLGROOMTILE_CountWallWarpTiles(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pTileInfoGrid, D2DrlgGridStrc* pTileTypeGrid, BOOL bKillEdgeX, BOOL bKillEdgeY)
 {
-	int v9 = 0;
+	const int nTileCountX = pRoomEx->nTileWidth + (bKillEdgeX == 0);
+	const int nTileCountY = pRoomEx->nTileHeight + (bKillEdgeY == 0);
 
-	for (int j = 0; j < pRoomEx->nTileHeight + (bKillEdgeY == 0); ++j)
+	for (int nY = 0; nY < nTileCountY; ++nY)
 	{
-		for (int i = 0; i < pRoomEx->nTileWidth + (bKillEdgeX == 0); ++i)
+		for (int nX = 0; nX < nTileCountX; ++nX)
 		{
-			v9 = DRLGGRID_GetGridEntry(pOutdoorRoom, i, j);
-
-			if (v9 == 3)
+			switch (int nTileType = DRLGGRID_GetGridEntry(pTileTypeGrid, nX, nY))
 			{
+			case TILETYPE_RIGHTPARTOFNORTHCORNERWALL:
 				++pRoomEx->pTileGrid->pTiles.nWalls;
-			}
-			else
-			{
-				if (v9 > 9 && v9 <= 11)
+				break;
+			case TILETYPE_SPECIALTILES_10:
+			case TILETYPE_SPECIALTILES_11:
+				if (D2C_PackedTileInformation{ (uint32_t)DRLGGRID_GetGridEntry(pTileInfoGrid, nX, nY) }.bHidden)
 				{
-					if (DRLGGRID_GetGridEntry(pDrlgCoordIndex, i, j) < 0)
-					{
-						pRoomEx->pTileGrid->pTiles.nFloors += 6;
-					}
-					else
-					{
-						++pRoomEx->pTileGrid->pTiles.nWalls;
-					}
+					pRoomEx->pTileGrid->pTiles.nFloors += 6;
 				}
+				else
+				{
+					++pRoomEx->pTileGrid->pTiles.nWalls;
+				}
+				break;
 			}
 		}
 	}

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -1143,15 +1143,7 @@ int __fastcall DRLGROOMTILE_GetNumberOfShadowsFromRoom(D2RoomStrc* pRoom)
 //D2Common.0x6FD8A1D0
 void __fastcall DRLGROOMTILE_FreeTileGrid(D2RoomExStrc* pRoomEx)
 {
-	D2DrlgAnimTileGridStrc* pNextAnimTileGrid = NULL;
-	D2DrlgAnimTileGridStrc* pAnimTileGrid = NULL;
-	D2DrlgTileLinkStrc* pNextTileLink = NULL;
-	D2DrlgTileLinkStrc* pTileLink = NULL;
-	D2DrlgTileGridStrc* pTileGrid = NULL;
-
-	pTileGrid = pRoomEx->pTileGrid;
-
-	if (pTileGrid)
+	if (D2DrlgTileGridStrc* pTileGrid = pRoomEx->pTileGrid)
 	{
 		if (pTileGrid->pTiles.pWallTiles)
 		{
@@ -1168,26 +1160,26 @@ void __fastcall DRLGROOMTILE_FreeTileGrid(D2RoomExStrc* pRoomEx)
 			D2_FREE_SERVER(pRoomEx->pLevel->pDrlg->pMempool, pTileGrid->pTiles.pRoofTiles);
 		}
 
-		pTileLink = pTileGrid->pMapLinks;
+		D2DrlgTileLinkStrc* pTileLink = pTileGrid->pMapLinks;
 		while (pTileLink)
 		{
-			pNextTileLink = pTileLink->pNext;
+			D2DrlgTileLinkStrc* pNextTileLink = pTileLink->pNext;
 			D2_FREE_SERVER(pRoomEx->pLevel->pDrlg->pMempool, pTileLink);
 			pTileLink = pNextTileLink;
 		}
-		pTileGrid->pMapLinks = NULL;
+		pTileGrid->pMapLinks = nullptr;
 
-		pAnimTileGrid = pTileGrid->pAnimTiles;
+		D2DrlgAnimTileGridStrc* pAnimTileGrid = pTileGrid->pAnimTiles;
 		while (pAnimTileGrid)
 		{
-			pNextAnimTileGrid = pAnimTileGrid->pNext;
+			D2DrlgAnimTileGridStrc* pNextAnimTileGrid = pAnimTileGrid->pNext;
 			D2_FREE_SERVER(pRoomEx->pLevel->pDrlg->pMempool, pAnimTileGrid->ppMapTileData);
 			D2_FREE_SERVER(pRoomEx->pLevel->pDrlg->pMempool, pAnimTileGrid);
 			pAnimTileGrid = pNextAnimTileGrid;
 		}
 
 		D2_FREE_SERVER(pRoomEx->pLevel->pDrlg->pMempool, pTileGrid);
-		pRoomEx->pTileGrid = NULL;
+		pRoomEx->pTileGrid = nullptr;
 	}
 }
 

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -1184,14 +1184,14 @@ void __fastcall DRLGROOMTILE_FreeTileGrid(D2RoomExStrc* pRoomEx)
 }
 
 //D2Common.0x6FD8A2E0
-void __fastcall sub_6FD8A2E0(D2RoomExStrc* pRoomEx, BOOL bKeepRoom)
+void __fastcall DRLGROOMTILE_FreeRoom(D2RoomExStrc* pRoomEx, BOOL bKeepRoom)
 {
 	if (!bKeepRoom && pRoomEx->pRoom)
 	{
 		DUNGEON_RemoveRoomFromAct(pRoomEx->pLevel->pDrlg->pAct, pRoomEx->pRoom);
 	}
 
-	pRoomEx->pRoom = NULL;
+	pRoomEx->pRoom = nullptr;
 
 	DRLGLOGIC_FreeDrlgCoordList(pRoomEx);
 
@@ -1212,8 +1212,8 @@ void __fastcall sub_6FD8A2E0(D2RoomExStrc* pRoomEx, BOOL bKeepRoom)
 
 		for (D2RoomTileStrc* i = pRoomEx->pRoomTiles; i; i = i->pNext)
 		{
-			i->unk0x0C = NULL;
-			i->unk0x10 = NULL;
+			i->unk0x0C = nullptr;
+			i->unk0x10 = nullptr;
 		}
 
 		if (bKeepRoom)

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -1226,28 +1226,20 @@ void __fastcall DRLGROOMTILE_FreeRoom(D2RoomExStrc* pRoomEx, BOOL bKeepRoom)
 //D2Common.0x6FD8A380
 void __fastcall DRLGROOMTILE_LoadDT1FilesForRoom(D2RoomExStrc* pRoomEx)
 {
-	D2LvlTypesTxt* pLvlTypesTxtRecord = NULL;
-	unsigned int dwDT1Mask = 0;
-	int nCounter = 0;
-	char szPath[MAX_PATH] = {};
+	D2LvlTypesTxt* pLvlTypesTxtRecord = DATATBLS_GetLevelTypesTxtRecord(pRoomEx->pLevel->nLevelType);
 
-	pLvlTypesTxtRecord = DATATBLS_GetLevelTypesTxtRecord(pRoomEx->pLevel->nLevelType);
-
-	dwDT1Mask = pRoomEx->dwDT1Mask;
-
-	while (dwDT1Mask && nCounter < 32)
+	static_assert(ARRAY_SIZE(pLvlTypesTxtRecord->szFile) <= 32, "DT1Mask is 32bits, needs to match the number of file records");
+	
+	uint32_t dwDT1Mask = pRoomEx->dwDT1Mask;
+	for (int nFileIndex = 0; nFileIndex < ARRAY_SIZE(pLvlTypesTxtRecord->szFile) && dwDT1Mask != 0; ++nFileIndex, dwDT1Mask >>= 1)
 	{
 		if (dwDT1Mask & 1)
 		{
-			D2CMP_10087_LoadTileLibrarySlot(pRoomEx->pTiles, pLvlTypesTxtRecord->szFile[nCounter]);
+			D2CMP_10087_LoadTileLibrarySlot(pRoomEx->pTiles, pLvlTypesTxtRecord->szFile[nFileIndex]);
 		}
-
-		dwDT1Mask >>= 1;
-
-		++nCounter;
 	}
 
-	szPath[0] = sgptDataTables->szDefaultString;
+	char szPath[MAX_PATH] = { sgptDataTables->szDefaultString };
 
 	wsprintfA(szPath, "%s\\Tiles\\Act1\\Outdoors\\Blank.dt1", "DATA\\GLOBAL");
 	D2CMP_10087_LoadTileLibrarySlot(pRoomEx->pTiles, szPath);

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -988,31 +988,28 @@ void __fastcall DRLGROOMTILE_GetCreateLinkedTileData(void* pMemPool, D2RoomExStr
 }
 
 //D2Common.0x6FD89E30
-void __fastcall DRLGROOMTILE_CountAllTileTypes(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pDrlgCoordIndex, BOOL bCheckCoordinatesValidity, BOOL bKillEdgeX, BOOL bKillEdgeY)
+void __fastcall DRLGROOMTILE_CountAllTileTypes(D2RoomExStrc* pRoomEx, D2DrlgGridStrc* pTileInfoGrid, BOOL bCheckCoordinatesValidity, BOOL bKillEdgeX, BOOL bKillEdgeY)
 {
-	int* pFlags = 0;
-	int nHeight = 0;
-	int nWidth = 0;
+	const int nTileCountX = pRoomEx->nTileWidth + (bKillEdgeX == 0);
+	const int nTileCountY = pRoomEx->nTileHeight + (bKillEdgeY == 0);
 
-	nWidth = pRoomEx->nTileWidth + (bKillEdgeX == 0);
-	nHeight = pRoomEx->nTileHeight + (bKillEdgeY == 0);
-
-	for (int nY = 0; nY < nHeight; ++nY)
+	for (int nY = 0; nY < nTileCountY; ++nY)
 	{
-		for (int nX = 0; nX < nWidth; ++nX)
+		for (int nX = 0; nX < nTileCountX; ++nX)
 		{
-			pFlags = DRLGGRID_GetGridFlagsPointer(pDrlgCoordIndex, nX, nY);
-			if (*pFlags & 1)
+			const int* pFlags = DRLGGRID_GetGridFlagsPointer(pTileInfoGrid, nX, nY);
+			D2C_PackedTileInformation nTileInformation{ (uint32_t)*pFlags };
+			if (nTileInformation.bIsWall)
 			{
 				++pRoomEx->pTileGrid->pTiles.nWalls;
 			}
 
-			if (*pFlags & 2 || bCheckCoordinatesValidity && DRLGROOM_AreXYInsideCoordinates(&pRoomEx->pDrlgCoord, nX + pRoomEx->nTileXPos, nY + pRoomEx->nTileYPos))
+			if (nTileInformation.bIsFloor || bCheckCoordinatesValidity && DRLGROOM_AreXYInsideCoordinates(&pRoomEx->pDrlgCoord, nX + pRoomEx->nTileXPos, nY + pRoomEx->nTileYPos))
 			{
 				++pRoomEx->pTileGrid->pTiles.nFloors;
 			}
 
-			if (*pFlags & 0x8000000)
+			if (nTileInformation.bShadow)
 			{
 				++pRoomEx->pTileGrid->pTiles.nRoofs;
 			}

--- a/source/D2Common/src/Drlg/DrlgRoomTile.cpp
+++ b/source/D2Common/src/Drlg/DrlgRoomTile.cpp
@@ -1111,22 +1111,21 @@ void __fastcall DRLGROOMTILE_AllocTileData(D2RoomExStrc* pRoomEx)
 }
 
 //D2Common.0x6FD8A130
-void __fastcall DRLGROOMTILE_ReallocRoofTileGrid(void* pMemPool, D2DrlgTileGridStrc* pTileGrid, int nRoofs)
+void __fastcall DRLGROOMTILE_ReallocRoofTileGrid(void* pMemPool, D2DrlgTileGridStrc* pTileGrid, int nAdditionalRoofs)
 {
-	int nCounter = 0;
-
-	if (nRoofs)
+	if (nAdditionalRoofs)
 	{
-		pTileGrid->pTiles.pRoofTiles = (D2DrlgTileDataStrc*)D2_REALLOC_SERVER(pMemPool, pTileGrid->pTiles.pRoofTiles, sizeof(D2DrlgTileDataStrc) * (nRoofs + pTileGrid->pTiles.nRoofs));
+		pTileGrid->pTiles.pRoofTiles = (D2DrlgTileDataStrc*)D2_REALLOC_SERVER(pMemPool, pTileGrid->pTiles.pRoofTiles, sizeof(D2DrlgTileDataStrc) * (nAdditionalRoofs + pTileGrid->pTiles.nRoofs));
 		
+		int nCounter = 0;
 		while (nCounter < pTileGrid->nShadows - 1)
 		{
 			pTileGrid->pTiles.pRoofTiles[nCounter].unk0x20 = &pTileGrid->pTiles.pRoofTiles[nCounter + 1];
 			++nCounter;
 		}
 
-		pTileGrid->pTiles.pRoofTiles[nCounter].unk0x20 = NULL;
-		pTileGrid->pTiles.nRoofs += nRoofs;
+		pTileGrid->pTiles.pRoofTiles[nCounter].unk0x20 = nullptr;
+		pTileGrid->pTiles.nRoofs += nAdditionalRoofs;
 	}
 }
 


### PR DESCRIPTION
This is a follow-up of #72 and #73 .
Mostly using the new `D2C_PackedTileInformation` and a bit of code cleaning.

With this `DrlgRoomTile.cpp` has been cleaned entirely (could maybe rename a few more things, but good enough).