### PR TITLE
Remove extra "Get" in UNITS_GetLeftSkill

### DIFF
--- a/source/D2Common/definitions/D2Common.1.10f.def
+++ b/source/D2Common/definitions/D2Common.1.10f.def
@@ -321,7 +321,7 @@ EXPORTS
 	UNITS_IsInMovingMode												@10318
 	UNITS_IsInMovingModeEx												@10319
 	UNITS_GetStartSkill													@10320
-	UNITS_GetGetLeftSkill												@10321
+	UNITS_GetLeftSkill													@10321
 	UNITS_GetRightSkill													@10322
 	UNITS_GetUsedSkill													@10323
 	UNITS_SetUsedSkill													@10324

--- a/source/D2Common/include/Units/Units.h
+++ b/source/D2Common/include/Units/Units.h
@@ -195,7 +195,7 @@ D2COMMON_DLL_DECL uint8_t __stdcall UNITS_GetDirection(D2UnitStrc* pUnit);
 //D2Common.0x6FDBD570 (#10320)
 D2COMMON_DLL_DECL D2SkillStrc* __stdcall UNITS_GetStartSkill(D2UnitStrc* pUnit);
 //D2Common.0x6FDBD5B0 (#10321)
-D2COMMON_DLL_DECL D2SkillStrc* __stdcall UNITS_GetGetLeftSkill(D2UnitStrc* pUnit);
+D2COMMON_DLL_DECL D2SkillStrc* __stdcall UNITS_GetLeftSkill(D2UnitStrc* pUnit);
 //D2Common.0x6FDBD5F0 (#10322)
 D2COMMON_DLL_DECL D2SkillStrc* __stdcall UNITS_GetRightSkill(D2UnitStrc* pUnit);
 //D2Common.0x6FDBD630 (#10324)

--- a/source/D2Common/src/D2Skills.cpp
+++ b/source/D2Common/src/D2Skills.cpp
@@ -718,7 +718,7 @@ void __stdcall SKILLS_InitSkillList(D2UnitStrc* pUnit)
 		while (nCounter < 10);
 	}
 
-	if (!UNITS_GetGetLeftSkill(pUnit))
+	if (!UNITS_GetLeftSkill(pUnit))
 	{
 		SKILLS_SetLeftActiveSkill(pUnit, 0, -1);
 	}

--- a/source/D2Common/src/Units/Units.cpp
+++ b/source/D2Common/src/Units/Units.cpp
@@ -47,7 +47,7 @@ D2SkillStrc* __stdcall UNITS_GetStartSkill(D2UnitStrc* pUnit)
 }
 
 //D2Common.0x6FDBD5B0 (#10321)
-D2SkillStrc* __stdcall UNITS_GetGetLeftSkill(D2UnitStrc* pUnit)
+D2SkillStrc* __stdcall UNITS_GetLeftSkill(D2UnitStrc* pUnit)
 {
 	D2_ASSERT(pUnit);
 	return SKILLS_GetLeftSkillFromSkillList(pUnit->pSkills);


### PR DESCRIPTION
These changes fix an incorrect name for the UNITS_GetLeftSkill function.