### PR TITLE
Finish the D2C_Language enum definitions

### DIFF
--- a/source/D2CommonDefinitions/include/D2Constants.h
+++ b/source/D2CommonDefinitions/include/D2Constants.h
@@ -431,17 +431,27 @@ enum D2C_VendorInventoryModes
 #endif // CONSTANTS_UI
 
 #ifndef CONSTANTS_STRINGS //Pseudo-Macro to group all constants
-enum D2C_LangId
+enum D2C_Language
 {
-	D2LANG_ENG = 0x00,
-	D2LANG_ESP = 0x01,
-	D2LANG_GER = 0x02,
-	D2LANG_FRA = 0x03,
-	D2LANG_POR = 0x04,
-	D2LANG_ITA = 0x05,
-	D2LANG_JPN = 0x06,
-	D2LANG_KOR = 0x07,
-	D2LANG_POL = 0x0A,
+	LANGUAGE_ENGLISH = 0,
+	LANGUAGE_SPANISH = 1,
+	LANGUAGE_GERMAN = 2,
+	LANGUAGE_FRENCH = 3,
+	LANGUAGE_PORTUGUESE = 4,
+	LANGUAGE_ITALIAN = 5,
+	LANGUAGE_JAPANESE = 6,
+	LANGUAGE_KOREAN = 7,
+	// SIN = Simplified Chinese (for Singapore)
+	LANGUAGE_CHINESESIN = 8,
+	// CHI = Traditional Chinese (for Taiwan)
+	LANGUAGE_CHINESETWN = 9,
+	LANGUAGE_POLISH = 10,
+	LANGUAGE_RUSSIAN = 11,
+
+	// TODO: Unknown. Possibly English language for Korean systems?
+	LANGUAGE_ENGLISHKOR = 12,
+
+	NUM_LANGUAGE,
 };
 
 enum D2C_StringTablesHcidx


### PR DESCRIPTION
The values can be uncovered via the sgLocaleTable variable in the address range [6FC1D9F0 to 6FC1DB28).

The names for the enums have been changed to use full names, due to the assert string `"sgLocaleTable[0].eLanguage == LANGUAGE_ENGLISH"` in D2Lang.6FC1DEF8.

Enum names are replaced with English names for consistency. Previous naming would have switched between English naming, native language naming, Chinese for Traditional Chinese (for Taiwanese market), and Singapore for Simplified Chinese.