### PR TITLE
Implement D2CMP functions in Count.cpp

### DIFF
--- a/source/D2CMP/CMakeLists.txt
+++ b/source/D2CMP/CMakeLists.txt
@@ -50,4 +50,4 @@ target_include_directories(D2CMP PUBLIC include)
 
 target_compile_definitions(D2CMP PRIVATE D2CMP_IMPL)
 
-target_link_libraries(D2CMP PUBLIC D2CommonDefinitions)
+target_link_libraries(D2CMP PUBLIC D2CommonDefinitions Fog)

--- a/source/D2CMP/include/Count.h
+++ b/source/D2CMP/include/Count.h
@@ -1,2 +1,69 @@
-#pragma once 
-#include <D2BasicTypes.h> 
+/**
+ * D2MOO
+ * Copyright (c) 2020-2023  The Phrozen Keep community
+ *
+ * This file belongs to D2MOO.
+ * File authors: Mir Drualga
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <windows.h>
+
+/**
+ * Returns the count of consecutive bytes that are equal to the first
+ * byte in pSrc, up to nMaxCount bytes. Also sets pbCountEqualsDist if
+ * the count equals the distance from pSrc to pEnd, and
+ * pbIsRemainingSame if all remaining bytes after nMaxCount are the
+ * same as bValue.
+ *
+ * 1.00: D2CMP.0x100085D0
+ * 1.07 Beta: D2CMPd.0x6FC7DA50
+ * 1.07: Inline or unused
+ * 1.10: Inline or unused
+ */
+int __fastcall CountConsecutiveFirst(const BYTE* pSrc, const BYTE* pEnd, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame);
+
+/**
+ * Returns the count of consecutive bytes that are equal to bValue, up
+ * to nMaxCount bytes. Also sets pbCountEqualsDist if the count equals
+ * the distance from pSrc to pEnd, and pbIsRemainingSame if all
+ * remaining bytes after nMaxCount are the same as bValue.
+ *
+ * 1.00: D2CMP.0x10008730
+ * 1.07 Beta: D2CMPd.0x6FC7DBE0
+ * 1.07: D2CMP.0x6FE15FE0
+ * 1.10: D2CMP.0x6FDF5AF0
+ */
+int __fastcall CountConsecutive(BYTE bValue, const BYTE* pSrc, const BYTE* pEnd, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame);
+
+/**
+ * Returns the count of consecutive bytes that are not equal to
+ * bValue, up to nMaxCount bytes. Also sets pbCountEqualsDist if the
+ * count equals the distance from pSrc to pEnd, and pbIsRemainingSame
+ * if all remaining bytes after nMaxCount are the same as bValue.
+ *
+ * 1.00: D2CMP.0x10008730
+ * 1.07 Beta: D2CMPd.0x6FC7DD70
+ * 1.07: D2CMP.0x6FE16060
+ * 1.10: D2CMP.0x6FDF5B70
+ */
+int __fastcall CountConsecutiveDiff(const BYTE* pSrc, const BYTE* pEnd, BYTE bValue, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame);

--- a/source/D2CMP/include/Count.h
+++ b/source/D2CMP/include/Count.h
@@ -31,7 +31,7 @@
 /**
  * Returns the count of consecutive bytes that are equal to the first
  * byte in pSrc, up to nMaxCount bytes. Also sets pbCountEqualsDist if
- * the count equals the distance from pSrc to pEnd, and
+ * the count equals the distance from pSrc to pEnd, or
  * pbIsRemainingSame if all remaining bytes after nMaxCount are the
  * same as bValue.
  *
@@ -45,7 +45,7 @@ int __fastcall CountConsecutiveFirst(const BYTE* pSrc, const BYTE* pEnd, int nMa
 /**
  * Returns the count of consecutive bytes that are equal to bValue, up
  * to nMaxCount bytes. Also sets pbCountEqualsDist if the count equals
- * the distance from pSrc to pEnd, and pbIsRemainingSame if all
+ * the distance from pSrc to pEnd, or pbIsRemainingSame if all
  * remaining bytes after nMaxCount are the same as bValue.
  *
  * 1.00: D2CMP.0x10008730
@@ -58,7 +58,7 @@ int __fastcall CountConsecutive(BYTE bValue, const BYTE* pSrc, const BYTE* pEnd,
 /**
  * Returns the count of consecutive bytes that are not equal to
  * bValue, up to nMaxCount bytes. Also sets pbCountEqualsDist if the
- * count equals the distance from pSrc to pEnd, and pbIsRemainingSame
+ * count equals the distance from pSrc to pEnd, or pbIsRemainingSame
  * if all remaining bytes after nMaxCount are the same as bValue.
  *
  * 1.00: D2CMP.0x10008730

--- a/source/D2CMP/src/Count.cpp
+++ b/source/D2CMP/src/Count.cpp
@@ -44,11 +44,7 @@
  */
 int __fastcall CountConsecutiveFirst(const BYTE* pSrc, const BYTE* pEnd, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame)
 {
-	if (pSrc >= pEnd)
-	{
-		FOG_DisplayAssert("pSrc < pEnd", __FILE__, __LINE__);
-		exit(-1);
-	}
+	D2_ASSERT("pSrc < pEnd");
 
 	BYTE bFirst = pSrc[0];
 	int nCount;
@@ -85,11 +81,7 @@ int __fastcall CountConsecutiveFirst(const BYTE* pSrc, const BYTE* pEnd, int nMa
  */
 int __fastcall CountConsecutive(BYTE bValue, const BYTE* pSrc, const BYTE* pEnd, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame)
 {
-	if (pSrc >= pEnd)
-	{
-		FOG_DisplayAssert("pSrc < pEnd", __FILE__, __LINE__);
-		exit(-1);
-	}
+	D2_ASSERT("pSrc < pEnd");
 
 	int nCount;
 	for (nCount = 0; pSrc < pEnd && bValue == *pSrc && nCount < nMaxCount; ++pSrc, ++nCount) {}
@@ -126,11 +118,7 @@ int __fastcall CountConsecutive(BYTE bValue, const BYTE* pSrc, const BYTE* pEnd,
  */
 int __fastcall CountConsecutiveDiff(const BYTE* pSrc, const BYTE* pEnd, BYTE bValue, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame)
 {
-	if (pSrc >= pEnd)
-	{
-		FOG_DisplayAssert("pSrc < pEnd", __FILE__, __LINE__);
-		exit(-1);
-	}
+	D2_ASSERT("pSrc < pEnd");
 
 	int nCount;
 	for (nCount = 0; pSrc < pEnd && *pSrc != bValue && nCount < nMaxCount; ++pSrc, ++nCount) {}

--- a/source/D2CMP/src/Count.cpp
+++ b/source/D2CMP/src/Count.cpp
@@ -1,1 +1,157 @@
-#include "Count.h" 
+/**
+ * D2MOO
+ * Copyright (c) 2020-2023  The Phrozen Keep community
+ *
+ * This file belongs to D2MOO.
+ * File authors: Mir Drualga
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "Count.h"
+
+#include <windows.h>
+
+#include <cstdlib>
+
+#include "Fog.h"
+
+/**
+ * 1.00: D2CMP.0x100085D0
+ * 1.07 Beta: D2CMPd.0x6FC7DA50
+ * 1.07: Inline or unused
+ * 1.10: Inline or unused
+ *
+ * This implementation outputs effectively the same binary from 1.00.
+ */
+int __fastcall CountConsecutiveFirst(const BYTE* pSrc, const BYTE* pEnd, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame)
+{
+	if (pSrc >= pEnd)
+	{
+		FOG_DisplayAssert("pSrc < pEnd", __FILE__, __LINE__);
+		exit(-1);
+	}
+
+	BYTE bFirst = pSrc[0];
+	int nCount;
+	for (nCount = 0; pSrc < pEnd && bFirst == *pSrc && nCount < nMaxCount; ++pSrc, ++nCount) {}
+	if (pSrc == pEnd)
+	{
+		*pbCountEqualsDist = TRUE;
+		*pbIsRemainingSame = FALSE;
+		return nCount;
+	}
+
+	*pbCountEqualsDist = FALSE;
+	for (; pSrc < pEnd && bFirst == *pSrc; ++pSrc) {}
+
+	if (pSrc == pEnd)
+	{
+		*pbIsRemainingSame = TRUE;
+	}
+	else
+	{
+		*pbIsRemainingSame = FALSE;
+	}
+	return nCount;
+}
+
+/**
+ * 1.00: D2CMP.0x10008730
+ * 1.07 Beta: D2CMPd.0x6FC7DBE0
+ * 1.07: D2CMP.0x6FE15FE0
+ * 1.10: D2CMP.0x6FDF5AF0
+ *
+ * This implementation outputs effectively the same binary from 1.00, 1.07,
+ * and 1.10.
+ */
+int __fastcall CountConsecutive(BYTE bValue, const BYTE* pSrc, const BYTE* pEnd, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame)
+{
+	if (pSrc >= pEnd)
+	{
+		FOG_DisplayAssert("pSrc < pEnd", __FILE__, __LINE__);
+		exit(-1);
+	}
+
+	int nCount;
+	for (nCount = 0; pSrc < pEnd && bValue == *pSrc && nCount < nMaxCount; ++pSrc, ++nCount) {}
+	if (pSrc == pEnd)
+	{
+		*pbCountEqualsDist = TRUE;
+		*pbIsRemainingSame = FALSE;
+		return nCount;
+	}
+
+	*pbCountEqualsDist = FALSE;
+	for (; pSrc < pEnd && bValue == *pSrc; ++pSrc) {}
+
+	if (pSrc == pEnd)
+	{
+		*pbIsRemainingSame = TRUE;
+	}
+	else
+	{
+		*pbIsRemainingSame = FALSE;
+	}
+
+	return nCount;
+}
+
+/**
+ * 1.00: D2CMP.0x10008730
+ * 1.07 Beta: D2CMPd.0x6FC7DD70
+ * 1.07: D2CMP.0x6FE16060
+ * 1.10: D2CMP.0x6FDF5B70
+ *
+ * This implementation outputs effectively the same binary from 1.00, 1.07,
+ * and 1.10.
+ */
+int __fastcall CountConsecutiveDiff(const BYTE* pSrc, const BYTE* pEnd, BYTE bValue, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame)
+{
+	if (pSrc >= pEnd)
+	{
+		FOG_DisplayAssert("pSrc < pEnd", __FILE__, __LINE__);
+		exit(-1);
+	}
+
+	int nCount;
+	for (nCount = 0; pSrc < pEnd && *pSrc != bValue && nCount < nMaxCount; ++pSrc, ++nCount) {}
+	if (pSrc == pEnd)
+	{
+		*pbCountEqualsDist = TRUE;
+		*pbIsRemainingSame = FALSE;
+		return nCount;
+	}
+
+	*pbCountEqualsDist = FALSE;
+	for (; pSrc < pEnd && bValue == *pSrc; ++pSrc) {}
+
+	if (pSrc == pEnd)
+	{
+		*pbIsRemainingSame = TRUE;
+	}
+	else
+	{
+		*pbIsRemainingSame = FALSE;
+	}
+
+	return nCount;
+}

--- a/source/D2CMP/src/Count.cpp
+++ b/source/D2CMP/src/Count.cpp
@@ -44,30 +44,7 @@
  */
 int __fastcall CountConsecutiveFirst(const BYTE* pSrc, const BYTE* pEnd, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame)
 {
-	D2_ASSERT("pSrc < pEnd");
-
-	BYTE bFirst = pSrc[0];
-	int nCount;
-	for (nCount = 0; pSrc < pEnd && bFirst == *pSrc && nCount < nMaxCount; ++pSrc, ++nCount) {}
-	if (pSrc == pEnd)
-	{
-		*pbCountEqualsDist = TRUE;
-		*pbIsRemainingSame = FALSE;
-		return nCount;
-	}
-
-	*pbCountEqualsDist = FALSE;
-	for (; pSrc < pEnd && bFirst == *pSrc; ++pSrc) {}
-
-	if (pSrc == pEnd)
-	{
-		*pbIsRemainingSame = TRUE;
-	}
-	else
-	{
-		*pbIsRemainingSame = FALSE;
-	}
-	return nCount;
+	return CountConsecutive(pSrc[0], pSrc, pEnd, nMaxCount, pbCountEqualsDist, pbIsRemainingSame);
 }
 
 /**
@@ -81,7 +58,7 @@ int __fastcall CountConsecutiveFirst(const BYTE* pSrc, const BYTE* pEnd, int nMa
  */
 int __fastcall CountConsecutive(BYTE bValue, const BYTE* pSrc, const BYTE* pEnd, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame)
 {
-	D2_ASSERT("pSrc < pEnd");
+	D2_ASSERT(pSrc < pEnd);
 
 	int nCount;
 	for (nCount = 0; pSrc < pEnd && bValue == *pSrc && nCount < nMaxCount; ++pSrc, ++nCount) {}
@@ -118,7 +95,7 @@ int __fastcall CountConsecutive(BYTE bValue, const BYTE* pSrc, const BYTE* pEnd,
  */
 int __fastcall CountConsecutiveDiff(const BYTE* pSrc, const BYTE* pEnd, BYTE bValue, int nMaxCount, BOOL* pbCountEqualsDist, BOOL* pbIsRemainingSame)
 {
-	D2_ASSERT("pSrc < pEnd");
+	D2_ASSERT(pSrc < pEnd);
 
 	int nCount;
 	for (nCount = 0; pSrc < pEnd && *pSrc != bValue && nCount < nMaxCount; ++pSrc, ++nCount) {}


### PR DESCRIPTION
These changes implement the D2CMP functions in Count.cpp. VC6 has been confirmed to output effectively the same binary as 1.00, 1.07, and 1.10 in release mode.

Attached are output files from VC6.
[D2CMP.Count.cpp.zip](https://github.com/ThePhrozenKeep/D2MOO/files/10390956/D2CMP.Count.cpp.zip)
