### PR TITLE
Implement Unicode::strncpy

### DIFF
--- a/source/D2Lang/definitions/D2Lang.1.10f.def
+++ b/source/D2Lang/definitions/D2Lang.1.10f.def
@@ -30,7 +30,7 @@ EXPORTS
     ?strncat@Unicode@@SIPAU1@PAU1@PBU1@H@Z @10041 ; Unicode::strncat
     ?strncmp@Unicode@@SIHPBU1@0I@Z @10042 ; Unicode::strncmp
 ;   D2LANG_10043 @10043 ; ?strncoll@Unicode@@SIHPBU1@0H@Z
-;   D2LANG_10044 @10044 ; ?strncpy@Unicode@@SIPAU1@PAU1@PBU1@H@Z
+    ?strncpy@Unicode@@SIPAU1@PAU1@PBU1@H@Z @10044 ; Unicode::strncpy
 ;   D2LANG_10045 @10045 ; ?strnicmp@Unicode@@SIHPBU1@0I@Z
     ?strstr@Unicode@@SIPAU1@PBU1@0@Z @10046 ; Unicode::strstr
 ;   D2LANG_10047 @10047 ; ?strstri@Unicode@@SIPAU1@PBU1@0@Z

--- a/source/D2Lang/include/D2Unicode.h
+++ b/source/D2Lang/include/D2Unicode.h
@@ -191,6 +191,22 @@ struct D2LANG_DLL_DECL Unicode {
       size_t count);
 
   /**
+   * Copies up to a specified count of characters from a
+   * null-terminated source string into a null-terminated destination
+   * string. If the count is greater than the length of the source
+   * string, then the remaining characters are filled with the null
+   * terminator character. Returns the destination string.
+   *
+   * 1.00: D2Lang.0x1000114A (#10042)
+   * 1.10: D2Lang.0x6FC11460 (#10044)
+   * 1.11: D2Lang.0x6FC0A900 (#10044)
+   * 1.13c: D2Lang.0x6FC0B0D0 (#10044)
+   * ?strncpy@Unicode@@SIPAU1@PAU1@PBU1@H@Z
+   */
+  static Unicode* __fastcall strncpy(
+      Unicode* dest, const Unicode* src, int count);
+
+  /**
    * Returns the first occurrence of a null-terminated substring in a
    * null-terminated string. If the substring is empty, or the
    * string does not contain the substring, then the function returns

--- a/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
+++ b/source/D2Lang/src/D2Unicode/D2UnicodeStr.cpp
@@ -1,5 +1,9 @@
 /**
- * Copyright (c) 2021 Mir Drualga
+ * D2MOO
+ * Copyright (c) 2020-2022  The Phrozen Keep community
+ *
+ * This file belongs to D2MOO.
+ * File authors: Mir Drualga, Lectem
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -309,6 +313,34 @@ int __fastcall Unicode::strncmp(
   }
 
   return 0;
+}
+
+/**
+ * This implementation outputs the same binary from 1.00.
+ *
+ * 1.00: D2Lang.0x1000114A (#10042)
+ * 1.10: D2Lang.0x6FC11460 (#10044)
+ * 1.11: D2Lang.0x6FC0A900 (#10044)
+ * 1.13c: D2Lang.0x6FC0B0D0 (#10044)
+ * ?strncpy@Unicode@@SIPAU1@PAU1@PBU1@H@Z
+ */
+Unicode* __fastcall Unicode::strncpy(
+    Unicode* dest, const Unicode* src, int count)
+{
+  // Copy src into dest, up to count characters.
+  Unicode* current_dest = dest;
+  for (; (count--) != 0 && src->ch != L'\0'; ++current_dest, ++src)
+  {
+    current_dest->ch = src->ch;
+  }
+
+  // Fill remaining characters as null-terminator.
+  for (; count != -1; ++current_dest, --count)
+  {
+    current_dest->ch = L'\0';
+  }
+
+  return dest;
 }
 
 Unicode* __fastcall Unicode::strstr(

--- a/source/D2Lang/tests/D2LangTests.cpp
+++ b/source/D2Lang/tests/D2LangTests.cpp
@@ -351,6 +351,46 @@ TEST_CASE("Unicode::strncmp")
     }
 }
 
+TEST_CASE("Unicode::strncpy")
+{
+    SUBCASE("Empty onto empty")
+    {
+        Unicode dest[256];
+        CHECK(Unicode::strncpy(dest, D2_USTR(L""), 1) == dest);
+        CHECK(wcscmp((wchar_t*)dest, L"") == 0);
+    }
+    SUBCASE("Empty onto non-empty")
+    {
+        Unicode dest[256] = { L'D', L'i', L'a', L'b', L'l', L'o' };
+        CHECK(Unicode::strncpy(dest, D2_USTR(L""), 7) == dest);
+        CHECK(wmemcmp((wchar_t*)dest, L"\0\0\0\0\0\0", 7) == 0);
+    }
+    SUBCASE("Text onto empty")
+    {
+        Unicode dest[256];
+        CHECK(Unicode::strncpy(dest, D2_USTR(L"Diablo"), 7) == dest);
+        CHECK(wcscmp((wchar_t*)dest, L"Diablo") == 0);
+    }
+    SUBCASE("Text overfill onto empty")
+    {
+        Unicode dest[256];
+        CHECK(Unicode::strncpy(dest, D2_USTR(L"Diablo"), 13) == dest);
+        CHECK(wcscmp((wchar_t*)dest, L"Diablo\0\0\0\0\0\0") == 0);
+    }
+    SUBCASE("Text onto non-empty")
+    {
+        Unicode dest[256] = { L'D', L'i', L'a', L'b', L'l', L'o' };
+        CHECK(Unicode::strncpy(dest, D2_USTR(L"Baal"), 5) == dest);
+        CHECK(wcscmp((wchar_t*)dest, L"Baal") == 0);
+    }
+    SUBCASE("Text overfill onto non-empty")
+    {
+        Unicode dest[256] = { L'D', L'i', L'a', L'b', L'l', L'o' };
+        CHECK(Unicode::strncpy(dest, D2_USTR(L"Baal"), 9) == dest);
+        CHECK(wcscmp((wchar_t*)dest, L"Baal\0\0\0\0") == 0);
+    }
+}
+
 TEST_CASE("Unicode::strlen")
 {
     SUBCASE("Empty")


### PR DESCRIPTION
These changes add D2Lang.dll `Unicode::strncpy` function. This function implementation allows VC6 to generate the exact same binary output as 1.00. Test cases are included.

Attached are VC6 binary files for confirmation.

[Unicode::strcpy.zip](https://github.com/ThePhrozenKeep/D2MOO/files/10313581/Unicode.strcpy.zip)
