### PR TITLE
Redirect Archive-related file functions

### DIFF
--- a/source/D2Common/CMakeLists.txt
+++ b/source/D2Common/CMakeLists.txt
@@ -11,7 +11,7 @@ add_library(D2CommonStatic
   include/Imports/DllBases.h
 )
 
-target_link_libraries(D2CommonStatic PUBLIC D2CommonDefinitions D2CMP D2Lang Fog)
+target_link_libraries(D2CommonStatic PUBLIC D2CommonDefinitions D2CMP D2Hell D2Lang Fog)
 
 target_include_directories(D2CommonStatic PUBLIC include)
 
@@ -229,6 +229,6 @@ target_link_libraries(D2Common
 # D2CommonStatic itself should not be linked by targets linking D2Common, hence why it is PRIVATE
   PRIVATE D2CommonStatic
 # But we still its dependencies to be propagated so that users can consume them
-  PUBLIC D2CommonDefinitions D2CMP D2Lang Fog
+  PUBLIC D2CommonDefinitions D2CMP D2Hell D2Lang Fog
 )
 target_include_directories(D2Common INTERFACE include)

--- a/source/D2Common/include/D2DataTbls.h
+++ b/source/D2Common/include/D2DataTbls.h
@@ -512,26 +512,8 @@ extern BOOL DATATBLS_LoadFromBin;
 
 #pragma pack()
 
-
-
-//D2Common.0x6FDC412C
-void __fastcall DATATBLS_CloseFileInMPQ(void* pMemPool, HSFILE hFileHandle);
-//D2Common.0x6FDC40F0
-BOOL __fastcall DATATBLS_CheckIfFileExists(void* pMemPool, const char* szFileName, HSFILE* pFileHandle, int bDontLogError);
 //D2Common.0x6FDC45EE
 size_t __cdecl DATATBLS_LockAndWriteToFile(const void* Str, size_t Size, size_t Count, FILE* File);
-//D2Common.0x6FDC41C1
-BOOL __fastcall DATATBLS_ReadFromFile(void* pMemPool, HSFILE pFileHandle, void* pBuffer, size_t nBytesToRead);
-//D2Common.0x6FDC4152
-size_t __fastcall DATATBLS_GetFileSize(void* pMemPool, HSFILE pFileHandle, uint32_t* lpFileSizeHigh);
-//D2Common.0x6FDC4268
-void* __fastcall DATATBLS_GetBinaryData(void* pMemPool, const char* szFileName, int* pSize, const char* szFile, int nLine);
-
-
-
-
-
-
 //D2Common.0x6FD494D0
 uint16_t __fastcall DATATBLS_GetStringIdFromReferenceString(char* szReference);
 //D2Common.0x6FD49500 - Changed this function a lot (had 6 hardcoded (i.e. pre-defined) Args)

--- a/source/D2Common/include/D2DataTbls.h
+++ b/source/D2Common/include/D2DataTbls.h
@@ -557,7 +557,7 @@ D2COMMON_DLL_DECL char* __stdcall DATATBLS_GetUnitNameFromUnitTypeAndClassId(int
 //D2Common.0x6FD4FCF0 (#10580)
 D2COMMON_DLL_DECL void __stdcall DATATBLS_WriteBinFile(char* szFileName, void* pWriteBuffer, size_t nBufferSize, int nRecordCount);
 //D2Common.0x6FD4FD70 (#10578)
-D2COMMON_DLL_DECL void* __stdcall DATATBLS_CompileTxt(void* pMemPool, const char* szName, D2BinFieldStrc* pTbl, int* pRecordCount, int nSize);
+D2COMMON_DLL_DECL void* __stdcall DATATBLS_CompileTxt(void* pMemPool, const char* szName, D2BinFieldStrc* pTbl, int* pRecordCount, size_t dwSize);
 //D2Common.0x6FD500F0 (#11242)
 D2COMMON_DLL_DECL void __stdcall DATATBLS_ToggleCompileTxtFlag(BOOL bSilent);
 //D2Common.0x6FD50110 (#10579)

--- a/source/D2Common/src/DataTbls/AnimTbls.cpp
+++ b/source/D2Common/src/DataTbls/AnimTbls.cpp
@@ -1,7 +1,9 @@
 #include "D2DataTbls.h"
 
 #include "D2Composit.h"
-#include <Units/Units.h>
+#include "Units/Units.h"
+
+#include <Archive.h>
 
 //TODO: Find names
 
@@ -18,7 +20,7 @@ D2AnimDataStrc* __fastcall DATATBLS_LoadAnimDataD2(void* pMemPool)
 	memset(pAnimData, 0x00, sizeof(D2AnimDataStrc));
 
 	wsprintfA(szPath, "%s\\AnimData.d2", "DATA\\GLOBAL");
-	pRecords = (char*)DATATBLS_GetBinaryData(pMemPool, szPath, NULL, __FILE__, __LINE__);
+	pRecords = (char*)ARCHIVE_READ_FILE_TO_ALLOC_BUFFER(pMemPool, szPath, NULL);
 	pAnimData->pRecords = (D2AnimDataRecordStrc*)pRecords;
 
 	pHashTable = pAnimData->pHashTable;

--- a/source/D2Common/src/DataTbls/DataTbls.cpp
+++ b/source/D2Common/src/DataTbls/DataTbls.cpp
@@ -627,7 +627,7 @@ void __stdcall DATATBLS_WriteBinFile(char* szFileName, void* pWriteBuffer, size_
 }
 
 //D2Common.0x6FD4FD70 (#10578)
-void* __stdcall DATATBLS_CompileTxt(void* pMemPool, const char* szName, D2BinFieldStrc* pTbl, int* pRecordCount, int nSize)
+void* __stdcall DATATBLS_CompileTxt(void* pMemPool, const char* szName, D2BinFieldStrc* pTbl, int* pRecordCount, size_t dwSize)
 {
 	D2BinFileStrc* pBinFile = NULL;
 	FILE* pFile = NULL;
@@ -656,9 +656,9 @@ void* __stdcall DATATBLS_CompileTxt(void* pMemPool, const char* szName, D2BinFie
 
 		pBinFile = FOG_CreateBinFile(pData, dwDataSize);
 		nRecordCount = FOG_GetRecordCountFromBinFile(pBinFile);
-		pTxt = FOG_AllocPool(NULL, nSize * nRecordCount, __FILE__, __LINE__, 0);
-		memset(pTxt, 0x00, nSize * nRecordCount);
-		FOG_10207(pBinFile, pTbl, pTxt, nRecordCount, nSize);
+		pTxt = FOG_AllocPool(NULL, dwSize * nRecordCount, __FILE__, __LINE__, 0);
+		memset(pTxt, 0x00, dwSize * nRecordCount);
+		FOG_10207(pBinFile, pTbl, pTxt, nRecordCount, dwSize);
 		FOG_FreeBinFile(pBinFile);
 
 		wsprintfA(szFilePath, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", szName, ".bin");
@@ -666,7 +666,7 @@ void* __stdcall DATATBLS_CompileTxt(void* pMemPool, const char* szName, D2BinFie
 		if (pFile)
 		{
 			DATATBLS_LockAndWriteToFile(&nRecordCount, 4, 1, pFile);
-			DATATBLS_LockAndWriteToFile(pTxt, nSize * nRecordCount, 1, pFile);
+			DATATBLS_LockAndWriteToFile(pTxt, dwSize * nRecordCount, 1, pFile);
 			fclose(pFile);
 		}
 		FOG_FreePool(NULL, pTxt, __FILE__, __LINE__, 0);
@@ -700,9 +700,9 @@ void* __stdcall DATATBLS_CompileTxt(void* pMemPool, const char* szName, D2BinFie
 	{
 		pBinFile = FOG_CreateBinFile(pData, dwDataSize);
 		nRecordCount = FOG_GetRecordCountFromBinFile(pBinFile);
-		pTxt = FOG_AllocPool(NULL, nSize * nRecordCount, __FILE__, __LINE__, 0);
-		memset(pTxt, 0x00, nSize * nRecordCount);
-		FOG_10207(pBinFile, pTbl, pTxt, nRecordCount, nSize);
+		pTxt = FOG_AllocPool(NULL, dwSize * nRecordCount, __FILE__, __LINE__, 0);
+		memset(pTxt, 0x00, dwSize * nRecordCount);
+		FOG_10207(pBinFile, pTbl, pTxt, nRecordCount, dwSize);
 		FOG_FreeBinFile(pBinFile);
 	}
 

--- a/source/D2Common/src/DataTbls/FieldTbls.cpp
+++ b/source/D2Common/src/DataTbls/FieldTbls.cpp
@@ -1,5 +1,7 @@
 #include "D2DataTbls.h"
 
+#include <Archive.h>
+
 #include "D2Collision.h"
 
 
@@ -14,10 +16,10 @@ BOOL __fastcall DATATBLS_LoadExpFieldD2(void* pMemPool)
 {
 	char szPath[80] = {};
 	char* pExpField = NULL;
-	int nSize = 0;
+	size_t nSize = 0;
 
 	wsprintfA(szPath, "%s\\expfield.d2", "DATA\\GLOBAL");
-	pExpField = (char*)DATATBLS_GetBinaryData(pMemPool, szPath, &nSize, __FILE__, __LINE__);
+	pExpField = (char*)ARCHIVE_READ_FILE_TO_ALLOC_BUFFER(pMemPool, szPath, &nSize);
 
 	return DATATBLS_InitializeCollisionFieldTable(pExpField, nSize);
 }

--- a/source/D2Common/src/DataTbls/HoradricCube.cpp
+++ b/source/D2Common/src/DataTbls/HoradricCube.cpp
@@ -1,5 +1,8 @@
 #include "D2DataTbls.h"
-#include <D2Items.h>
+
+#include <Archive.h>
+
+#include "D2Items.h"
 
 // Inlined in both Parsers
 static BOOL DATATBLS_AreStringsEqual(const char* szString1, const char* szString2)
@@ -696,13 +699,13 @@ void __fastcall DATATBLS_LoadCubeMainTxt(void* pMemPool)
 	};
 
 	wsprintfA(szPath, "%s\\%s", "DATA\\GLOBAL\\EXCEL", "cubeserver.bin");
-	if (DATATBLS_CheckIfFileExists(pMemPool, szPath, &pFileHandle, 1))
+	if (ARCHIVE_OpenFile(pMemPool, szPath, &pFileHandle, TRUE))
 	{
 		FOG_DisplayWarning("Found cubeserver.bin in data path.  This file should only be on the server\n", __FILE__, __LINE__);
 	}
 
 	wsprintfA(szPath, "%s\\%s", "DATA\\GLOBAL\\EXCEL", "cubeserver.txt");
-	if (DATATBLS_CheckIfFileExists(pMemPool, szPath, &pFileHandle, 1))
+	if (ARCHIVE_OpenFile(pMemPool, szPath, &pFileHandle, TRUE))
 	{
 		FOG_DisplayWarning("Found cubeserver.txt in data path.  This file should only be on the server\n", __FILE__, __LINE__);
 	}

--- a/source/D2Common/src/DataTbls/ItemsTbls.cpp
+++ b/source/D2Common/src/DataTbls/ItemsTbls.cpp
@@ -1,6 +1,7 @@
 #include "D2DataTbls.h"
 
 #include "D2Items.h"
+#include <Archive.h>
 #include <D2Lang.h>
 #include <D2BitManip.h>
 #include <D2StatList.h>
@@ -1940,23 +1941,23 @@ void __fastcall DATATBLS_LoadRunesTxt(void* pMemPool)
 	sgptDataTables->pRunesLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
 
 	wsprintfA(szPath, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", "runessrv", ".txt");
-	if (DATATBLS_CheckIfFileExists(pMemPool, szPath, &pFileHandle, 1))
+	if (ARCHIVE_OpenFile(pMemPool, szPath, &pFileHandle, TRUE))
 	{
-		DATATBLS_CloseFileInMPQ(pMemPool, pFileHandle);
+		ARCHIVE_CloseFile(pMemPool, pFileHandle);
 		FOG_DisplayWarning("Found runessrv.txt in archive - This file should only be in server builds.", __FILE__, __LINE__);
 	}
 
 	wsprintfA(szPath, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", "runessrv", ".bin");
-	if (DATATBLS_CheckIfFileExists(pMemPool, szPath, &pFileHandle, 1))
+	if (ARCHIVE_OpenFile(pMemPool, szPath, &pFileHandle, TRUE))
 	{
-		DATATBLS_CloseFileInMPQ(pMemPool, pFileHandle);
+		ARCHIVE_CloseFile(pMemPool, pFileHandle);
 		FOG_DisplayWarning("Found runessrv.bin in archive - This file should only be in server builds.", __FILE__, __LINE__);
 	}
 
 	wsprintfA(szPath, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", "runessrv", ".xls");
-	if (DATATBLS_CheckIfFileExists(pMemPool, szPath, &pFileHandle, 1))
+	if (ARCHIVE_OpenFile(pMemPool, szPath, &pFileHandle, TRUE))
 	{
-		DATATBLS_CloseFileInMPQ(pMemPool, pFileHandle);
+		ARCHIVE_CloseFile(pMemPool, pFileHandle);
 		FOG_DisplayWarning("Found runessrv.xls in archive - This file should only be in server builds.", __FILE__, __LINE__);
 	}
 

--- a/source/D2Common/src/DataTbls/SkillsTbls.cpp
+++ b/source/D2Common/src/DataTbls/SkillsTbls.cpp
@@ -329,7 +329,6 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 	void* pTmpSkillDescTxt = NULL;
 	void* pTmpMonStatsTxt = NULL;
 	int nHighestClassSkillCount = 0;
-	int nSize = 0;
 	uint8_t nPetType = 0;
 	uint8_t nClass = 0;
 	char szFileName[260] = {};
@@ -718,10 +717,12 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 		FOG_10215(pRangeLinker, ' col');
 
 		pMonStatsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		pTmpMonStatsTxt = DATATBLS_CompileTxt(pMemPool, "monstats", pTmpMonStatsTbl, &nSize, 2);
+
+		int nTmpRecordCount;
+		pTmpMonStatsTxt = DATATBLS_CompileTxt(pMemPool, "monstats", pTmpMonStatsTbl, &nTmpRecordCount, 2);
 
 		pSkillDescLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
-		pTmpSkillDescTxt = DATATBLS_CompileTxt(pMemPool, "skilldesc", pTmpSkillDescTbl, &nSize, 2);
+		pTmpSkillDescTxt = DATATBLS_CompileTxt(pMemPool, "skilldesc", pTmpSkillDescTbl, &nTmpRecordCount, 2);
 	}
 
 	sgptDataTables->pSkillsLinker = (D2TxtLinkStrc*)FOG_AllocLinker(__FILE__, __LINE__);
@@ -786,9 +787,10 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 	}
 
 	wsprintfA(szFileName, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", "skillscode", ".bin");
-	sgptDataTables->pSkillsCode = (char*)ARCHIVE_READ_FILE_TO_ALLOC_BUFFER(pMemPool, szFileName, (size_t*)&nSize);
-	sgptDataTables->nSkillsCodeSizeEx = nSize;
-	sgptDataTables->nSkillsCodeSize = nSize;
+	size_t dwSize;
+	sgptDataTables->pSkillsCode = (char*)ARCHIVE_READ_FILE_TO_ALLOC_BUFFER(pMemPool, szFileName, &dwSize);
+	sgptDataTables->nSkillsCodeSizeEx = dwSize;
+	sgptDataTables->nSkillsCodeSize = dwSize;
 
 	if (sgptDataTables->bCompileTxt && sgptDataTables->pSkillDescCode)
 	{
@@ -803,9 +805,9 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 	}
 
 	wsprintfA(szFileName, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", "skilldesccode", ".bin");
-	sgptDataTables->pSkillDescCode = (char*)ARCHIVE_READ_FILE_TO_ALLOC_BUFFER(pMemPool, szFileName, (size_t*)&nSize);
-	sgptDataTables->nSkillDescCodeSizeEx = nSize;
-	sgptDataTables->nSkillDescCodeSize = nSize;
+	sgptDataTables->pSkillDescCode = (char*)ARCHIVE_READ_FILE_TO_ALLOC_BUFFER(pMemPool, szFileName, &dwSize);
+	sgptDataTables->nSkillDescCodeSizeEx = dwSize;
+	sgptDataTables->nSkillDescCodeSize = dwSize;
 
 	sgptDataTables->nClassSkillCount = (int*)FOG_AllocPool(NULL, 7 * sizeof(int), __FILE__, __LINE__, 0);
 	memset(sgptDataTables->nClassSkillCount, 0x00, 7 * sizeof(int));

--- a/source/D2Common/src/DataTbls/SkillsTbls.cpp
+++ b/source/D2Common/src/DataTbls/SkillsTbls.cpp
@@ -1,5 +1,6 @@
 #include "D2DataTbls.h"
 
+#include <Archive.h>
 
 //D2Common.0x6FD498D0
 int __fastcall DATATBLS_MapSkillsTxtKeywordToNumber(char* szKey)
@@ -785,7 +786,7 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 	}
 
 	wsprintfA(szFileName, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", "skillscode", ".bin");
-	sgptDataTables->pSkillsCode = (char*)DATATBLS_GetBinaryData(pMemPool, szFileName, &nSize, __FILE__, __LINE__);
+	sgptDataTables->pSkillsCode = (char*)ARCHIVE_READ_FILE_TO_ALLOC_BUFFER(pMemPool, szFileName, (size_t*)&nSize);
 	sgptDataTables->nSkillsCodeSizeEx = nSize;
 	sgptDataTables->nSkillsCodeSize = nSize;
 
@@ -802,7 +803,7 @@ void __fastcall DATATBLS_LoadSkills_SkillDescTxt(void* pMemPool)
 	}
 
 	wsprintfA(szFileName, "%s\\%s%s", "DATA\\GLOBAL\\EXCEL", "skilldesccode", ".bin");
-	sgptDataTables->pSkillDescCode = (char*)DATATBLS_GetBinaryData(pMemPool, szFileName, &nSize, __FILE__, __LINE__);
+	sgptDataTables->pSkillDescCode = (char*)ARCHIVE_READ_FILE_TO_ALLOC_BUFFER(pMemPool, szFileName, (size_t*)&nSize);
 	sgptDataTables->nSkillDescCodeSizeEx = nSize;
 	sgptDataTables->nSkillDescCodeSize = nSize;
 

--- a/source/D2Common/src/Drlg/DrlgPreset.cpp
+++ b/source/D2Common/src/Drlg/DrlgPreset.cpp
@@ -1,6 +1,18 @@
 #include "Drlg/D2DrlgPreset.h"
 
+#include <algorithm>
+
+#include <Archive.h>
+#include <D2CMP.h>
+
 #include "D2DataTbls.h"
+#include "D2Dungeon.h"
+#include "D2Items.h"
+#include "D2Monsters.h"
+#include "D2Seed.h"
+#include "DataTbls/LevelsIds.h"
+#include "DataTbls/MonsterIds.h"
+#include "DataTbls/ObjectsIds.h"
 #include "Drlg/D2DrlgActivate.h"
 #include "Drlg/D2DrlgDrlg.h"
 #include "Drlg/D2DrlgDrlgAnim.h"
@@ -12,16 +24,7 @@
 #include "Drlg/D2DrlgMaze.h"
 #include "Drlg/D2DrlgRoomTile.h"
 #include "Drlg/D2DrlgTileSub.h"
-#include "D2Dungeon.h"
-#include "D2Seed.h"
-#include <D2CMP.h>
-#include <DataTbls/LevelsIds.h>
-#include <DataTbls/MonsterIds.h>
-#include <DataTbls/ObjectsIds.h>
-#include <D2Items.h>
-#include <D2Monsters.h>
-#include <Units/Units.h>
-#include <algorithm>
+#include "Units/Units.h"
 
 // D2Common.0x6FDEA700
 D2LevelFileListStrc* gpLevelFilesList_6FDEA700;
@@ -112,7 +115,7 @@ static void SkipInt32s(int32_t*& pData, uint32_t nbToSkip)
 //D2Common.0x6FD85A10
 void __fastcall DRLGPRESET_ParseDS1File(D2DrlgFileStrc* pDrlgFile, void* pMemPool, const char* szFileName)
 {
-	D2DS1FileStrc* pDS1File = (D2DS1FileStrc*)DATATBLS_GetBinaryData(pMemPool, szFileName, NULL, __FILE__, __LINE__);
+	D2DS1FileStrc* pDS1File = (D2DS1FileStrc*)ARCHIVE_READ_FILE_TO_ALLOC_BUFFER(pMemPool, szFileName, NULL);
 	pDrlgFile->pDS1File = pDS1File;
 	pDrlgFile->nWidth = pDS1File->nWidth;
 	pDrlgFile->nHeight = pDS1File->nHeight;

--- a/source/D2Hell/include/Archive.h
+++ b/source/D2Hell/include/Archive.h
@@ -31,12 +31,9 @@
 #include <stddef.h>
 #include <windows.h>
 
-// TODO: Replace these HS type declarations and typedefs with an
-// appropriate include once a proper place for these types are found.
-// This should ideally be in a Storm-related header file.
-
-struct HSFILE__;
-using HSFILE = HSFILE__*;
+// TODO: Replace this include with the header file that defines
+// HSFILE.
+#include <Fog.h>
 
 /**
  * Opens a file in the MPQ archives and returns the handle to the

--- a/source/D2Hell/include/Archive.h
+++ b/source/D2Hell/include/Archive.h
@@ -29,17 +29,81 @@
 #pragma once
 
 #include <stddef.h>
+#include <windows.h>
+
+// TODO: Replace these HS type declarations and typedefs with an
+// appropriate include once a proper place for these types are found.
+// This should ideally be in a Storm-related header file.
+
+struct HSFILE__;
+using HSFILE = HSFILE__*;
+
+/**
+ * Opens a file in the MPQ archives and returns the handle to the
+ * file.
+ *
+ * hArchive is the first parameter, but it is effectively unused.
+ *
+ * Static library; may be defined in multiple places than ones listed:
+ * 1.00: Inline
+ * 1.10: Inline OR D2Common.0x6FDC40F0
+ * 1.13c: Inline
+ * 1.14c: Game.0x00514B24
+ */
+BOOL __fastcall ARCHIVE_OpenFile(void* hArchive, const char* szFilePath, HSFILE* phFile, BOOL bFileNotFoundLogSkipped);
+
+/**
+ * Closes a file handle to a file from the MPQ archives.
+ *
+ * hArchive is the first parameter, but it is effectively unused.
+ *
+ * Static library; may be defined in multiple places than ones listed:
+ * 1.00: Inline
+ * 1.10: Inline OR D2Common.0x6FDC412C
+ * 1.13c: Inline
+ * 1.14c: Game.0x00514B60
+ */
+void __fastcall ARCHIVE_CloseFile(void* hArchive, HSFILE hFile);
+
+/**
+ * Gets the uncompressed size of a file in the MPQ archives.
+ *
+ * hArchive is the first parameter, but it is effectively unused.
+ *
+ * Static library; may be defined in multiple places than ones listed:
+ * 1.00: D2Lang.0x10004DFE
+ * 1.10: D2Lang.0x6FC145F2 OR D2Common.0x6FDC4152
+ * 1.13c: Inline
+ * 1.14c: Game.0x00514B87
+ */
+size_t __fastcall ARCHIVE_GetFileSize(void* hArchive, HSFILE hFile, size_t* pdwFileSizeHigh);
+
+/**
+ * Reads a file from the MPQ archives into a specified buffer.
+ *
+ * hArchive is the first parameter, but it is effectively unused.
+ *
+ * Static library; may be defined in multiple places than ones listed:
+ * 1.00: D2Lang.0x10004EE3
+ * 1.10: D2Lang.0x6FC14661 OR D2Common.0x6FDC41C1
+ * 1.13c: D2Lang.0x6FC07C00
+ * 1.14c: Game.0x00514C61
+ */
+void __fastcall ARCHIVE_ReadFileToBuffer(void* hArchive, HSFILE hFile, void* pBuffer, size_t dwBytesToRead);
 
 /**
  * Reads a file from the MPQ archives into a buffer allocated by
- * this function, and returns that buffer.
+ * this function. Returns the buffer containing the file's contents,
+ * or nullptr on failure.
  *
- * pArchiveHandle is the first parameter, but it is effectively unused.
+ * hArchive is the first parameter, but it is effectively unused.
  *
  * Static library; may be defined in multiple places than ones listed:
  * 1.00: D2Lang.0x10005029
- * 1.10: D2Lang.0x6FC14708
+ * 1.10: D2Lang.0x6FC14708 OR D2Common.0x6FDC4268
  * 1.13c: D2Lang.0x6FC07EF0
  * 1.14c: Game.0x00514D55
  */
-void* __fastcall ARCHIVE_ReadFile(void* pArchiveHandle, const char* szFilePath, size_t* pBytesWritten, const char* szSrcPath, int nLine);
+void* __fastcall ARCHIVE_ReadFileToAllocBuffer(void* hArchive, const char* szFilePath, size_t* pdwBytesWritten, const char* szSrcPath, int nLine);
+
+#define ARCHIVE_READ_FILE_TO_ALLOC_BUFFER(hArchive, szFilePath, pBytesWritten) ARCHIVE_ReadFileToAllocBuffer(hArchive, szFilePath, pBytesWritten, __FILE__, __LINE__)


### PR DESCRIPTION
Functions that previously used DATATBLS for Archive-file are now directed to the static library D2HELL definition.