### PR TITLE
Implement Unicode::unicode2Win and Unicode::win2Unicode

### DIFF
--- a/source/D2Lang/CMakeLists.txt
+++ b/source/D2Lang/CMakeLists.txt
@@ -6,6 +6,7 @@ add_library(D2LangStatic
     src/D2Unicode/D2UnicodeChar.cpp
     src/D2Unicode/D2UnicodeStr.cpp
     src/D2Unicode/D2UnicodeUtf.cpp
+    src/D2Unicode/D2UnicodeWin.cpp
     src/D2StrTable.cpp
 
     include/D2Lang.h

--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -41,14 +41,14 @@ EXPORTS
     ?toUpper@Unicode@@QBE?AU1@XZ @10052 ; Unicode::toUpper
     ?toUtf@Unicode@@SIPADPADPBU1@H@Z @10053 ; Unicode::toUtf
 ;   D2LANG_10054 @10054 ; ?unicode2Sys@Unicode@@SIPADPADPBU1@H@Z
-;   D2LANG_10055 @10055 ; ?unicode2Win@Unicode@@SIPADPADPBU1@H@Z
+    ?unicode2Win@Unicode@@SIPADPADPBU1@H@Z @10055 ; Unicode::unicode2Win
 ;   D2LANG_10056 @10056 ; ?unicodeWidth@Unicode@@SIKPBDH@Z
 ;   D2LANG_10057 @10057 ; ?unicodenwidth@Unicode@@SIIPBDH@Z
 ;   D2LANG_10058 @10058 ; ?unloadSysMap@Unicode@@SIXXZ
 ;   D2LANG_10059 @10059 ; ?utf8ToUnicode@Unicode@@SIPAU1@PAU1@PBDH@Z
 ;   D2LANG_10060 @10060 ; ?utfnwidth@Unicode@@SIIPBU1@H@Z
 ;   D2LANG_10061 @10061 ; ?utfwidth@Unicode@@QBEHXZ
-;   D2LANG_10062 @10062 ; ?win2Unicode@Unicode@@SIPAU1@PAU1@PBDH@Z
+    ?win2Unicode@Unicode@@SIPAU1@PAU1@PBDH@Z @10062 ; Unicode::win2Unicode
 ;   D2LANG_10000 @10000 NONAME
 ;   D2LANG_10001 @10001 NONAME
 ;   D2LANG_10002 @10002 NONAME

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -1,5 +1,9 @@
 /**
- * Copyright (c) 2021 Mir Drualga
+ * D2MOO
+ * Copyright (c) 2020-2022  The Phrozen Keep community
+ *
+ * This file belongs to D2MOO.
+ * File authors: Mir Drualga
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -27,6 +31,7 @@
 #include <wchar.h>
 
 #include <D2BasicTypes.h>
+
 #include "D2Lang.h"
 
 /*
@@ -215,6 +220,19 @@ struct D2LANG_DLL_DECL Unicode {
 
   /**
    * Converts a null-terminated UCS-2 string into a null-terminated
+   * 7-bit ASCII string. The count indicates the capacity of the
+   * destination in terms of UCS-2 characters. Returns the pointer to
+   * the destination string.
+   *
+   * 1.00: D2Lang.0x1000109B (#10053)
+   * 1.10: D2Lang.0x6FC11C20 (#10055)
+   * ?unicode2Win@Unicode@@SIPADPADPBU1@H@Z
+   */
+  static char* __fastcall unicode2Win(
+      char* dest, const Unicode* src, int count);
+
+  /**
+   * Converts a null-terminated UCS-2 string into a null-terminated
    * UTF-8 string. The count indicates the capacity of the destination
    * in terms of UTF-8 code units. Returns the pointer to the
    * destination string.
@@ -229,6 +247,19 @@ struct D2LANG_DLL_DECL Unicode {
    * D2Lang.0x6FC12B60 (#10053) ?toUtf@Unicode@@SIPADPADPBU1@H@Z
    */
   static char* __fastcall toUtf(char* dest, const Unicode* src, int count);
+
+  /**
+   * Converts a null-terminated 7-bit ASCII string into a
+   * null-terminated UCS-2 string. The count indicates the capacity of
+   * the destination in terms of UCS-2 characters. Returns the pointer
+   * to the destination string.
+   *
+   * 1.00: D2Lang.0x10001122 (#10059)
+   * 1.10: D2Lang.0x6FC11BD0 (#10062)
+   * ?win2Unicode@Unicode@@SIPAU1@PAU1@PBDH@Z
+   */
+  static Unicode* __fastcall win2Unicode(
+      Unicode* dest, const char* src, int count);
 
   /**
    * Performs case insensitive comparison between this Unicode code

--- a/source/D2Lang/src/D2Unicode/D2UnicodeWin.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeWin.cpp
@@ -1,0 +1,83 @@
+/**
+ * D2MOO
+ * Copyright (c) 2020-2022  The Phrozen Keep community
+ *
+ * This file belongs to D2MOO.
+ * File authors: Mir Drualga
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "D2Unicode.h"
+
+
+/**
+ * This implementation outputs the same binary from 1.00 and 1.10.
+ *
+ * 1.00: D2Lang.0x1000109B (#10053)
+ * 1.10: D2Lang.0x6FC11C20 (#10055)
+ */
+char* __fastcall Unicode::unicode2Win(char* dest, const Unicode* src, int count)
+{
+	char* current_dest = dest;
+	while (count > 1 && src->ch != L'\0')
+	{
+		const Unicode* current_src = src++;
+		++current_dest;
+		--count;
+
+		*(current_dest - 1) = (char)current_src->ch;
+	}
+
+	*current_dest = '\0';
+	return dest;
+}
+
+/**
+ * This implementation outputs the same binary from 1.00.
+ *
+ * 1.00: D2Lang.0x10001122 (#10059)
+ * 1.10: D2Lang.0x6FC11BD0 (#10062)
+ */
+Unicode* __fastcall Unicode::win2Unicode(Unicode* dest, const char* src, int count)
+{
+	int i;
+	// Copy the source string as-is to the destination.
+	for (i = 0; i < count; ++i)
+	{
+		unsigned char src_ch = src[i];
+		if (src_ch == '\0')
+		{
+			break;
+		}
+		dest[i].ch = src_ch;
+	}
+
+	// Set the null-terminator.
+	if (src[i] != '\0')
+	{
+		dest[i - 1].ch = L'\0';
+		return dest;
+	}
+
+	dest[i].ch = L'\0';
+	return dest;
+}


### PR DESCRIPTION
These changes implement D2Lang.dll `Unicode::unicode2Win` and `Unicode::win2Unicode`. Both implementations are confirmed to produce the exact same binary as the functions from 1.00.