### PR TITLE
Refactor D2Common ordinal 10515 for easier flow

### DIFF
--- a/source/D2Common/definitions/D2Common.1.10f.def
+++ b/source/D2Common/definitions/D2Common.1.10f.def
@@ -515,7 +515,7 @@ EXPORTS
 	D2Common_10512														@10512
 	D2Common_10513														@10513
 	STATLIST_ClampStaminaManaHP											@10514
-	D2Common_10515														@10515
+	STATLIST_DeactivateTemporaryStates									@10515
 	STATLIST_UpdateStatListsExpiration									@10516
 	STATLIST_SetUnitStat												@10517
 	STATLIST_AddUnitStat												@10518

--- a/source/D2Common/include/D2StatList.h
+++ b/source/D2Common/include/D2StatList.h
@@ -579,7 +579,7 @@ D2COMMON_DLL_DECL int __stdcall STATLIST_GetStatValue(D2StatListStrc* pStatList,
 //D2Common.0x6FDB7F40 (#10522)
 D2COMMON_DLL_DECL int __stdcall STATLIST_GetUnitStatBonus(D2UnitStrc* pUnit, int nStatId, uint16_t nLayer);
 //D2Common.0x6FDB80C0 (#10515)
-D2COMMON_DLL_DECL void __stdcall D2Common_10515(D2UnitStrc* pUnit);
+D2COMMON_DLL_DECL void __stdcall STATLIST_DeactivateTemporaryStates(D2UnitStrc* pUnit);
 //D2Common.0x6FDB8120 (#10467)
 D2COMMON_DLL_DECL int __stdcall D2Common_10467(D2StatListStrc* pStatList, int nStat);
 //D2Common.0x6FDB8150 (#10468)

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -1447,37 +1447,34 @@ int __stdcall STATLIST_GetUnitStatBonus(D2UnitStrc* pUnit, int nStatId, uint16_t
 //D2Common.0x6FDB80C0 (#10515)
 void __stdcall D2Common_10515(D2UnitStrc* pUnit)
 {
-	D2StatListStrc* pStatListEx = NULL;
-	D2StatListStrc* pPrevious = NULL;
-
-	if (pUnit->pStatListEx && pUnit->pStatListEx->dwFlags & STATLIST_NEWLENGTH)
+	if (pUnit->pStatListEx == nullptr || !(pUnit->pStatListEx->dwFlags & STATLIST_NEWLENGTH))
 	{
-		if (D2StatListStrc* pCurStatListEx = pUnit->pStatListEx->pMyLastList)
+		return;
+	}
+
+	D2StatListStrc* pCurrent, *pPrevious;
+	for (pCurrent = pUnit->pStatListEx->pMyLastList; pCurrent != nullptr; pCurrent = pPrevious)
+	{
+		pPrevious = pCurrent->pPrevLink;
+		if (!(pCurrent->dwFlags & STATLIST_TEMPONLY))
 		{
-			do
-			{
-				pPrevious = pCurStatListEx->pPrevLink;
-				if (pCurStatListEx->dwFlags & STATLIST_TEMPONLY)
-				{
-					if (pCurStatListEx->dwStateNo)
-					{
-						STATES_ToggleState(pUnit, pCurStatListEx->dwStateNo, FALSE);
-					}
-
-					if (!(pCurStatListEx->dwFlags & STATLIST_EXTENDED))
-					{
-						D2Common_STATLIST_FreeStatListImpl_6FDB7050((D2StatListExStrc*)pCurStatListEx);
-					}
-
-					pPrevious = pUnit->pStatListEx->pMyLastList;
-				}
-				pCurStatListEx = pPrevious;
-			}
-			while (pPrevious);
+			continue;
 		}
 
-		pUnit->pStatListEx->dwFlags &= ~STATLIST_NEWLENGTH;
+		if (pCurrent->dwStateNo)
+		{
+			STATES_ToggleState(pUnit, pCurrent->dwStateNo, FALSE);
+		}
+
+		if (!(pCurrent->dwFlags & STATLIST_EXTENDED))
+		{
+			D2Common_STATLIST_FreeStatListImpl_6FDB7050((D2StatListExStrc*)pCurrent);
+		}
+
+		pPrevious = pUnit->pStatListEx->pMyLastList;
 	}
+
+	pUnit->pStatListEx->dwFlags &= ~STATLIST_NEWLENGTH;
 }
 
 //D2Common.0x6FDB8120 (#10467)

--- a/source/D2Common/src/D2StatList.cpp
+++ b/source/D2Common/src/D2StatList.cpp
@@ -1445,15 +1445,15 @@ int __stdcall STATLIST_GetUnitStatBonus(D2UnitStrc* pUnit, int nStatId, uint16_t
 }
 
 //D2Common.0x6FDB80C0 (#10515)
-void __stdcall D2Common_10515(D2UnitStrc* pUnit)
+void __stdcall STATLIST_DeactivateTemporaryStates(D2UnitStrc* pUnit)
 {
 	if (pUnit->pStatListEx == nullptr || !(pUnit->pStatListEx->dwFlags & STATLIST_NEWLENGTH))
 	{
 		return;
 	}
 
-	D2StatListStrc* pCurrent, *pPrevious;
-	for (pCurrent = pUnit->pStatListEx->pMyLastList; pCurrent != nullptr; pCurrent = pPrevious)
+	D2StatListStrc* pPrevious;
+	for (D2StatListStrc* pCurrent = pUnit->pStatListEx->pMyLastList; pCurrent != nullptr; pCurrent = pPrevious)
 	{
 		pPrevious = pCurrent->pPrevLink;
 		if (!(pCurrent->dwFlags & STATLIST_TEMPONLY))
@@ -1466,9 +1466,9 @@ void __stdcall D2Common_10515(D2UnitStrc* pUnit)
 			STATES_ToggleState(pUnit, pCurrent->dwStateNo, FALSE);
 		}
 
-		if (!(pCurrent->dwFlags & STATLIST_EXTENDED))
+		if (!STATLIST_IsExtended(pCurrent))
 		{
-			D2Common_STATLIST_FreeStatListImpl_6FDB7050((D2StatListExStrc*)pCurrent);
+			D2Common_STATLIST_FreeStatListImpl_6FDB7050(pCurrent);
 		}
 
 		pPrevious = pUnit->pStatListEx->pMyLastList;

--- a/source/D2Common/src/Units/Units.cpp
+++ b/source/D2Common/src/Units/Units.cpp
@@ -825,7 +825,7 @@ BOOL __stdcall UNITS_ChangeAnimMode(D2UnitStrc* pUnit, int nMode)
 			UNITROOM_RefreshUnit(pUnit);
 			pUnit->dwAnimMode = nMode;
 			pUnit->dwFlags |= UNITFLAG_DOUPDATE;
-			D2Common_10515(pUnit);
+			STATLIST_DeactivateTemporaryStates(pUnit);
 			UNITS_SetAnimStartFrame(pUnit);
 			return TRUE;
 		}


### PR DESCRIPTION
These changes simplify ordinal 10515 for better readability.

For documentation reference: This function appears to be a free/dealloc function for D2UnitStrc starting from a StatList marked STATLIST_TEMPONLY.