### PR TITLE
Fix ChestEnd to set flags to untargettable

### DIFF
--- a/source/D2Game/src/OBJECTS/ObjMode.cpp
+++ b/source/D2Game/src/OBJECTS/ObjMode.cpp
@@ -1241,7 +1241,7 @@ __forceinline void __fastcall OBJECTS_ChestEnd(D2ObjOperateFnStrc* pOp, int32_t 
         UNITS_ChangeAnimMode(pOp->pObject, OBJMODE_OPENED);
     }
 
-    pOp->pObject->dwFlags &= UNITFLAG_TARGETABLE;
+    pOp->pObject->dwFlags &= ~UNITFLAG_TARGETABLE;
 
     if (pOp->pObject->dwDropItemCode)
     {


### PR DESCRIPTION
As far as I can tell, this should be negative the targetable flag, i.e., making the chest no longer useable. 