### PR TITLE
Fix missing const on szFile parameters

### DIFF
--- a/source/D2Common/include/D2DataTbls.h
+++ b/source/D2Common/include/D2DataTbls.h
@@ -517,7 +517,7 @@ extern BOOL DATATBLS_LoadFromBin;
 //D2Common.0x6FDC412C
 void __fastcall DATATBLS_CloseFileInMPQ(void* pMemPool, void* pFileHandle);
 //D2Common.0x6FDC40F0
-BOOL __fastcall DATATBLS_CheckIfFileExists(void* pMemPool, char* szFileName, void** pFileHandle, int bDontLogError);
+BOOL __fastcall DATATBLS_CheckIfFileExists(void* pMemPool, const char* szFileName, void** pFileHandle, int bDontLogError);
 //D2Common.0x6FDC45EE
 size_t __cdecl DATATBLS_LockAndWriteToFile(const void* Str, size_t Size, size_t Count, FILE* File);
 //D2Common.0x6FDC41C1
@@ -525,7 +525,7 @@ BOOL __fastcall DATATBLS_ReadFromFile(void* pMemPool, void* pFileHandle, void* p
 //D2Common.0x6FDC4152
 size_t __fastcall DATATBLS_GetFileSize(void* pMemPool, void* pFileHandle, uint32_t* lpFileSizeHigh);
 //D2Common.0x6FDC4268
-void* __fastcall DATATBLS_GetBinaryData(void* pMemPool, const char* szFileName, int* pSize, char* szFile, int nLine);
+void* __fastcall DATATBLS_GetBinaryData(void* pMemPool, const char* szFileName, int* pSize, const char* szFile, int nLine);
 
 
 
@@ -547,7 +547,7 @@ D2COMMON_DLL_DECL int __stdcall DATATBLS_GetMaxLevel(int nClass);
 //D2Common.0x6FD49710 (#10630)
 D2COMMON_DLL_DECL uint32_t __stdcall DATATBLS_GetCurrentLevelFromExp(int nClass, uint32_t dwExperience);
 //D2Common.0x6FD49760
-void __fastcall DATATBLS_GetBinFileHandle(void* pMemPool, char* szFile, void** ppFileHandle, int* pSize, int* pSizeEx);
+void __fastcall DATATBLS_GetBinFileHandle(void* pMemPool, const char* szFile, void** ppFileHandle, int* pSize, int* pSizeEx);
 //D2Common.0x6FD49850
 int __fastcall DATATBLS_AppendMemoryBuffer(char** ppCodes, int* pSize, int* pSizeEx, char* pBuffer, int nBufferSize);
 
@@ -575,7 +575,7 @@ D2COMMON_DLL_DECL char* __stdcall DATATBLS_GetUnitNameFromUnitTypeAndClassId(int
 //D2Common.0x6FD4FCF0 (#10580)
 D2COMMON_DLL_DECL void __stdcall DATATBLS_WriteBinFile(char* szFileName, void* pWriteBuffer, size_t nBufferSize, int nRecordCount);
 //D2Common.0x6FD4FD70 (#10578)
-D2COMMON_DLL_DECL void* __stdcall DATATBLS_CompileTxt(void* pMemPool, char* szName, D2BinFieldStrc* pTbl, int* pRecordCount, int nSize);
+D2COMMON_DLL_DECL void* __stdcall DATATBLS_CompileTxt(void* pMemPool, const char* szName, D2BinFieldStrc* pTbl, int* pRecordCount, int nSize);
 //D2Common.0x6FD500F0 (#11242)
 D2COMMON_DLL_DECL void __stdcall DATATBLS_ToggleCompileTxtFlag(BOOL bSilent);
 //D2Common.0x6FD50110 (#10579)

--- a/source/D2Common/include/D2Inventory.h
+++ b/source/D2Common/include/D2Inventory.h
@@ -187,7 +187,7 @@ BOOL __fastcall INVENTORY_FindFreePositionTopLeftToBottomRightWithWeight(D2Inven
 //D2Common.0x6FD8F0E0
 BOOL __fastcall INVENTORY_FindFreePositionTopLeftToBottomRight(D2InventoryGridStrc* pInventoryGrid, int* pFreeX, int* pFreeY, uint8_t nItemWidth, uint8_t nItemHeight);
 //D2Common.0x6FD8F1E0 (#10246)
-D2COMMON_DLL_DECL BOOL __stdcall INVENTORY_PlaceItemAtFreePosition(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nInventoryRecordId, BOOL bUnused, uint8_t nPage, char* szFile, int nLine);
+D2COMMON_DLL_DECL BOOL __stdcall INVENTORY_PlaceItemAtFreePosition(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nInventoryRecordId, BOOL bUnused, uint8_t nPage, const char* szFile, int nLine);
 //D2Common.0x6FD8F250
 BOOL __fastcall INVENTORY_PlaceItemInGrid(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nXPos, int nYPos, int nInventoryGrid, int nInventoryRecordId, BOOL bUnused);
 //D2Common.0x6FD8F600 (#10247)

--- a/source/D2Common/include/D2Items.h
+++ b/source/D2Common/include/D2Items.h
@@ -251,7 +251,7 @@ D2COMMON_DLL_DECL uint16_t __stdcall ITEMS_GetRareSuffixId(D2UnitStrc* pItem);
 //D2Common.0x6FD98730 (#10706)
 D2COMMON_DLL_DECL void __stdcall ITEMS_AssignRareSuffix(D2UnitStrc* pItem, uint16_t nSuffix);
 //D2Common.0x6FD98750 (#10707)
-D2COMMON_DLL_DECL BOOL __stdcall ITEMS_CheckItemFlag(D2UnitStrc* pItem, uint32_t dwFlag, int nLine, char* szFile);
+D2COMMON_DLL_DECL BOOL __stdcall ITEMS_CheckItemFlag(D2UnitStrc* pItem, uint32_t dwFlag, int nLine, const char* szFile);
 //D2Common.0x6FD98780 (#10708)
 D2COMMON_DLL_DECL void __stdcall ITEMS_SetItemFlag(D2UnitStrc* pItem, uint32_t dwFlag, BOOL bSet);
 //D2Common.0x6FD987C0 (#10709)
@@ -331,7 +331,7 @@ D2COMMON_DLL_DECL uint32_t __stdcall ITEMS_GetAltGfx(D2UnitStrc* pItem);
 //D2Common.0x6FD99480 (#10748)
 D2COMMON_DLL_DECL uint8_t __stdcall ITEMS_GetComponent(D2UnitStrc* pItem);
 //D2Common.0x6FD99500 (#10749)
-D2COMMON_DLL_DECL void __stdcall ITEMS_GetDimensions(D2UnitStrc* pItem, uint8_t* pWidth, uint8_t* pHeight, char* szFile, int nLine);
+D2COMMON_DLL_DECL void __stdcall ITEMS_GetDimensions(D2UnitStrc* pItem, uint8_t* pWidth, uint8_t* pHeight, const char* szFile, int nLine);
 //D2Common.0x6FD99540 (#10750)
 D2COMMON_DLL_DECL void __stdcall ITEMS_GetAllowedBodyLocations(D2UnitStrc* pItem, uint8_t* pBodyLoc1, uint8_t* pBodyLoc2);
 //D2Common.0x6FD995D0 (#10751)

--- a/source/D2Common/include/D2Log.h
+++ b/source/D2Common/include/D2Log.h
@@ -1,6 +1,6 @@
 #pragma once
 
-void __cdecl LOG_11100(int a1, int a2, int a3, int a4, char* szFile, int nLine, const char* szFormat, ...);
+void __cdecl LOG_11100(int a1, int a2, int a3, int a4, const char* szFile, int nLine, const char* szFormat, ...);
 void __cdecl LOG_11101(int nGame, int nFrame, int nClient, int a4, int nSize, const char* szFormat, ...);
 void __fastcall LOG_11102(void* a1);
 void __fastcall LOG_11103(void* a1);

--- a/source/D2Common/include/D2Skills.h
+++ b/source/D2Common/include/D2Skills.h
@@ -195,9 +195,9 @@ D2COMMON_DLL_DECL D2SkillStrc* __fastcall SKILLS_GetSkillById(D2UnitStrc* pUnit,
 //D2Common.0x6FDAFF80 (#10950)
 D2COMMON_DLL_DECL D2SkillStrc* __fastcall SKILLS_GetHighestLevelSkillFromUnitAndId(D2UnitStrc* pUnit, int nSkillId);
 //D2Common.0x6FDAFFD0 (#10951)
-D2COMMON_DLL_DECL void __stdcall SKILLS_RemoveSkill(D2UnitStrc* pUnit, int nSkillId, char* szFile, int nLine);
+D2COMMON_DLL_DECL void __stdcall SKILLS_RemoveSkill(D2UnitStrc* pUnit, int nSkillId, const char* szFile, int nLine);
 //D2Common.0x6FDAFFF0
-void __fastcall D2COMMON_SKILLS_RemoveSkill_6FDAFFF0(D2UnitStrc* pUnit, int nSkillId, int a3, char* szFile, int nLine);
+void __fastcall D2COMMON_SKILLS_RemoveSkill_6FDAFFF0(D2UnitStrc* pUnit, int nSkillId, int a3, const char* szFile, int nLine);
 //D2Common.0x6FDB0270 (#10958)
 D2COMMON_DLL_DECL void* __stdcall D2Common_10958(D2UnitStrc* pUnit, void* a2);
 //D2Common.0x6FDB02A0 (#10959)
@@ -207,7 +207,7 @@ D2COMMON_DLL_DECL void __stdcall SKILLS_FreeSkillList(D2UnitStrc* pUnit);
 //D2Common.0x6FDB0320 (#10952)
 D2COMMON_DLL_DECL D2SkillStrc* __stdcall SKILLS_AddSkill(D2UnitStrc* pUnit, int nSkillId);
 //D2Common.0x6FDB04D0 (#10953)
-D2COMMON_DLL_DECL void __stdcall SKILLS_AssignSkill(D2UnitStrc* pUnit, int nSkillId, int nSkillLevel, BOOL bRemove, char* szFile, int nLine);
+D2COMMON_DLL_DECL void __stdcall SKILLS_AssignSkill(D2UnitStrc* pUnit, int nSkillId, int nSkillLevel, BOOL bRemove, const char* szFile, int nLine);
 //D2Common.0x6FDB05E0 (#10954)
 D2COMMON_DLL_DECL void __stdcall D2Common_10954(D2UnitStrc* pUnit, D2UnitGUID nOwnerGUID, int nSkillId, int nSkillLevel, int nCharges, BOOL bFreeMemory);
 //D2Common.0x6FDB08C0 (#10957)
@@ -221,7 +221,7 @@ D2COMMON_DLL_DECL void __stdcall SKILLS_SetLeftActiveSkill(D2UnitStrc* pUnit, in
 //D2Common.0x6FDB0A30 (#10962)
 D2COMMON_DLL_DECL void __stdcall SKILLS_SetRightActiveSkill(D2UnitStrc* pUnit, int nSkillId, D2UnitGUID nOwnerGUID);
 //D2Common.0x6FDB0AC0 (#10963)
-D2COMMON_DLL_DECL int __stdcall SKILLS_GetSkillIdFromSkill(D2SkillStrc* pSkill, char* szFile, int nLine);
+D2COMMON_DLL_DECL int __stdcall SKILLS_GetSkillIdFromSkill(D2SkillStrc* pSkill, const char* szFile, int nLine);
 //D2Common.0x6FDB0AF0 (#10965)
 D2COMMON_DLL_DECL int __fastcall SKILLS_GetSeqNumFromSkill(D2UnitStrc* pUnit, D2SkillStrc* pSkill);
 //D2Common.0x6FDB0B70 (#10964)
@@ -331,7 +331,7 @@ D2COMMON_DLL_DECL void __stdcall SKILLS_SetQuantity(D2SkillStrc* pSkill, int nQu
 //D2Common.0x6FDB2FA0 (#11014)
 D2COMMON_DLL_DECL int __stdcall D2Common_11014_ConvertShapeShiftedMode(int nArrayIndex, int nMonsterId);
 //D2Common.0x6FDB30A0 (#11013)
-D2COMMON_DLL_DECL void __stdcall D2COMMON_11013_ConvertMode(D2UnitStrc* pUnit, int* pType, int* pClass, int* pMode, char* szFile, int nLine);
+D2COMMON_DLL_DECL void __stdcall D2COMMON_11013_ConvertMode(D2UnitStrc* pUnit, int* pType, int* pClass, int* pMode, const char* szFile, int nLine);
 //D2Common.0x6FDB3290 (#11015)
 D2COMMON_DLL_DECL void __stdcall D2Common_11015(D2UnitStrc* pUnit, int a2, int nSkillId);
 //D2Common.0x6FDB3340 (#11016)

--- a/source/D2Common/include/Path/Path.h
+++ b/source/D2Common/include/Path/Path.h
@@ -209,7 +209,7 @@ D2COMMON_DLL_DECL void __stdcall D2Common_10143(D2UnitStrc* pUnit, int a2);
 //D2Common.0x6FDA98F0 (#10144)
 D2COMMON_DLL_DECL void __stdcall D2Common_10144(D2UnitStrc* pUnit, BOOL bDoNothing);
 //D2Common.0x6FDA9A70 (#10146)
-D2COMMON_DLL_DECL void __stdcall PATH_SetVelocity(D2DynamicPathStrc* pDynamicPath, int nVelocity, char* szFile, int nLine);
+D2COMMON_DLL_DECL void __stdcall PATH_SetVelocity(D2DynamicPathStrc* pDynamicPath, int nVelocity, const char* szFile, int nLine);
 //D2Common.0x6FDA9AB0 (#10147)
 D2COMMON_DLL_DECL int __stdcall PATH_GetVelocity(D2DynamicPathStrc* pDynamicPath);
 //D2Common.0x6FDA9AC0 (#10148)

--- a/source/D2Common/include/Units/Units.h
+++ b/source/D2Common/include/Units/Units.h
@@ -287,7 +287,7 @@ D2COMMON_DLL_DECL void __stdcall UNITS_UpdateFrame(D2UnitStrc* pUnit);
 //D2Common.0x6FDBF020 (#10375)
 D2COMMON_DLL_DECL void __stdcall D2COMMON_10375_UNITS_SetFrameNonRate(D2UnitStrc* pUnit, int nRate, int nFailRate);
 //D2Common.0x6FDBF050
-void __stdcall D2COMMON_10376_UpdateAnimRateAndVelocity(D2UnitStrc* pUnit, char* szFile, int nLine);
+void __stdcall D2COMMON_10376_UpdateAnimRateAndVelocity(D2UnitStrc* pUnit, const char* szFile, int nLine);
 //D2Common.0x6FDBF8D0 (#10377)
 D2COMMON_DLL_DECL void __stdcall UNITS_SetAnimationSpeed(D2UnitStrc* pUnit, int nSpeed);
 //D2Common.0x6FDBF910 (#10378)

--- a/source/D2Common/src/D2Inventory.cpp
+++ b/source/D2Common/src/D2Inventory.cpp
@@ -944,7 +944,7 @@ BOOL __fastcall INVENTORY_FindFreePositionTopLeftToBottomRight(D2InventoryGridSt
 }
 
 //D2Common.0x6FD8F1E0 (#10246)
-BOOL __stdcall INVENTORY_PlaceItemAtFreePosition(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nInventoryRecordId, BOOL bUnused, uint8_t nPage, char* szFile, int nLine)
+BOOL __stdcall INVENTORY_PlaceItemAtFreePosition(D2InventoryStrc* pInventory, D2UnitStrc* pItem, int nInventoryRecordId, BOOL bUnused, uint8_t nPage, const char* szFile, int nLine)
 {
 	int nX = 0;
 	int nY = 0;

--- a/source/D2Common/src/D2Log.cpp
+++ b/source/D2Common/src/D2Log.cpp
@@ -3,7 +3,7 @@
 #include "CommonDefinitions.h"
 
 
-void __cdecl LOG_11100(int a1, int a2, int a3, int a4, char* szFile, int nLine, const char* szFormat, ...)
+void __cdecl LOG_11100(int a1, int a2, int a3, int a4, const char* szFile, int nLine, const char* szFormat, ...)
 {
 	REMOVE_LATER_WriteToLogFile("LOG_11100: Useless");
 }

--- a/source/D2Common/src/D2Skills.cpp
+++ b/source/D2Common/src/D2Skills.cpp
@@ -798,13 +798,13 @@ D2SkillStrc* __fastcall SKILLS_GetHighestLevelSkillFromUnitAndId(D2UnitStrc* pUn
 }
 
 //D2Common.0x6FDAFFD0 (#10951)
-void __stdcall SKILLS_RemoveSkill(D2UnitStrc* pUnit, int nSkillId, char* szFile, int nLine)
+void __stdcall SKILLS_RemoveSkill(D2UnitStrc* pUnit, int nSkillId, const char* szFile, int nLine)
 {
 	D2COMMON_SKILLS_RemoveSkill_6FDAFFF0(pUnit, nSkillId, 1, szFile, nLine);
 }
 
 //D2Common.0x6FDAFFF0
-void __fastcall D2COMMON_SKILLS_RemoveSkill_6FDAFFF0(D2UnitStrc* pUnit, int nSkillId, BOOL bDecrementAndCheckSkillLevel, char* szFile, int nLine)
+void __fastcall D2COMMON_SKILLS_RemoveSkill_6FDAFFF0(D2UnitStrc* pUnit, int nSkillId, BOOL bDecrementAndCheckSkillLevel, const char* szFile, int nLine)
 {
 	if (!pUnit)
 	{
@@ -1033,7 +1033,7 @@ D2SkillStrc* __stdcall SKILLS_AddSkill(D2UnitStrc* pUnit, int nSkillId)
 }
 
 //D2Common.0x6FDB04D0 (#10953)
-void __stdcall SKILLS_AssignSkill(D2UnitStrc* pUnit, int nSkillId, int nSkillLevel, BOOL bRemove, char* szFile, int nLine)
+void __stdcall SKILLS_AssignSkill(D2UnitStrc* pUnit, int nSkillId, int nSkillLevel, BOOL bRemove, const char* szFile, int nLine)
 {
 	D2SkillStrc* pSkill = NULL;
 
@@ -1328,7 +1328,7 @@ void __stdcall SKILLS_SetRightActiveSkill(D2UnitStrc* pUnit, int nSkillId, D2Uni
 }
 
 //D2Common.0x6FDB0AC0 (#10963)
-int __stdcall SKILLS_GetSkillIdFromSkill(D2SkillStrc* pSkill, char* szFile, int nLine)
+int __stdcall SKILLS_GetSkillIdFromSkill(D2SkillStrc* pSkill, const char* szFile, int nLine)
 {
 	if (pSkill)
 	{
@@ -2866,7 +2866,7 @@ int __stdcall D2Common_11014_ConvertShapeShiftedMode(int nArrayIndex, int nMonst
 }
 
 //D2Common.0x6FDB30A0 (#11013)
-void __stdcall D2COMMON_11013_ConvertMode(D2UnitStrc* pUnit, int* pType, int* pClass, int* pMode, char* szFile, int nLine)
+void __stdcall D2COMMON_11013_ConvertMode(D2UnitStrc* pUnit, int* pType, int* pClass, int* pMode, const char* szFile, int nLine)
 {
 	if (!(pUnit && (pUnit->dwFlagEx & UNITFLAGEX_ISSHAPESHIFTED) && sgptDataTables->nTransformStates > 0))
 	{

--- a/source/D2Common/src/DataTbls/DataTbls.cpp
+++ b/source/D2Common/src/DataTbls/DataTbls.cpp
@@ -26,7 +26,7 @@ void __fastcall DATATBLS_CloseFileInMPQ(void* pMemPool, void* pFileHandle)
 }
 
 //D2Common.0x6FDC40F0
-BOOL __fastcall DATATBLS_CheckIfFileExists(void* pMemPool, char* szFileName, void** pFileHandle, int bDontLogError)
+BOOL __fastcall DATATBLS_CheckIfFileExists(void* pMemPool, const char* szFileName, void** pFileHandle, int bDontLogError)
 {
 	if (FOG_MPQFileOpen(szFileName, pFileHandle))
 	{
@@ -98,7 +98,7 @@ size_t __fastcall DATATBLS_GetFileSize(void* pMemPool, void* pFileHandle, uint32
 }
 
 //D2Common.0x6FDC4268
-void* __fastcall DATATBLS_GetBinaryData(void* pMemPool, const char* szFileName, int* pSize, char* szFile, int nLine)
+void* __fastcall DATATBLS_GetBinaryData(void* pMemPool, const char* szFileName, int* pSize, const char* szFile, int nLine)
 {
 	void* pFileHandle = NULL;
 	void* pBuffer = NULL;
@@ -264,7 +264,7 @@ uint32_t __stdcall DATATBLS_GetCurrentLevelFromExp(int nClass, uint32_t dwExperi
 }
 
 //D2Common.0x6FD49760
-void __fastcall DATATBLS_GetBinFileHandle(void* pMemPool, char* szFile, void** ppFileHandle, int* pSize, int* pSizeEx)
+void __fastcall DATATBLS_GetBinFileHandle(void* pMemPool, const char* szFile, void** ppFileHandle, int* pSize, int* pSizeEx)
 {
 	FILE* pFile = NULL;
 	int nSize = 0;
@@ -727,7 +727,7 @@ void __stdcall DATATBLS_WriteBinFile(char* szFileName, void* pWriteBuffer, size_
 }
 
 //D2Common.0x6FD4FD70 (#10578)
-void* __stdcall DATATBLS_CompileTxt(void* pMemPool, char* szName, D2BinFieldStrc* pTbl, int* pRecordCount, int nSize)
+void* __stdcall DATATBLS_CompileTxt(void* pMemPool, const char* szName, D2BinFieldStrc* pTbl, int* pRecordCount, int nSize)
 {
 	D2BinFileStrc* pBinFile = NULL;
 	FILE* pFile = NULL;

--- a/source/D2Common/src/Items/Items.cpp
+++ b/source/D2Common/src/Items/Items.cpp
@@ -225,7 +225,7 @@ void __stdcall ITEMS_AssignRareSuffix(D2UnitStrc* pItem, uint16_t nSuffix)
 }
 
 //D2Common.0x6FD98750 (#10707)
-BOOL __stdcall ITEMS_CheckItemFlag(D2UnitStrc* pItem, uint32_t dwFlag, int nLine, char* szFile)
+BOOL __stdcall ITEMS_CheckItemFlag(D2UnitStrc* pItem, uint32_t dwFlag, int nLine, const char* szFile)
 {
 	if (D2ItemDataStrc * pItemData = ITEMS_GetItemData(pItem))
 	{
@@ -902,7 +902,7 @@ uint8_t __stdcall ITEMS_GetComponent(D2UnitStrc* pItem)
 }
 
 //D2Common.0x6FD99500 (#10749)
-void __stdcall ITEMS_GetDimensions(D2UnitStrc* pItem, uint8_t* pWidth, uint8_t* pHeight, char* szFile, int nLine)
+void __stdcall ITEMS_GetDimensions(D2UnitStrc* pItem, uint8_t* pWidth, uint8_t* pHeight, const char* szFile, int nLine)
 {
 	if (pItem && pItem->dwUnitType == UNIT_ITEM)
 	{

--- a/source/D2Common/src/Path/Path.cpp
+++ b/source/D2Common/src/Path/Path.cpp
@@ -743,7 +743,7 @@ void __stdcall D2Common_10144(D2UnitStrc* pUnit, BOOL bDoNothing)
 }
 
 //D2Common.0x6FDA9A70 (#10146)
-void __stdcall PATH_SetVelocity(D2DynamicPathStrc* pDynamicPath, int nVelocity, char* szFile, int nLine)
+void __stdcall PATH_SetVelocity(D2DynamicPathStrc* pDynamicPath, int nVelocity, const char* szFile, int nLine)
 {
 	if (pDynamicPath)
 	{

--- a/source/D2Common/src/Units/Units.cpp
+++ b/source/D2Common/src/Units/Units.cpp
@@ -1543,7 +1543,7 @@ __forceinline void __fastcall UNITS_UpdateRunWalkAnimRateAndVelocity(D2UnitStrc*
 
 //D2Common.0x6FDBF050
 //TODO: Check everything related to this function
-void __stdcall UNITS_UpdateRunWalkAnimRateAndVelocity(D2UnitStrc* pUnit, const char* szFile, int nLine)
+void __stdcall D2COMMON_10376_UpdateAnimRateAndVelocity(D2UnitStrc* pUnit, const char* szFile, int nLine)
 {
 	D2SkillStrc* v10 = NULL;
 	int nUnitType = 0;

--- a/source/D2Common/src/Units/Units.cpp
+++ b/source/D2Common/src/Units/Units.cpp
@@ -1449,7 +1449,7 @@ __forceinline void __fastcall UNITS_UpdateOtherAnimRateAndVelocity(D2UnitStrc* p
 }
 
 //TODO: ...
-__forceinline void __fastcall UNITS_UpdateRunWalkAnimRateAndVelocity(D2UnitStrc* pUnit, int nAnimMode, int nUnitType, int nClassId, char* szFile, int nLine)
+__forceinline void __fastcall UNITS_UpdateRunWalkAnimRateAndVelocity(D2UnitStrc* pUnit, int nAnimMode, int nUnitType, int nClassId, const char* szFile, int nLine)
 {
 	D2CharStatsTxt* pCharStatsTxtRecord = NULL;
 	D2MonStatsTxt* pMonStatsTxtRecord = NULL;
@@ -1543,7 +1543,7 @@ __forceinline void __fastcall UNITS_UpdateRunWalkAnimRateAndVelocity(D2UnitStrc*
 
 //D2Common.0x6FDBF050
 //TODO: Check everything related to this function
-void __stdcall D2COMMON_10376_UpdateAnimRateAndVelocity(D2UnitStrc* pUnit, char* szFile, int nLine)
+void __stdcall UNITS_UpdateRunWalkAnimRateAndVelocity(D2UnitStrc* pUnit, const char* szFile, int nLine)
 {
 	D2SkillStrc* v10 = NULL;
 	int nUnitType = 0;
@@ -1755,7 +1755,7 @@ LABEL_75:
 
 ////TODO:Remove
 //D2FUNC(D2COMMON, 10376, void, __stdcall, (D2UnitStrc*, char*, int), 0x7F050)
-//void __stdcall D2COMMON_10376_UpdateAnimRateAndVelocity(D2UnitStrc* pUnit, char* szFile, int nLine)
+//void __stdcall D2COMMON_10376_UpdateAnimRateAndVelocity(D2UnitStrc* pUnit, const char* szFile, int nLine)
 //{
 //	return D2COMMON_10376(pUnit, szFile, nLine);
 //}

--- a/source/D2Hell/src/Archive.cpp
+++ b/source/D2Hell/src/Archive.cpp
@@ -149,7 +149,7 @@ void* __fastcall ARCHIVE_ReadFile(void* pArchiveHandle, const char* szFilePath, 
 	size_t dwFileSizeHigh;
 	size_t dwFileSize = ARCHIVE_GetFileSize(pArchiveHandle, pFileHandle, &dwFileSizeHigh);
 	// TODO: Remove the char* cast once FOG has been const corrected.
-	void* pBuffer = FOG_AllocClientMemory(dwFileSize + 800, (char*)szSrcPath, nLine, 0);
+	void* pBuffer = FOG_AllocClientMemory(dwFileSize + 800, szSrcPath, nLine, 0);
 	if (pBuffer == nullptr)
 	{
 		return nullptr;

--- a/source/D2Hell/src/Archive.cpp
+++ b/source/D2Hell/src/Archive.cpp
@@ -148,7 +148,6 @@ void* __fastcall ARCHIVE_ReadFile(void* pArchiveHandle, const char* szFilePath, 
 
 	size_t dwFileSizeHigh;
 	size_t dwFileSize = ARCHIVE_GetFileSize(pArchiveHandle, pFileHandle, &dwFileSizeHigh);
-	// TODO: Remove the char* cast once FOG has been const corrected.
 	void* pBuffer = FOG_AllocClientMemory(dwFileSize + 800, szSrcPath, nLine, 0);
 	if (pBuffer == nullptr)
 	{

--- a/source/Fog/include/Fog.h
+++ b/source/Fog/include/Fog.h
@@ -110,12 +110,12 @@ D2FUNC_DLL(FOG, 10021, int, __fastcall, (const char* szLogName), 0xE1A0)								
 D2FUNC_DLL(FOG, Assertion, void, __cdecl, (const char* szMsg, const char* szFile, int nLine), 0xED30)												//Fog.#10023
 D2FUNC_DLL(FOG, 10024_PacketAssertion, void, __cdecl, (const char* szMsg, const char* szFile, int nLine), 0xED60)									//Fog.#10024
 D2FUNC_DLL(FOG, 10025, void, __cdecl, (const char* szMsg, const char* szFile, int nLine), 0xED90)													//Fog.#10025
-D2FUNC_DLL(FOG, WriteToLogFile, void, __cdecl, (char* szFormat, ...), 0x120A0)																		//Fog.#10029
-D2FUNC_DLL(FOG, AllocClientMemory, void*, __fastcall, (int nSize, char* szFile, int nLine, int n0), 0x8F50)											//Fog.#10042
-D2FUNC_DLL(FOG, FreeClientMemory, void, __fastcall, (void* pFree, char* szFile, int nLine, int n0), 0x8F90)											//Fog.#10043
-D2FUNC_DLL(FOG, AllocServerMemory, void*, __fastcall, (void* pMemPool, int nSize, char* szFile, int nLine, int n0), 0x8FF0)							//Fog.#10045
-D2FUNC_DLL(FOG, FreeServerMemory, void, __fastcall, (void* pMemPool, void* pFree, char* szFile, int nLine, int n0), 0x9030)							//Fog.#10046
-D2FUNC_DLL(FOG, ReallocServerMemory, void*, __fastcall, (void* pMemPool, void* pMemory, int nSize, char* szFile, int nLine, int n0), 0x9060)		//Fog.#10047
+D2FUNC_DLL(FOG, WriteToLogFile, void, __cdecl, (const char* szFormat, ...), 0x120A0)																		//Fog.#10029
+D2FUNC_DLL(FOG, AllocClientMemory, void*, __fastcall, (int nSize, const char* szFile, int nLine, int n0), 0x8F50)											//Fog.#10042
+D2FUNC_DLL(FOG, FreeClientMemory, void, __fastcall, (void* pFree, const char* szFile, int nLine, int n0), 0x8F90)											//Fog.#10043
+D2FUNC_DLL(FOG, AllocServerMemory, void*, __fastcall, (void* pMemPool, int nSize, const char* szFile, int nLine, int n0), 0x8FF0)							//Fog.#10045
+D2FUNC_DLL(FOG, FreeServerMemory, void, __fastcall, (void* pMemPool, void* pFree, const char* szFile, int nLine, int n0), 0x9030)							//Fog.#10046
+D2FUNC_DLL(FOG, ReallocServerMemory, void*, __fastcall, (void* pMemPool, void* pMemory, int nSize, const char* szFile, int nLine, int n0), 0x9060)		//Fog.#10047
 D2FUNC_DLL(FOG, 10050_EnterCriticalSection, void, __fastcall, (CRITICAL_SECTION* pCriticalSection, int nLine), 0xDC20)								//Fog.#10050
 D2FUNC_DLL(FOG, 10083_Cos_LUT, float, __stdcall, (int16_t index), 0x1DF0)																			//Fog.#10083
 D2FUNC_DLL(FOG, 10084_Sin_LUT, float, __stdcall, (int16_t index), 0x1E10)																			//Fog.#10084
@@ -128,7 +128,7 @@ D2FUNC_DLL(FOG, 10207, void, __stdcall, (D2BinFileStrc* pBinFile, D2BinFieldStrc
 D2FUNC_DLL(FOG, CreateBinFile, D2BinFileStrc*, __stdcall, (void* pDataBuffer, int nBufferSize), 0xA8B0)												//Fog.#10208
 D2FUNC_DLL(FOG, FreeBinFile, void, __stdcall, (D2BinFileStrc* pBinFile), 0xAA10)																	//Fog.#10209
 D2FUNC_DLL(FOG, GetRecordCountFromBinFile, int, __stdcall, (D2BinFileStrc* pBinFile), 0xAA50)														//Fog.#10210
-D2FUNC_DLL(FOG, AllocLinker, void*, __stdcall, (char* szFile, int nLine), 0xB720)																	//Fog.#10211
+D2FUNC_DLL(FOG, AllocLinker, void*, __stdcall, (const char* szFile, int nLine), 0xB720)																	//Fog.#10211
 D2FUNC_DLL(FOG, FreeLinker, void, __stdcall, (void* pLinker), 0xB750)																				//Fog.#10212
 D2FUNC_DLL(FOG, GetLinkIndex, int, __stdcall, (void* pLink, uint32_t dwCode, BOOL bLogError), 0xB810)												//Fog.#10213
 D2FUNC_DLL(FOG, GetStringFromLinkIndex, int, __stdcall, (void* pLinker, int nIndex, char* szString), 0xB8F0)										//Fog.#10214


### PR DESCRIPTION
C/C++ language standards specify that `__FILE__` is a string literal. String literals are of type const char[], and therefore require the const specifier to be valid uses.