### PR TITLE
Collision mask functions

### DIFF
--- a/D2.Detours.patches/1.10f/D2Common.patch.cpp
+++ b/D2.Detours.patches/1.10f/D2Common.patch.cpp
@@ -174,7 +174,7 @@ static PatchAction patchActions[GetOrdinalCount()] = {
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetMaskWithSize                                           @10128
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetMaskWithSizeXY                                         @10129
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetMaskWithPattern                                        @10130
-    PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_10131                                                      @10131
+    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_TryMoveUnitPresenceMask                                   @10131
     PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_10132                                                      @10132
     PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_10133                                                      @10133
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_GetFreeCoordinates                                        @10134

--- a/D2.Detours.patches/1.10f/D2Common.patch.cpp
+++ b/D2.Detours.patches/1.10f/D2Common.patch.cpp
@@ -1080,7 +1080,7 @@ static PatchAction patchActions[GetOrdinalCount()] = {
     PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_11034                                                      @11034
     PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_11035                                                      @11035
     PatchAction::FunctionReplacePatchByOriginal,       //   D2COMMON_11036_GetMonCurseResistanceSubtraction                     @11036
-    PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_11037                                                      @11037
+    PatchAction::FunctionReplacePatchByOriginal,       //   SKILLS_CheckIfCanLeapTo                                             @11037
     PatchAction::Ignore,                         /*C*/ //; ------------------------UNUSED------------------------               @11038
     PatchAction::FunctionReplacePatchByOriginal,       //   D2COMMON_11039_CheckWeaponIsMissileBased                            @11039
     PatchAction::FunctionReplacePatchByOriginal,       //   SKILLS_IsEnhanceable                                                @11040

--- a/D2.Detours.patches/1.10f/D2Common.patch.cpp
+++ b/D2.Detours.patches/1.10f/D2Common.patch.cpp
@@ -164,8 +164,8 @@ static PatchAction patchActions[GetOrdinalCount()] = {
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMask                                                 @10118
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithSize                                         @10119
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithSizeXY                                       @10120
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithPattern                                     @10121
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckAnyCollisionWithPattern                                     @10122
+    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithPattern                                      @10121
+    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckAnyCollisionWithPattern                              @10122
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_ResetMask                                                 @10123
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_ResetMaskWithSize                                         @10124
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_ResetMaskWithSizeXY                                       @10125
@@ -174,9 +174,9 @@ static PatchAction patchActions[GetOrdinalCount()] = {
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetMaskWithSize                                           @10128
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetMaskWithSizeXY                                         @10129
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetMaskWithPattern                                        @10130
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_TryMoveUnitPresenceMask                                   @10131
-    PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_10132                                                      @10132
-    PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_10133                                                      @10133
+    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_TryMoveUnitCollisionMask                                  @10131
+    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_TryTeleportUnitCollisionMask                              @10132
+    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetUnitCollisionMask                                      @10133
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_GetFreeCoordinates                                        @10134
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_GetFreeCoordinatesWithMaxDistance                         @10135
     PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_10136                                                      @10136

--- a/D2.Detours.patches/1.10f/D2Common.patch.cpp
+++ b/D2.Detours.patches/1.10f/D2Common.patch.cpp
@@ -1325,7 +1325,7 @@ static PatchAction patchActions[GetOrdinalCount()] = {
     PatchAction::FunctionReplacePatchByOriginal,       //   UNITROOM_AddUnitToRoomEx                                            @11279
     PatchAction::FunctionReplacePatchByOriginal,       //   MONSTERS_GetSpawnMode_XY                                            @11280
     PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_11281_CollisionPatternFromSize                                               @11281
-    PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_11282_Unused                                               @11282
+    PatchAction::FunctionReplacePatchByOriginal,       //   PATH_GetCollisionPatternFromMonStats2Txt                            @11282
     PatchAction::FunctionReplacePatchByOriginal,       //   SKILLS_CalculateKickDamage                                          @11283
     PatchAction::FunctionReplacePatchByOriginal,       //   MISSILE_EvaluateMissileFormula                                      @11284
     PatchAction::FunctionReplacePatchByOriginal,       //   MISSILE_GetMinDamage                                                @11285

--- a/D2.Detours.patches/1.10f/D2Common.patch.cpp
+++ b/D2.Detours.patches/1.10f/D2Common.patch.cpp
@@ -164,8 +164,8 @@ static PatchAction patchActions[GetOrdinalCount()] = {
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMask                                                 @10118
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithSize                                         @10119
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithSizeXY                                       @10120
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithPattern1                                     @10121
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithPattern2                                     @10122
+    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithPattern                                     @10121
+    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckAnyCollisionWithPattern                                     @10122
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_ResetMask                                                 @10123
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_ResetMaskWithSize                                         @10124
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_ResetMaskWithSizeXY                                       @10125

--- a/D2.Detours.patches/1.10f/D2Common.patch.cpp
+++ b/D2.Detours.patches/1.10f/D2Common.patch.cpp
@@ -161,22 +161,22 @@ static PatchAction patchActions[GetOrdinalCount()] = {
     PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   DUNGEON_GameToClientTileDrawPositionCoords                          @10115
     PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   DUNGEON_ClientSubileDrawPositionToGameCoords                        @10116
     PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   DUNGEON_GameToClientSubtileDrawPositionCoords                       @10117
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMask                                                 @10118
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithSize                                         @10119
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithSizeXY                                       @10120
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckMaskWithPattern                                      @10121
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_CheckAnyCollisionWithPattern                              @10122
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_ResetMask                                                 @10123
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_ResetMaskWithSize                                         @10124
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_ResetMaskWithSizeXY                                       @10125
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_ResetMaskWithPattern                                      @10126
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetMask                                                   @10127
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetMaskWithSize                                           @10128
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetMaskWithSizeXY                                         @10129
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetMaskWithPattern                                        @10130
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_TryMoveUnitCollisionMask                                  @10131
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_TryTeleportUnitCollisionMask                              @10132
-    PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_SetUnitCollisionMask                                      @10133
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_CheckMask                                                 @10118
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_CheckMaskWithSize                                         @10119
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_CheckMaskWithSizeXY                                       @10120
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_CheckMaskWithPattern                                      @10121
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_CheckAnyCollisionWithPattern                              @10122
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_ResetMask                                                 @10123
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_ResetMaskWithSize                                         @10124
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_ResetMaskWithSizeXY                                       @10125
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_ResetMaskWithPattern                                      @10126
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_SetMask                                                   @10127
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_SetMaskWithSize                                           @10128
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_SetMaskWithSizeXY                                         @10129
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_SetMaskWithPattern                                        @10130
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_TryMoveUnitCollisionMask                                  @10131
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_TryTeleportUnitCollisionMask                              @10132
+    PatchAction::FunctionReplaceOriginalByPatch, /*C*/ //   COLLISION_SetUnitCollisionMask                                      @10133
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_GetFreeCoordinates                                        @10134
     PatchAction::FunctionReplacePatchByOriginal,       //   COLLISION_GetFreeCoordinatesWithMaxDistance                         @10135
     PatchAction::FunctionReplacePatchByOriginal,       //   D2Common_10136                                                      @10136

--- a/source/D2Common/definitions/D2Common.1.10f.def
+++ b/source/D2Common/definitions/D2Common.1.10f.def
@@ -131,7 +131,7 @@ EXPORTS
 	COLLISION_SetMaskWithSize											@10128
 	COLLISION_SetMaskWithSizeXY											@10129
 	COLLISION_SetMaskWithPattern										@10130
-	D2Common_10131														@10131
+	COLLISION_TryMoveUnitPresenceMask									@10131
 	D2Common_10132														@10132
 	D2Common_10133														@10133
 	COLLISION_GetFreeCoordinates										@10134

--- a/source/D2Common/definitions/D2Common.1.10f.def
+++ b/source/D2Common/definitions/D2Common.1.10f.def
@@ -121,8 +121,8 @@ EXPORTS
 	COLLISION_CheckMask													@10118
 	COLLISION_CheckMaskWithSize											@10119
 	COLLISION_CheckMaskWithSizeXY										@10120
-	COLLISION_CheckMaskWithPattern1										@10121
-	COLLISION_CheckMaskWithPattern2										@10122
+	COLLISION_CheckMaskWithPattern										@10121
+	COLLISION_CheckAnyCollisionWithPattern								@10122
 	COLLISION_ResetMask													@10123
 	COLLISION_ResetMaskWithSize											@10124
 	COLLISION_ResetMaskWithSizeXY										@10125

--- a/source/D2Common/definitions/D2Common.1.10f.def
+++ b/source/D2Common/definitions/D2Common.1.10f.def
@@ -1037,7 +1037,7 @@ EXPORTS
 	D2Common_11034														@11034
 	D2Common_11035														@11035
 	D2COMMON_11036_GetMonCurseResistanceSubtraction						@11036
-	D2Common_11037														@11037
+	SKILLS_CheckIfCanLeapTo												@11037
 ;------------------------UNUSED------------------------						@11038
 	D2COMMON_11039_CheckWeaponIsMissileBased							@11039
 	SKILLS_IsEnhanceable												@11040

--- a/source/D2Common/definitions/D2Common.1.10f.def
+++ b/source/D2Common/definitions/D2Common.1.10f.def
@@ -131,9 +131,9 @@ EXPORTS
 	COLLISION_SetMaskWithSize											@10128
 	COLLISION_SetMaskWithSizeXY											@10129
 	COLLISION_SetMaskWithPattern										@10130
-	COLLISION_TryMoveUnitPresenceMask									@10131
-	D2Common_10132														@10132
-	D2Common_10133														@10133
+	COLLISION_TryMoveUnitCollisionMask									@10131
+	COLLISION_TryTeleportUnitCollisionMask								@10132
+	COLLISION_SetUnitCollisionMask										@10133
 	COLLISION_GetFreeCoordinates										@10134
 	COLLISION_GetFreeCoordinatesWithMaxDistance							@10135
 	D2Common_10136														@10136

--- a/source/D2Common/definitions/D2Common.1.10f.def
+++ b/source/D2Common/definitions/D2Common.1.10f.def
@@ -1282,7 +1282,7 @@ EXPORTS
 	UNITROOM_AddUnitToRoomEx											@11279
 	MONSTERS_GetSpawnMode_XY											@11280
 	D2Common_11281_CollisionPatternFromSize								@11281
-	D2Common_11282_Unused												@11282
+	PATH_GetCollisionPatternFromMonStats2Txt							@11282
 	SKILLS_CalculateKickDamage											@11283
 	MISSILE_EvaluateMissileFormula										@11284
 	MISSILE_GetMinDamage												@11285

--- a/source/D2Common/include/D2Collision.h
+++ b/source/D2Common/include/D2Collision.h
@@ -132,7 +132,7 @@ D2COMMON_DLL_DECL void __stdcall COLLISION_SetMaskWithSizeXY(D2RoomStrc* pRoom, 
 //D2Common.0x6FD44600
 void __fastcall COLLISION_SetCollisionMaskForBoundingBox(D2RoomCollisionGridStrc* pCollisionGrid, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask);
 //D2Common.0x6FD44660 (#10131)
-D2COMMON_DLL_DECL uint16_t __fastcall D2Common_10131(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nCollisionPattern, int nCollisionType, uint16_t nMask);
+D2COMMON_DLL_DECL uint16_t __fastcall COLLISION_TryMoveUnitPresenceMask(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nCollisionPattern, uint16_t nPresenceMask, uint16_t nCollisionMask);
 //D2Common.0x6FD44910
 void __fastcall COLLISION_CreateBoundingBox(D2BoundingBoxStrc* pBoundingBox, int nCenterX, int nCenterY, unsigned int nSizeX, unsigned int nSizeY);
 //D2Common.0x6FD44950 (#10132)

--- a/source/D2Common/include/D2Collision.h
+++ b/source/D2Common/include/D2Collision.h
@@ -34,6 +34,7 @@ enum D2C_CollisionFlags : uint32_t
 	COLLIDE_4000 = 0x4000,
 	COLLIDE_CORPSE = 0x8000,				// also used by portals, but dead monsters are mask 0x8000
 	COLLIDE_ALL_MASK = 0xFFFFFFFF,
+	COLLIDE_MASK_WALKING_UNIT = COLLIDE_BLOCK_PLAYER | COLLIDE_BLOCK_LEAP | COLLIDE_OBJECT | COLLIDE_DOOR | COLLIDE_UNIT_RELATED,
 };
 
 struct D2RoomCollisionGridStrc

--- a/source/D2Common/include/D2Collision.h
+++ b/source/D2Common/include/D2Collision.h
@@ -93,17 +93,18 @@ int __fastcall COLLISION_AdaptBoundingBoxToGrid(D2RoomStrc* pRoom, D2BoundingBox
 //D2Common.0x6FD41CA0
 uint16_t __fastcall COLLISION_CheckCollisionMaskForBoundingBoxRecursively(D2RoomStrc* pRoom, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask);
 //D2Common.0x6FD41DE0 (#10121)
-D2COMMON_DLL_DECL uint16_t __stdcall COLLISION_CheckMaskWithPattern1(D2RoomStrc* pRoom, int nX, int nY, int nCollisionPattern, uint16_t nMask);
+D2COMMON_DLL_DECL uint16_t __stdcall COLLISION_CheckMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY, int nCollisionPattern, uint16_t nMask);
 //D2Common.0x6FD42000
 uint16_t __fastcall COLLISION_CheckCollisionMaskWithAdjacentCells(D2RoomStrc* pRoom, int nX, int nY, uint16_t nMask);
 //D2Common.0x6FD42670
 uint16_t __fastcall COLLISION_CheckCollisionMask(D2RoomStrc* pRoom, int nX, int nY, uint16_t nMask);
 //D2Common.0x6FD42740 (#10122)
-D2COMMON_DLL_DECL int __stdcall COLLISION_CheckMaskWithPattern2(D2RoomStrc* pRoom, int nX, int nY, int nCollisionPattern, uint16_t nMask);
+D2COMMON_DLL_DECL int __stdcall COLLISION_CheckAnyCollisionWithPattern(D2RoomStrc* pRoom, int nX, int nY, int nCollisionPattern, uint16_t nMask);
 //D2Common.0x6FD428D0
-int __fastcall sub_6FD428D0(D2RoomStrc* pRoom, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask);
+// Faster than COLLISION_CheckCollisionMaskForBoundingBoxRecursively since can stop as soon as a collision is found.
+BOOL __fastcall COLLISION_CheckAnyCollisionForBoundingBoxRecursively(D2RoomStrc* pRoom, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask);
 //D2Common.0x6FD42A30
-int __fastcall sub_6FD42A30(D2RoomStrc* pRoom, int nX, int nY, uint16_t nMask);
+BOOL __fastcall COLLISION_CheckAnyCollisionWithAdjacentCells(D2RoomStrc* pRoom, int nX, int nY, uint16_t nMask);
 //D2Common.0x6FD43080 (#10119)
 D2COMMON_DLL_DECL uint16_t __stdcall COLLISION_CheckMaskWithSize(D2RoomStrc* pRoom, int nX, int nY, int nUnitSize, uint16_t nMask);
 //D2Common.0x6FD432A0 (#10128)

--- a/source/D2Common/include/D2Collision.h
+++ b/source/D2Common/include/D2Collision.h
@@ -35,7 +35,7 @@ enum D2C_CollisionPattern
 	COLLISION_PATTERN_SMALL_NO_PRESENCE   = 5,
 };
 
-enum D2C_CollisionFlags : uint32_t
+enum D2C_CollisionFlags : uint16_t
 {
 	COLLIDE_NONE = 0x0000,
 	COLLIDE_BLOCK_PLAYER = 0x0001,			// 'black space' in arcane sanctuary, cliff walls etc
@@ -51,10 +51,11 @@ enum D2C_CollisionFlags : uint32_t
 	COLLIDE_OBJECT = 0x0400,
 	COLLIDE_DOOR = 0x0800,
 	COLLIDE_UNIT_RELATED = 0x1000,			// set for units sometimes, but not always
-	COLLIDE_PET = 0x2000,
+	COLLIDE_PET = 0x2000,					// linked to whether a monster that may be attacked is present
 	COLLIDE_4000 = 0x4000,
 	COLLIDE_CORPSE = 0x8000,				// also used by portals, but dead monsters are mask 0x8000
-	COLLIDE_ALL_MASK = 0xFFFFFFFF,
+	COLLIDE_ALL_MASK = 0xFFFF,
+	COLLIDE_INVALID = (COLLIDE_BLANK | COLLIDE_WALL | COLLIDE_BLOCK_MISSILE | COLLIDE_BLOCK_PLAYER),
 	COLLIDE_MASK_WALKING_UNIT = COLLIDE_BLOCK_PLAYER | COLLIDE_BLOCK_LEAP | COLLIDE_OBJECT | COLLIDE_DOOR | COLLIDE_UNIT_RELATED,
 };
 

--- a/source/D2Common/include/D2Collision.h
+++ b/source/D2Common/include/D2Collision.h
@@ -14,6 +14,27 @@ struct D2BoundingBoxStrc
 	int32_t nTop;								//0x0C
 };
 
+// Size of the unit in subtiles
+enum D2C_CollisionUnitSize
+{
+	COLLISION_UNIT_SIZE_NONE  = 0,
+	COLLISION_UNIT_SIZE_POINT = 1, // Occupies 1 subtile in width
+	COLLISION_UNIT_SIZE_SMALL = 2, // Occupies 2 subtiles in width
+	COLLISION_UNIT_SIZE_BIG   = 3, // Occupies 3 subtiles in width
+	COLLISION_UNIT_SIZE_COUNT
+};
+
+enum D2C_CollisionPattern
+{
+	COLLISION_PATTERN_NONE = 0,
+	COLLISION_PATTERN_SMALL_UNIT_PRESENCE = 1,
+	COLLISION_PATTERN_BIG_UNIT_PRESENCE = 2,
+	// Actually linked to whether a monster may be attacked?
+	COLLISION_PATTERN_SMALL_PET_PRESENCE  = 3,
+	COLLISION_PATTERN_BIG_PET_PRESENCE    = 4,
+	COLLISION_PATTERN_SMALL_NO_PRESENCE   = 5,
+};
+
 enum D2C_CollisionFlags : uint32_t
 {
 	COLLIDE_NONE = 0x0000,

--- a/source/D2Common/include/D2Collision.h
+++ b/source/D2Common/include/D2Collision.h
@@ -132,19 +132,19 @@ D2COMMON_DLL_DECL void __stdcall COLLISION_SetMaskWithSizeXY(D2RoomStrc* pRoom, 
 //D2Common.0x6FD44600
 void __fastcall COLLISION_SetCollisionMaskForBoundingBox(D2RoomCollisionGridStrc* pCollisionGrid, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask);
 //D2Common.0x6FD44660 (#10131)
-D2COMMON_DLL_DECL uint16_t __fastcall COLLISION_TryMoveUnitPresenceMask(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nCollisionPattern, uint16_t nPresenceMask, uint16_t nCollisionMask);
+D2COMMON_DLL_DECL uint16_t __fastcall COLLISION_TryMoveUnitCollisionMask(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nUnitSize, uint16_t nCollisionMask, uint16_t nMoveConditionMask);
 //D2Common.0x6FD44910
 void __fastcall COLLISION_CreateBoundingBox(D2BoundingBoxStrc* pBoundingBox, int nCenterX, int nCenterY, unsigned int nSizeX, unsigned int nSizeY);
 //D2Common.0x6FD44950 (#10132)
-D2COMMON_DLL_DECL uint16_t __fastcall D2Common_10132(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nCollisionPattern, int nCollisionType, uint16_t nMask);
+D2COMMON_DLL_DECL uint16_t __fastcall COLLISION_TryTeleportUnitCollisionMask(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nCollisionPattern, uint16_t nCollisionMask, uint16_t nMoveConditionMask);
 //D2Common.0x6FD44BB0
-uint16_t __fastcall sub_6FD44BB0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nCollisionPattern, uint16_t nMask1, uint16_t nMask2);
+uint16_t __fastcall COLLISION_ForceTeleportUnitCollisionMaskAndGetCollision(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nUnitSize, uint16_t nCollisionMask, uint16_t nMoveConditionMask);
 //D2Common.0x6FD44E00
-uint16_t __fastcall sub_6FD44E00(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nCollisionPattern, uint16_t nMask);
+uint16_t __fastcall COLLISION_TeleportUnitCollisionMask(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nUnitSize, uint16_t nMask);
 //D2Common.0x6FD44FF0
-int __fastcall sub_6FD44FF0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nCollisionPattern, int nCollisionType, uint16_t nMask);
+int __fastcall COLLISION_TrySetUnitCollisionMask(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nCollisionPattern, uint16_t nCollisionMask, uint16_t nMoveConditionMask);
 //D2Common.0x6FD451D0 (#10133)
-D2COMMON_DLL_DECL void __fastcall D2Common_10133(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nCollisionPattern, int nCollisionType);
+D2COMMON_DLL_DECL void __fastcall COLLISION_SetUnitCollisionMask(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nCollisionPattern, uint16_t nCollisionMask);
 //D2Common.0x6FD45210 (#11263)
 //Returns true if a collision with mask was found. pEndCoord will be set to the collision location.
 D2COMMON_DLL_DECL BOOL __stdcall COLLISION_RayTrace(D2RoomStrc* pRoom, D2CoordStrc* pBeginCoord, D2CoordStrc* pEndCoord, uint16_t nCollisionMask);

--- a/source/D2Common/include/D2Skills.h
+++ b/source/D2Common/include/D2Skills.h
@@ -358,7 +358,7 @@ D2COMMON_DLL_DECL int __stdcall D2Common_11035(int nLevel, int nSkillId);
 //D2Common.0x6FDB3C20 (#11036)
 D2COMMON_DLL_DECL int __stdcall D2COMMON_11036_GetMonCurseResistanceSubtraction(int nLevel, int nSkillId);
 //D2Common.0x6FDB3CB0 (#11037)
-D2COMMON_DLL_DECL BOOL __stdcall D2Common_11037(D2UnitStrc* pUnit1, D2UnitStrc* pUnit2, int* pX, int* pY);
+D2COMMON_DLL_DECL BOOL __stdcall SKILLS_CheckIfCanLeapTo(D2UnitStrc* pUnit1, D2UnitStrc* pUnit2, int* pX, int* pY);
 //D2Common.0x6FDB3F60 (#11039)
 D2COMMON_DLL_DECL int __stdcall D2COMMON_11039_CheckWeaponIsMissileBased(D2UnitStrc* pUnit, int* pValue);
 //D2Common.0x6FDB4020 (#11040)

--- a/source/D2Common/include/DataTbls/SkillsTbls.h
+++ b/source/D2Common/include/DataTbls/SkillsTbls.h
@@ -94,6 +94,15 @@ enum D2C_SkillsTxtFlags
 	SKILLSFLAG2_WARP = (1 << SKILLSFLAGINDEX2_WARP),
 };
 
+// Targeting behaviour when skill is cast by object
+enum D2C_SkillsTxtItemTarget {
+	SKILLSITEMTARGET_ATTACKER = 0, // default
+	SKILLSITEMTARGET_CASTER = 1,
+	SKILLSITEMTARGET_RANDOM = 2, // Random walkable location in a radius of size 20
+	SKILLSITEMTARGET_RANDOM_CORPSE = 3,
+	SKILLSITEMTARGET_LAST_ATTACKER = 4, // Attacker or last known attacker
+};
+
 struct D2SkillCalcTxt
 {
 	uint32_t dwCode;						//0x00
@@ -209,7 +218,7 @@ struct D2SkillsTxt
 	uint16_t wCltOverlayA;					//0x110
 	uint16_t wCltOverlayB;					//0x112
 	int32_t dwCltCalc[3];					//0x114
-	uint8_t nItemTarget;					//0x120
+	uint8_t nItemTarget;					//0x120 D2C_SkillsTxtItemTarget
 	uint8_t pad0x121;						//0x121
 	uint16_t wItemCastSound;				//0x122
 	uint16_t wItemCastOverlay;				//0x124

--- a/source/D2Common/include/Path/Path.h
+++ b/source/D2Common/include/Path/Path.h
@@ -213,7 +213,7 @@ uint8_t __fastcall sub_6FDA90C0(D2PathInfoStrc* pPathInfo);
 //D2Common.0x6FDA9190 (#10156)
 D2COMMON_DLL_DECL void __stdcall PATH_FreeDynamicPath(void* pMemPool, D2DynamicPathStrc* pDynamicPath);
 //D2Common.0x6FDA91B0 (#11282)
-D2COMMON_DLL_DECL int __stdcall D2Common_11282_Unused(int nMonsterId);
+D2COMMON_DLL_DECL int __stdcall PATH_GetCollisionPatternFromMonStats2Txt(int nMonsterId);
 //D2Common.0x6FDA9250 (#11281)
 D2COMMON_DLL_DECL int __stdcall D2Common_11281_CollisionPatternFromSize(D2UnitStrc* pUnit, int nSize);
 //D2Common.0x6FDA92F0 (#10214)

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -1106,34 +1106,18 @@ void __stdcall COLLISION_ResetMaskWithSizeXY(D2RoomStrc* pRoom, int nX, int nY, 
 //D2Common.0x6FD44370
 void __fastcall COLLISION_ResetCollisionMaskForBoundingBox(D2RoomCollisionGridStrc* pCollisionGrid, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask)
 {
-	uint16_t* pCollisionMask = NULL;
-	int nX = 0;
-	int nY = 0;
+	const int32_t boxWidth = pBoundingBox->nRight - pBoundingBox->nLeft + 1;
+	const int32_t boxHeight = pBoundingBox->nTop - pBoundingBox->nBottom + 1;
+	const int32_t nCollisionMaskBeginX = pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft;
+	const int32_t nCollisionMaskBeginY = pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop;
 
-	pCollisionMask = &pCollisionGrid->pCollisionMask[(pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + (pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop) * pCollisionGrid->pRoomCoords.dwSubtilesWidth];
-
-	if (pBoundingBox->nBottom <= pBoundingBox->nTop)
+	uint16_t* pCollisionMaskLine = &pCollisionGrid->pCollisionMask[nCollisionMaskBeginX + nCollisionMaskBeginY * pCollisionGrid->pRoomCoords.dwSubtilesWidth];
+	for (int y = 0; y < boxHeight; y++)
 	{
-		nY = (pBoundingBox->nTop - pCollisionGrid->pRoomCoords.dwSubtilesTop) - (pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop) + 1;
-		do
-		{
-			if (pBoundingBox->nLeft <= pBoundingBox->nRight)
-			{
-				nX = (pBoundingBox->nRight - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - (pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + 1;
-				do
-				{
-					*pCollisionMask &= ~nMask;
-					++pCollisionMask;
-
-					--nX;
-				}
-				while (nX);
-			}
-			pCollisionMask += pCollisionGrid->pRoomCoords.dwSubtilesWidth + (pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - (pBoundingBox->nRight - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - 1;
-
-			--nY;
+		for (int x = 0; x < boxWidth; x++) {
+			pCollisionMaskLine[x] &= ~nMask;
 		}
-		while (nY);
+		pCollisionMaskLine += pCollisionGrid->pRoomCoords.dwSubtilesWidth;
 	}
 }
 

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -988,18 +988,12 @@ void __fastcall COLLISION_ResetCollisionMask(D2RoomStrc* pRoom, int nX, int nY, 
 //D2Common.0x6FD43CE0
 void __fastcall COLLISION_ResetCollisionMaskForBoundingBoxRecursively(D2RoomStrc* pRoom, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask)
 {
-	D2RoomCollisionGridStrc* pCollisionGrid = NULL;
-	int nBoundingBoxes = 0;
-	D2BoundingBoxStrc pBoundingBoxes[3] = {};
-
-	pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, pBoundingBox->nLeft, pBoundingBox->nBottom);
-
-	if (pRoom)
+	if (pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, pBoundingBox->nLeft, pBoundingBox->nBottom))
 	{
-		pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom);
-		if (pCollisionGrid)
+		if (D2RoomCollisionGridStrc* pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom))
 		{
-			nBoundingBoxes = COLLISION_AdaptBoundingBoxToGrid(pRoom, pBoundingBox, pBoundingBoxes);
+			D2BoundingBoxStrc pBoundingBoxes[3] = {};
+			int nBoundingBoxes = COLLISION_AdaptBoundingBoxToGrid(pRoom, pBoundingBox, pBoundingBoxes);
 			if (nBoundingBoxes > 0)
 			{
 				COLLISION_ResetCollisionMaskForBoundingBox(pCollisionGrid, &pBoundingBoxes[0], nMask);

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -1140,34 +1140,18 @@ void __stdcall COLLISION_SetMaskWithSizeXY(D2RoomStrc* pRoom, int nX, int nY, un
 //D2Common.0x6FD44600
 void __fastcall COLLISION_SetCollisionMaskForBoundingBox(D2RoomCollisionGridStrc* pCollisionGrid, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask)
 {
-	uint16_t* pCollisionMask = NULL;
-	int nX = 0;
-	int nY = 0;
+	const int32_t boxWidth = pBoundingBox->nRight - pBoundingBox->nLeft + 1;
+	const int32_t boxHeight = pBoundingBox->nTop - pBoundingBox->nBottom + 1;
+	const int32_t nCollisionMaskBeginX = pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft;
+	const int32_t nCollisionMaskBeginY = pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop;
 
-	pCollisionMask = &pCollisionGrid->pCollisionMask[(pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + (pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop) * pCollisionGrid->pRoomCoords.dwSubtilesWidth];
-
-	if (pBoundingBox->nBottom <= pBoundingBox->nTop)
+	uint16_t* pCollisionMaskLine = &pCollisionGrid->pCollisionMask[nCollisionMaskBeginX + nCollisionMaskBeginY * pCollisionGrid->pRoomCoords.dwSubtilesWidth];
+	for (int y = 0; y < boxHeight; y++)
 	{
-		nY = (pBoundingBox->nTop - pCollisionGrid->pRoomCoords.dwSubtilesTop) - (pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop) + 1;
-		do
-		{
-			if (pBoundingBox->nLeft <= pBoundingBox->nRight)
-			{
-				nX = (pBoundingBox->nRight - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - (pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + 1;
-				do
-				{
-					*pCollisionMask |= nMask;
-					++pCollisionMask;
-
-					--nX;
-				}
-				while (nX);
-			}
-
-			pCollisionMask += pCollisionGrid->pRoomCoords.dwSubtilesWidth + (pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - (pBoundingBox->nRight - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - 1;
-			--nY;
+		for (int x = 0; x < boxWidth; x++) {
+			pCollisionMaskLine[x] |= nMask;
 		}
-		while (nY);
+		pCollisionMaskLine += pCollisionGrid->pRoomCoords.dwSubtilesWidth;
 	}
 }
 

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -349,36 +349,21 @@ uint16_t __stdcall COLLISION_CheckMaskWithSizeXY(D2RoomStrc* pRoom, int nX, int 
 //D2Common.0x6FD41B40
 uint16_t __fastcall COLLISION_CheckCollisionMaskForBoundingBox(D2RoomCollisionGridStrc* pCollisionGrid, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask)
 {
-	uint16_t* pCollisionMask = &pCollisionGrid->pCollisionMask[(pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + (pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop) * pCollisionGrid->pRoomCoords.dwSubtilesWidth];
-
-	if (pBoundingBox->nBottom <= pBoundingBox->nTop)
+	const int32_t boxWidth = pBoundingBox->nRight - pBoundingBox->nLeft + 1;
+	const int32_t boxHeight = pBoundingBox->nTop - pBoundingBox->nBottom + 1;
+	const int32_t nCollisionMaskBeginX = pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft;
+	const int32_t nCollisionMaskBeginY = pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop;
+	
+	uint16_t nResult = 0;
+	const uint16_t* pCollisionMaskLine = &pCollisionGrid->pCollisionMask[nCollisionMaskBeginX + nCollisionMaskBeginY * pCollisionGrid->pRoomCoords.dwSubtilesWidth];
+	for (int y = 0; y < boxHeight; y++)
 	{
-		uint16_t nResult = 0;
-		int nY = (pBoundingBox->nTop - pCollisionGrid->pRoomCoords.dwSubtilesTop) - (pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop) + 1;
-		do
-		{
-			if (pBoundingBox->nLeft <= pBoundingBox->nRight)
-			{
-				int nX = (pBoundingBox->nRight - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - (pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + 1;
-				do
-				{
-					nResult |= (*pCollisionMask) & nMask;
-					++pCollisionMask;
-
-					--nX;
-				}
-				while (nX);
-			}
-			pCollisionMask += pCollisionGrid->pRoomCoords.dwSubtilesWidth + (pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - (pBoundingBox->nRight - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - 1;
-
-			--nY;
+		for (int x = 0; x < boxWidth; x++) {
+			nResult |= pCollisionMaskLine[x] & nMask;
 		}
-		while (nY);
-
-		return nResult;
+		pCollisionMaskLine += pCollisionGrid->pRoomCoords.dwSubtilesWidth;
 	}
-
-	return 0;
+	return nResult;
 }
 
 //D2Common.0x6FD41BE0

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -463,7 +463,7 @@ uint16_t __fastcall COLLISION_CheckCollisionMaskForBoundingBoxRecursively(D2Room
 		}
 	}
 
-	return (COLLIDE_BLANK | COLLIDE_WALL | COLLIDE_BLOCK_MISSILE | COLLIDE_BLOCK_PLAYER);
+	return COLLIDE_INVALID;
 }
 
 //D2Common.0x6FD41DE0 (#10121)
@@ -585,7 +585,7 @@ uint16_t __fastcall COLLISION_CheckCollisionMask(D2RoomStrc* pRoom, int nX, int 
 		}
 	}
 
-	return (COLLIDE_BLANK | COLLIDE_WALL | COLLIDE_BLOCK_MISSILE | COLLIDE_BLOCK_PLAYER);
+	return COLLIDE_INVALID;
 }
 
 //D2Common.0x6FD42740 (#10122)

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -584,38 +584,27 @@ int __stdcall COLLISION_CheckAnyCollisionWithPattern(D2RoomStrc* pRoom, int nX, 
 //D2Common.0x6FD428D0
 BOOL __fastcall COLLISION_CheckAnyCollisionForBoundingBoxRecursively(D2RoomStrc* pRoom, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask)
 {
-	D2RoomCollisionGridStrc* pCollisionGrid = NULL;
-	int nBoundingBoxes = 0;
-	D2BoundingBoxStrc pBoundingBoxes[3] = {};
-
-	pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, pBoundingBox->nLeft, pBoundingBox->nBottom);
-
-	if (!pRoom)
+	if (pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, pBoundingBox->nLeft, pBoundingBox->nBottom))
 	{
-		return TRUE;
-	}
-
-	pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom);
-	if (!pCollisionGrid)
-	{
-		return TRUE;
-	}
-
-	nBoundingBoxes = COLLISION_AdaptBoundingBoxToGrid(pRoom, pBoundingBox, pBoundingBoxes);
-	if (nBoundingBoxes <= 0 || COLLISION_CheckCollisionMaskForBoundingBox(pCollisionGrid, &pBoundingBoxes[0], nMask))
-	{
-		return TRUE;
-	}
-
-	for (int i = 1; i < nBoundingBoxes; ++i)
-	{
-		if (COLLISION_CheckAnyCollisionForBoundingBoxRecursively(pRoom, &pBoundingBoxes[i], nMask))
+		if (D2RoomCollisionGridStrc* pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom))
 		{
-			return TRUE;
+			D2BoundingBoxStrc pBoundingBoxes[3] = {};
+			int nBoundingBoxes = COLLISION_AdaptBoundingBoxToGrid(pRoom, pBoundingBox, pBoundingBoxes);
+			if (nBoundingBoxes > 0 && COLLISION_CheckCollisionMaskForBoundingBox(pCollisionGrid, &pBoundingBoxes[0], nMask) == 0)
+			{
+				for (int i = 1; i < nBoundingBoxes; ++i)
+				{
+					if(COLLISION_CheckAnyCollisionForBoundingBoxRecursively(pRoom, &pBoundingBoxes[i], nMask) != 0)
+					{
+						return TRUE;
+					}
+				}
+				// No collision found!
+				return FALSE;
+			}
 		}
 	}
-
-	return FALSE;
+	return TRUE;
 }
 
 //D2Common.0x6FD42A30

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -349,21 +349,17 @@ uint16_t __stdcall COLLISION_CheckMaskWithSizeXY(D2RoomStrc* pRoom, int nX, int 
 //D2Common.0x6FD41B40
 uint16_t __fastcall COLLISION_CheckCollisionMaskForBoundingBox(D2RoomCollisionGridStrc* pCollisionGrid, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask)
 {
-	uint16_t* pCollisionMask = 0;
-	uint16_t nResult = 0;
-	int nX = 0;
-	int nY = 0;
-
-	pCollisionMask = &pCollisionGrid->pCollisionMask[(pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + (pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop) * pCollisionGrid->pRoomCoords.dwSubtilesWidth];
+	uint16_t* pCollisionMask = &pCollisionGrid->pCollisionMask[(pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + (pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop) * pCollisionGrid->pRoomCoords.dwSubtilesWidth];
 
 	if (pBoundingBox->nBottom <= pBoundingBox->nTop)
 	{
-		nY = (pBoundingBox->nTop - pCollisionGrid->pRoomCoords.dwSubtilesTop) - (pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop) + 1;
+		uint16_t nResult = 0;
+		int nY = (pBoundingBox->nTop - pCollisionGrid->pRoomCoords.dwSubtilesTop) - (pBoundingBox->nBottom - pCollisionGrid->pRoomCoords.dwSubtilesTop) + 1;
 		do
 		{
 			if (pBoundingBox->nLeft <= pBoundingBox->nRight)
 			{
-				nX = (pBoundingBox->nRight - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - (pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + 1;
+				int nX = (pBoundingBox->nRight - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - (pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + 1;
 				do
 				{
 					*pCollisionMask &= nMask;
@@ -436,22 +432,15 @@ int __fastcall COLLISION_AdaptBoundingBoxToGrid(D2RoomStrc* pRoom, D2BoundingBox
 //D2Common.0x6FD41CA0
 uint16_t __fastcall COLLISION_CheckCollisionMaskForBoundingBoxRecursively(D2RoomStrc* pRoom, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask)
 {
-	D2RoomCollisionGridStrc* pCollisionGrid = NULL;
-	int nBoundingBoxes = 0;
-	uint16_t nResult = 0;
-	D2BoundingBoxStrc pBoundingBoxes[3] = {};
-
-	pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, pBoundingBox->nLeft, pBoundingBox->nBottom);
-
-	if (pRoom)
+	if (pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, pBoundingBox->nLeft, pBoundingBox->nBottom))
 	{
-		pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom);
-		if (pCollisionGrid)
+		if (D2RoomCollisionGridStrc* pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom))
 		{
-			nBoundingBoxes = COLLISION_AdaptBoundingBoxToGrid(pRoom, pBoundingBox, pBoundingBoxes);
+			D2BoundingBoxStrc pBoundingBoxes[3] = {};
+			int nBoundingBoxes = COLLISION_AdaptBoundingBoxToGrid(pRoom, pBoundingBox, pBoundingBoxes);
 			if (nBoundingBoxes > 0)
 			{
-				nResult = COLLISION_CheckCollisionMaskForBoundingBox(pCollisionGrid, &pBoundingBoxes[0], nMask);
+				uint16_t nResult = COLLISION_CheckCollisionMaskForBoundingBox(pCollisionGrid, &pBoundingBoxes[0], nMask);
 
 				for (int i = 1; i < nBoundingBoxes; ++i)
 				{
@@ -572,13 +561,9 @@ uint16_t __fastcall COLLISION_CheckCollisionMaskWithAdjacentCells(D2RoomStrc* pR
 //D2Common.0x6FD42670
 uint16_t __fastcall COLLISION_CheckCollisionMask(D2RoomStrc* pRoom, int nX, int nY, uint16_t nMask)
 {
-	D2RoomCollisionGridStrc* pCollisionGrid = NULL;
-
-	pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, nX, nY);
-
-	if (pRoom)
+	if (pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, nX, nY))
 	{
-		pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom);
+		D2RoomCollisionGridStrc* pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom);
 		if (pCollisionGrid && pCollisionGrid->pCollisionMask)
 		{
 			return pCollisionGrid->pCollisionMask[nX + pCollisionGrid->pRoomCoords.dwSubtilesWidth * (nY - pCollisionGrid->pRoomCoords.dwSubtilesTop) - pCollisionGrid->pRoomCoords.dwSubtilesLeft] & nMask;

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -362,8 +362,7 @@ uint16_t __fastcall COLLISION_CheckCollisionMaskForBoundingBox(D2RoomCollisionGr
 				int nX = (pBoundingBox->nRight - pCollisionGrid->pRoomCoords.dwSubtilesLeft) - (pBoundingBox->nLeft - pCollisionGrid->pRoomCoords.dwSubtilesLeft) + 1;
 				do
 				{
-					*pCollisionMask &= nMask;
-					nResult |= *pCollisionMask;
+					nResult |= (*pCollisionMask) & nMask;
 					++pCollisionMask;
 
 					--nX;

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -1146,56 +1146,22 @@ void __fastcall COLLISION_SetCollisionMaskForBoundingBox(D2RoomCollisionGridStrc
 }
 
 //D2Common.0x6FD44660 (#10131)
-uint16_t __fastcall D2Common_10131(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nUnitSize, int nCollisionType, uint16_t nMask)
+uint16_t __fastcall COLLISION_TryMoveUnitPresenceMask(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nUnitSize, uint16_t nPresenceMask, uint16_t nCollisionMask)
 {
-	D2BoundingBoxStrc pBoundingBox = {};
-	uint16_t v10 = 0;
+	COLLISION_ResetMaskWithSize(pRoom, nX1, nY1, nUnitSize, nPresenceMask);
+	
+	const uint16_t nDestinationCollisionMask = COLLISION_CheckMaskWithSize(pRoom, nX2, nY2, nUnitSize, nCollisionMask);
 
-	if (pRoom)
+	if (nDestinationCollisionMask & (COLLIDE_BLOCK_PLAYER|COLLIDE_WALL))
 	{
-		switch (nUnitSize)
-		{
-		case COLLISION_UNIT_SIZE_NONE:
-			break;
-		
-		case COLLISION_UNIT_SIZE_POINT:
-			COLLISION_ResetCollisionMask(pRoom, nX1, nY1, nCollisionType);
-			break;
-
-		case COLLISION_UNIT_SIZE_SMALL:
-			COLLISION_ResetCollisionMask(pRoom, nX1 - 1, nY1, nCollisionType);
-			COLLISION_ResetCollisionMask(pRoom, nX1, nY1, nCollisionType);
-			COLLISION_ResetCollisionMask(pRoom, nX1 + 1, nY1, nCollisionType);
-			COLLISION_ResetCollisionMask(pRoom, nX1, nY1 - 1, nCollisionType);
-			COLLISION_ResetCollisionMask(pRoom, nX1, nY1 + 1, nCollisionType);
-			break;
-
-		case COLLISION_UNIT_SIZE_BIG:
-			COLLISION_CreateBoundingBox(&pBoundingBox, nX1, nY1, 3, 3);
-			COLLISION_ResetCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nCollisionType);
-			break;
-
-		default:
-			break;
-		}
-
-		v10 = COLLISION_CheckMaskWithSize(pRoom, nX2, nY2, nUnitSize, nMask);
+		COLLISION_SetMaskWithSize(pRoom, nX1, nY1, nUnitSize, nPresenceMask);
 	}
 	else
 	{
-		v10 = COLLISION_CheckMaskWithSize(pRoom, nX2, nY2, nUnitSize, nMask);
+		COLLISION_SetMaskWithSize(pRoom, nX2, nY2, nUnitSize, nPresenceMask);
 	}
 
-	if (v10 & 5)
-	{
-		COLLISION_SetMaskWithSize(pRoom, nX1, nY1, nUnitSize, nCollisionType);
-	}
-	else
-	{
-		COLLISION_SetMaskWithSize(pRoom, nX2, nY2, nUnitSize, nCollisionType);
-	}
-
-	return v10;
+	return nDestinationCollisionMask;
 }
 
 //D2Common.0x6FD44910

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -837,18 +837,12 @@ void __fastcall COLLISION_SetCollisionMask(D2RoomStrc* pRoom, int nX, int nY, ui
 //D2Common.0x6FD43580
 void __fastcall COLLISION_SetCollisionMaskForBoundingBoxRecursively(D2RoomStrc* pRoom, D2BoundingBoxStrc* pBoundingBox, uint16_t nMask)
 {
-	D2RoomCollisionGridStrc* pCollisionGrid = NULL;
-	int nBoundingBoxes = 0;
-	D2BoundingBoxStrc pBoundingBoxes[3] = {};
-
-	pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, pBoundingBox->nLeft, pBoundingBox->nBottom);
-
-	if (pRoom)
+	if (pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, pBoundingBox->nLeft, pBoundingBox->nBottom))
 	{
-		pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom);
-		if (pCollisionGrid)
+		if (D2RoomCollisionGridStrc* pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom))
 		{
-			nBoundingBoxes = COLLISION_AdaptBoundingBoxToGrid(pRoom, pBoundingBox, pBoundingBoxes);
+			D2BoundingBoxStrc pBoundingBoxes[3] = {};
+			int nBoundingBoxes = COLLISION_AdaptBoundingBoxToGrid(pRoom, pBoundingBox, pBoundingBoxes);
 			if (nBoundingBoxes > 0)
 			{
 				COLLISION_SetCollisionMaskForBoundingBox(pCollisionGrid, &pBoundingBoxes[0], nMask);

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -474,21 +474,21 @@ uint16_t __stdcall COLLISION_CheckMaskWithPattern1(D2RoomStrc* pRoom, int nX, in
 
 	switch (nCollisionPattern)
 	{
-	case 0:
+	case COLLISION_PATTERN_NONE:
 		return COLLISION_CheckCollisionMask(pRoom, nX, nY, nMask);
 
-	case 1:
-	case 3:
-	case 5:
+	case COLLISION_PATTERN_SMALL_UNIT_PRESENCE:
+	case COLLISION_PATTERN_SMALL_PET_PRESENCE:
+	case COLLISION_PATTERN_SMALL_NO_PRESENCE:
 		return COLLISION_CheckCollisionMaskWithAdjacentCells(pRoom, nX, nY, nMask);
 
-	case 2:
-	case 4:
+	case COLLISION_PATTERN_BIG_UNIT_PRESENCE:
+	case COLLISION_PATTERN_BIG_PET_PRESENCE:
 		COLLISION_CreateBoundingBox(&pBoundingBox, nX, nY, 3, 3);
 		return COLLISION_CheckCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nMask);
 
 	default:
-		return -1;
+		return COLLIDE_ALL_MASK;
 	}
 }
 
@@ -596,21 +596,19 @@ int __stdcall COLLISION_CheckMaskWithPattern2(D2RoomStrc* pRoom, int nX, int nY,
 
 	switch (nCollisionPattern)
 	{
-	case 0:
+	case COLLISION_PATTERN_NONE:
 		return COLLISION_CheckMask(pRoom, nX, nY, nMask);
 
-	case 1:
-	case 3:
+	case COLLISION_PATTERN_SMALL_UNIT_PRESENCE:
+	case COLLISION_PATTERN_SMALL_PET_PRESENCE:
+	case COLLISION_PATTERN_SMALL_NO_PRESENCE:
 		return sub_6FD42A30(pRoom, nX, nY, nMask);
 
-	case 2:
-	case 4:
+	case COLLISION_PATTERN_BIG_UNIT_PRESENCE:
+	case COLLISION_PATTERN_BIG_PET_PRESENCE:
 		COLLISION_CreateBoundingBox(&pBoundingBox, nX, nY, 3, 3);
 		return sub_6FD428D0(pRoom, &pBoundingBox, nMask);
 
-	case 5:
-		return sub_6FD42A30(pRoom, nX, nY, nMask);
-	
 	default:
 		return 1;
 	}
@@ -822,14 +820,14 @@ uint16_t __stdcall COLLISION_CheckMaskWithSize(D2RoomStrc* pRoom, int nX, int nY
 
 	switch (nUnitSize)
 	{
-	case 0:
-	case 1:
+	case COLLISION_UNIT_SIZE_NONE:
+	case COLLISION_UNIT_SIZE_POINT:
 		return COLLISION_CheckCollisionMask(pRoom, nX, nY, nMask);
 
-	case 2:
+	case COLLISION_UNIT_SIZE_SMALL:
 		return COLLISION_CheckCollisionMaskWithAdjacentCells(pRoom, nX, nY, nMask);
 
-	case 3:
+	case COLLISION_UNIT_SIZE_BIG:
 		COLLISION_CreateBoundingBox(&pBoundingBox, nX, nY, 3, 3);
 		return COLLISION_CheckCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nMask);
 
@@ -845,11 +843,11 @@ void __stdcall COLLISION_SetMaskWithSize(D2RoomStrc* pRoom, int nX, int nY, int 
 
 	switch (nUnitSize)
 	{
-	case 1:
+	case COLLISION_UNIT_SIZE_POINT:
 		COLLISION_SetCollisionMask(pRoom, nX, nY, nMask);
 		break;
 
-	case 2:
+	case COLLISION_UNIT_SIZE_SMALL:
 		COLLISION_SetCollisionMask(pRoom, nX - 1, nY, nMask);
 		COLLISION_SetCollisionMask(pRoom, nX, nY, nMask);
 		COLLISION_SetCollisionMask(pRoom, nX + 1, nY, nMask);
@@ -857,7 +855,7 @@ void __stdcall COLLISION_SetMaskWithSize(D2RoomStrc* pRoom, int nX, int nY, int 
 		COLLISION_SetCollisionMask(pRoom, nX, nY + 1, nMask);
 		break;
 
-	case 3:
+	case COLLISION_UNIT_SIZE_BIG:
 		COLLISION_CreateBoundingBox(&pBoundingBox, nX, nY, 3, 3);
 		COLLISION_SetCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nMask);
 		break;
@@ -870,13 +868,9 @@ void __stdcall COLLISION_SetMaskWithSize(D2RoomStrc* pRoom, int nX, int nY, int 
 //D2Common.0x6FD434B0
 void __fastcall COLLISION_SetCollisionMask(D2RoomStrc* pRoom, int nX, int nY, uint16_t nMask)
 {
-	D2RoomCollisionGridStrc* pCollisionGrid = NULL;
-
-	pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, nX, nY);
-
-	if (pRoom)
+	if (pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, nX, nY))
 	{
-		pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom);
+		D2RoomCollisionGridStrc* pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom);
 		if (pCollisionGrid && pCollisionGrid->pCollisionMask)
 		{
 			pCollisionGrid->pCollisionMask[nX + pCollisionGrid->pRoomCoords.dwSubtilesWidth * (nY - pCollisionGrid->pRoomCoords.dwSubtilesTop) - pCollisionGrid->pRoomCoords.dwSubtilesLeft] |= nMask;
@@ -921,7 +915,7 @@ void __stdcall COLLISION_SetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY, i
 
 	switch (nCollisionPattern)
 	{
-	case 1:
+	case COLLISION_PATTERN_SMALL_UNIT_PRESENCE:
 		COLLISION_SetCollisionMask(pRoom, nX - 1, nY, nMask);
 		COLLISION_SetCollisionMask(pRoom, nX, nY, nMask);
 		COLLISION_SetCollisionMask(pRoom, nX + 1, nY, nMask);
@@ -934,7 +928,7 @@ void __stdcall COLLISION_SetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY, i
 		}
 		break;
 
-	case 2:
+	case COLLISION_PATTERN_BIG_UNIT_PRESENCE:
 		COLLISION_CreateBoundingBox(&pBoundingBox, nX, nY, 3, 3);
 		COLLISION_SetCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nMask);
 
@@ -948,7 +942,7 @@ void __stdcall COLLISION_SetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY, i
 		}
 		break;
 
-	case 3:
+	case COLLISION_PATTERN_SMALL_PET_PRESENCE:
 		COLLISION_SetCollisionMask(pRoom, nX - 1, nY, nMask);
 		COLLISION_SetCollisionMask(pRoom, nX, nY, nMask);
 		COLLISION_SetCollisionMask(pRoom, nX + 1, nY, nMask);
@@ -969,7 +963,7 @@ void __stdcall COLLISION_SetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY, i
 		}
 		break;
 
-	case 4:
+	case COLLISION_PATTERN_BIG_PET_PRESENCE:
 		COLLISION_CreateBoundingBox(&pBoundingBox, nX, nY, 3, 3);
 		COLLISION_SetCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nMask);
 
@@ -983,7 +977,7 @@ void __stdcall COLLISION_SetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY, i
 		}
 		break;
 
-	case 5:
+	case COLLISION_PATTERN_SMALL_NO_PRESENCE:
 		COLLISION_SetCollisionMask(pRoom, nX - 1, nY, nMask);
 		COLLISION_SetCollisionMask(pRoom, nX, nY, nMask);
 		COLLISION_SetCollisionMask(pRoom, nX + 1, nY, nMask);
@@ -1031,13 +1025,9 @@ void __stdcall COLLISION_ResetMaskWithSize(D2RoomStrc* pRoom, int nX, int nY, in
 //D2Common.0x6FD43C10
 void __fastcall COLLISION_ResetCollisionMask(D2RoomStrc* pRoom, int nX, int nY, uint16_t nMask)
 {
-	D2RoomCollisionGridStrc* pCollisionGrid = NULL;
-
-	pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, nX, nY);
-
-	if (pRoom)
+	if (pRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, nX, nY))
 	{
-		pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom);
+		D2RoomCollisionGridStrc* pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pRoom);
 		if (pCollisionGrid && pCollisionGrid->pCollisionMask)
 		{
 			pCollisionGrid->pCollisionMask[nX + pCollisionGrid->pRoomCoords.dwSubtilesWidth * (nY - pCollisionGrid->pRoomCoords.dwSubtilesTop) - pCollisionGrid->pRoomCoords.dwSubtilesLeft] &= ~nMask;
@@ -1082,7 +1072,7 @@ void __stdcall COLLISION_ResetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY,
 	{
 		switch (nCollisionPattern)
 		{
-		case 1:
+		case COLLISION_PATTERN_SMALL_UNIT_PRESENCE:
 			COLLISION_ResetCollisionMask(pRoom, nX - 1, nY, nMask);
 			COLLISION_ResetCollisionMask(pRoom, nX, nY, nMask);
 			COLLISION_ResetCollisionMask(pRoom, nX + 1, nY, nMask);
@@ -1095,7 +1085,7 @@ void __stdcall COLLISION_ResetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY,
 			}
 			break;
 
-		case 2:
+		case COLLISION_PATTERN_BIG_UNIT_PRESENCE:
 			COLLISION_CreateBoundingBox(&pBoundingBox, nX, nY, 3, 3);
 			COLLISION_ResetCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nMask);
 
@@ -1109,7 +1099,7 @@ void __stdcall COLLISION_ResetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY,
 			}
 			break;
 
-		case 3:
+		case COLLISION_PATTERN_SMALL_PET_PRESENCE:
 			COLLISION_ResetCollisionMask(pRoom, nX - 1, nY, nMask);
 			COLLISION_ResetCollisionMask(pRoom, nX, nY, nMask);
 			COLLISION_ResetCollisionMask(pRoom, nX + 1, nY, nMask);
@@ -1122,7 +1112,7 @@ void __stdcall COLLISION_ResetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY,
 			}
 			break;
 
-		case 4:
+		case COLLISION_PATTERN_BIG_PET_PRESENCE:
 			COLLISION_CreateBoundingBox(&pBoundingBox, nX, nY, 3, 3);
 			COLLISION_ResetCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nMask);
 
@@ -1136,7 +1126,7 @@ void __stdcall COLLISION_ResetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY,
 			}
 			break;
 
-		case 5:
+		case COLLISION_PATTERN_SMALL_NO_PRESENCE:
 			COLLISION_ResetCollisionMask(pRoom, nX - 1, nY, nMask);
 			COLLISION_ResetCollisionMask(pRoom, nX, nY, nMask);
 			COLLISION_ResetCollisionMask(pRoom, nX + 1, nY, nMask);
@@ -1254,23 +1244,23 @@ void __fastcall COLLISION_SetCollisionMaskForBoundingBox(D2RoomCollisionGridStrc
 }
 
 //D2Common.0x6FD44660 (#10131)
-uint16_t __fastcall D2Common_10131(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nCollisionPattern, int nCollisionType, uint16_t nMask)
+uint16_t __fastcall D2Common_10131(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nUnitSize, int nCollisionType, uint16_t nMask)
 {
 	D2BoundingBoxStrc pBoundingBox = {};
 	uint16_t v10 = 0;
 
 	if (pRoom)
 	{
-		switch (nCollisionPattern)
+		switch (nUnitSize)
 		{
-		case 0:
+		case COLLISION_UNIT_SIZE_NONE:
 			break;
 		
-		case 1:
+		case COLLISION_UNIT_SIZE_POINT:
 			COLLISION_ResetCollisionMask(pRoom, nX1, nY1, nCollisionType);
 			break;
 
-		case 2:
+		case COLLISION_UNIT_SIZE_SMALL:
 			COLLISION_ResetCollisionMask(pRoom, nX1 - 1, nY1, nCollisionType);
 			COLLISION_ResetCollisionMask(pRoom, nX1, nY1, nCollisionType);
 			COLLISION_ResetCollisionMask(pRoom, nX1 + 1, nY1, nCollisionType);
@@ -1278,7 +1268,7 @@ uint16_t __fastcall D2Common_10131(D2RoomStrc* pRoom, int nX1, int nY1, int nX2,
 			COLLISION_ResetCollisionMask(pRoom, nX1, nY1 + 1, nCollisionType);
 			break;
 
-		case 3:
+		case COLLISION_UNIT_SIZE_BIG:
 			COLLISION_CreateBoundingBox(&pBoundingBox, nX1, nY1, 3, 3);
 			COLLISION_ResetCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nCollisionType);
 			break;
@@ -1287,20 +1277,20 @@ uint16_t __fastcall D2Common_10131(D2RoomStrc* pRoom, int nX1, int nY1, int nX2,
 			break;
 		}
 
-		v10 = COLLISION_CheckMaskWithSize(pRoom, nX2, nY2, nCollisionPattern, nMask);
+		v10 = COLLISION_CheckMaskWithSize(pRoom, nX2, nY2, nUnitSize, nMask);
 	}
 	else
 	{
-		v10 = COLLISION_CheckMaskWithSize(pRoom, nX2, nY2, nCollisionPattern, nMask);
+		v10 = COLLISION_CheckMaskWithSize(pRoom, nX2, nY2, nUnitSize, nMask);
 	}
 
 	if (v10 & 5)
 	{
-		COLLISION_SetMaskWithSize(pRoom, nX1, nY1, nCollisionPattern, nCollisionType);
+		COLLISION_SetMaskWithSize(pRoom, nX1, nY1, nUnitSize, nCollisionType);
 	}
 	else
 	{
-		COLLISION_SetMaskWithSize(pRoom, nX2, nY2, nCollisionPattern, nCollisionType);
+		COLLISION_SetMaskWithSize(pRoom, nX2, nY2, nUnitSize, nCollisionType);
 	}
 
 	return v10;
@@ -1309,89 +1299,73 @@ uint16_t __fastcall D2Common_10131(D2RoomStrc* pRoom, int nX1, int nY1, int nX2,
 //D2Common.0x6FD44910
 void __fastcall COLLISION_CreateBoundingBox(D2BoundingBoxStrc* pBoundingBox, int nCenterX, int nCenterY, unsigned int nSizeX, unsigned int nSizeY)
 {
-	pBoundingBox->nLeft = nCenterX - (nSizeX >> 1);
-	pBoundingBox->nRight = nCenterX - (nSizeX >> 1) + nSizeX - 1;
-	pBoundingBox->nBottom = nCenterY - (nSizeY >> 1);
-	pBoundingBox->nTop = nCenterY - (nSizeY >> 1) + nSizeY - 1;
+	pBoundingBox->nLeft = nCenterX - (nSizeX / 2);
+	pBoundingBox->nRight = pBoundingBox->nLeft + nSizeX - 1;
+	pBoundingBox->nBottom = nCenterY - (nSizeY / 2);
+	pBoundingBox->nTop = pBoundingBox->nBottom + nSizeY - 1;
 }
 
 //D2Common.0x6FD44950 (#10132)
 uint16_t __fastcall D2Common_10132(D2RoomStrc* pRoom, int nX1, int nY1, int nX2, int nY2, int nCollisionPattern, int nCollisionType, uint16_t nMask)
 {
-	D2BoundingBoxStrc pBoundingBox = {};
-	uint16_t nResult = 0;
 
 	COLLISION_ResetMaskWithPattern(pRoom, nX1, nY1, nCollisionPattern, nCollisionType);
 
+	uint16_t nPreviousMask = 0;
 	switch (nCollisionPattern)
 	{
-	case 0:
-		nResult = COLLISION_CheckCollisionMask(pRoom, nX2, nY2, nMask);
-		if (nResult)
-		{
-			COLLISION_SetMaskWithPattern(pRoom, nX1, nY1, nCollisionPattern, nCollisionType);
-			return nResult;
-		}
-		else
-		{
-			COLLISION_SetMaskWithPattern(pRoom, nX2, nY2, nCollisionPattern, nCollisionType);
-			return 0;
-		}
-
-	case 1:
-	case 3:
-	case 5:
-		nResult = COLLISION_CheckCollisionMaskWithAdjacentCells(pRoom, nX2, nY2, nMask);
-		if (nResult)
-		{
-			COLLISION_SetMaskWithPattern(pRoom, nX1, nY1, nCollisionPattern, nCollisionType);
-			return nResult;
-		}
-		else
-		{
-			COLLISION_SetMaskWithPattern(pRoom, nX2, nY2, nCollisionPattern, nCollisionType);
-			return 0;
-		}
-
-	case 2:
-	case 4:
-		COLLISION_CreateBoundingBox(&pBoundingBox, nX2, nY2, 3, 3);
-		nResult = COLLISION_CheckCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nMask);
-		if (nResult)
-		{
-			COLLISION_SetMaskWithPattern(pRoom, nX1, nY1, nCollisionPattern, nCollisionType);
-			return nResult;
-		}
-		else
-		{
-			COLLISION_SetMaskWithPattern(pRoom, nX2, nY2, nCollisionPattern, nCollisionType);
-			return 0;
-		}
-
-	default:
-		COLLISION_SetMaskWithPattern(pRoom, nX1, nY1, nCollisionPattern, nCollisionType);
-		return -1;
+	case COLLISION_PATTERN_NONE:
+		nPreviousMask = COLLISION_CheckCollisionMask(pRoom, nX2, nY2, nMask); 
+		break;
+	case COLLISION_PATTERN_SMALL_UNIT_PRESENCE:
+	case COLLISION_PATTERN_SMALL_PET_PRESENCE:
+	case COLLISION_PATTERN_SMALL_NO_PRESENCE:
+		nPreviousMask = COLLISION_CheckCollisionMaskWithAdjacentCells(pRoom, nX2, nY2, nMask);
+		break;
+	case COLLISION_PATTERN_BIG_UNIT_PRESENCE:
+	case COLLISION_PATTERN_BIG_PET_PRESENCE:
+	{
+		D2BoundingBoxStrc tBoundingBox = {};
+		COLLISION_CreateBoundingBox(&tBoundingBox, nX2, nY2, 3, 3);
+		nPreviousMask = COLLISION_CheckCollisionMaskForBoundingBoxRecursively(pRoom, &tBoundingBox, nMask);
+		break;
 	}
+	default:
+		nPreviousMask = COLLIDE_ALL_MASK;
+		break;
+	}
+
+	if (nPreviousMask)
+	{
+		COLLISION_SetMaskWithPattern(pRoom, nX1, nY1, nCollisionPattern, nCollisionType);
+		return nPreviousMask;
+	}
+	else
+	{
+		COLLISION_SetMaskWithPattern(pRoom, nX2, nY2, nCollisionPattern, nCollisionType);
+		return 0;
+	}
+
 }
 
 //D2Common.0x6FD44BB0
-uint16_t __fastcall sub_6FD44BB0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nCollisionPattern, uint16_t nMask1, uint16_t nMask2)
+uint16_t __fastcall sub_6FD44BB0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nUnitSize, uint16_t nMask1, uint16_t nMask2)
 {
-	D2BoundingBoxStrc pBoundingBox = {};
-	uint16_t nResult = 0;
+	D2BoundingBoxStrc tBoundingBox = {};
+	uint16_t nPreviousMask = 0;
 
 	if (pRoom1)
 	{
-		switch (nCollisionPattern)
+		switch (nUnitSize)
 		{
-		case 0:
+		case COLLISION_UNIT_SIZE_NONE:
 			break;
 
-		case 1:
+		case COLLISION_UNIT_SIZE_POINT:
 			COLLISION_ResetCollisionMask(pRoom1, nX1, nY1, nMask1);
 			break;
 
-		case 2:
+		case COLLISION_UNIT_SIZE_SMALL:
 			COLLISION_ResetCollisionMask(pRoom1, nX1 - 1, nY1, nMask1);
 			COLLISION_ResetCollisionMask(pRoom1, nX1, nY1, nMask1);
 			COLLISION_ResetCollisionMask(pRoom1, nX1 + 1, nY1, nMask1);
@@ -1399,46 +1373,46 @@ uint16_t __fastcall sub_6FD44BB0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStr
 			COLLISION_ResetCollisionMask(pRoom1, nX1, nY1 + 1, nMask1);
 			break;
 
-		case 3:
-			COLLISION_CreateBoundingBox(&pBoundingBox, nX1, nY1, 3, 3);
-			COLLISION_ResetCollisionMaskForBoundingBoxRecursively(pRoom1, &pBoundingBox, nMask1);
+		case COLLISION_UNIT_SIZE_BIG:
+			COLLISION_CreateBoundingBox(&tBoundingBox, nX1, nY1, 3, 3);
+			COLLISION_ResetCollisionMaskForBoundingBoxRecursively(pRoom1, &tBoundingBox, nMask1);
 			break;
 
 		default:
-			return -1;
+			return COLLIDE_ALL_MASK;
 		}
 	}
 
-	switch (nCollisionPattern)
+	switch (nUnitSize)
 	{
-	case 0:
-	case 1:
-		nResult = COLLISION_CheckCollisionMask(pRoom2, nX2, nY2, nMask2);
+	case COLLISION_UNIT_SIZE_NONE:
+	case COLLISION_UNIT_SIZE_POINT:
+		nPreviousMask = COLLISION_CheckCollisionMask(pRoom2, nX2, nY2, nMask2);
 		break;
 
-	case 2:
-		nResult = COLLISION_CheckCollisionMaskWithAdjacentCells(pRoom2, nX2, nY2, nMask2);
+	case COLLISION_UNIT_SIZE_SMALL:
+		nPreviousMask = COLLISION_CheckCollisionMaskWithAdjacentCells(pRoom2, nX2, nY2, nMask2);
 		break;
 
-	case 3:
-		COLLISION_CreateBoundingBox(&pBoundingBox, nX2, nY2, 3, 3);
-		nResult = COLLISION_CheckCollisionMaskForBoundingBoxRecursively(pRoom2, &pBoundingBox, nMask2);
+	case COLLISION_UNIT_SIZE_BIG:
+		COLLISION_CreateBoundingBox(&tBoundingBox, nX2, nY2, 3, 3);
+		nPreviousMask = COLLISION_CheckCollisionMaskForBoundingBoxRecursively(pRoom2, &tBoundingBox, nMask2);
 		break;
 
 	default:
-		return -1;
+		return COLLIDE_ALL_MASK;
 	}
 
-	switch (nCollisionPattern)
+	switch (nUnitSize)
 	{
-	case 0:
+	case COLLISION_PATTERN_NONE:
 		break;
 
-	case 1:
+	case COLLISION_UNIT_SIZE_POINT:
 		COLLISION_SetCollisionMask(pRoom2, nX2, nY2, nMask1);
 		break;
 
-	case 2:
+	case COLLISION_UNIT_SIZE_SMALL:
 		COLLISION_SetCollisionMask(pRoom2, nX2 - 1, nY2, nMask1);
 		COLLISION_SetCollisionMask(pRoom2, nX2, nY2, nMask1);
 		COLLISION_SetCollisionMask(pRoom2, nX2 + 1, nY2, nMask1);
@@ -1446,32 +1420,32 @@ uint16_t __fastcall sub_6FD44BB0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStr
 		COLLISION_SetCollisionMask(pRoom2, nX2, nY2 + 1, nMask1);
 		break;
 
-	case 3:
-		COLLISION_CreateBoundingBox(&pBoundingBox, nX2, nY2, 3, 3);
-		COLLISION_SetCollisionMaskForBoundingBoxRecursively(pRoom2, &pBoundingBox, nMask1);
+	case COLLISION_UNIT_SIZE_BIG:
+		COLLISION_CreateBoundingBox(&tBoundingBox, nX2, nY2, 3, 3);
+		COLLISION_SetCollisionMaskForBoundingBoxRecursively(pRoom2, &tBoundingBox, nMask1);
 		break;
 
 	default:
-		return -1;
+		return COLLIDE_ALL_MASK;
 	}
 
-	return nResult;
+	return nPreviousMask;
 }
 
 //D2Common.0x6FD44E00
-uint16_t __fastcall sub_6FD44E00(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nCollisionPattern, uint16_t nMask)
+uint16_t __fastcall sub_6FD44E00(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pRoom2, int nX2, int nY2, int nUnitSize, uint16_t nMask)
 {
 	D2BoundingBoxStrc pBoundingBox = {};
 
 	if (pRoom1)
 	{
-		switch (nCollisionPattern)
+		switch (nUnitSize)
 		{
-		case 1:
+		case COLLISION_UNIT_SIZE_POINT:
 			COLLISION_ResetCollisionMask(pRoom1, nX1, nY1, nMask);
 			break;
 
-		case 2:
+		case COLLISION_UNIT_SIZE_SMALL:
 			COLLISION_ResetCollisionMask(pRoom1, nX1 - 1, nY1, nMask);
 			COLLISION_ResetCollisionMask(pRoom1, nX1, nY1, nMask);
 			COLLISION_ResetCollisionMask(pRoom1, nX1 + 1, nY1, nMask);
@@ -1479,7 +1453,7 @@ uint16_t __fastcall sub_6FD44E00(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStr
 			COLLISION_ResetCollisionMask(pRoom1, nX1, nY1 + 1, nMask);
 			break;
 
-		case 3:
+		case COLLISION_UNIT_SIZE_BIG:
 			COLLISION_CreateBoundingBox(&pBoundingBox, nX1, nY1, 3, 3);
 			COLLISION_ResetCollisionMaskForBoundingBoxRecursively(pRoom1, &pBoundingBox, nMask);
 			break;
@@ -1489,13 +1463,13 @@ uint16_t __fastcall sub_6FD44E00(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStr
 		}
 	}
 
-	switch(nCollisionPattern)
+	switch(nUnitSize)
 	{
-	case 1:
+	case COLLISION_UNIT_SIZE_POINT:
 		COLLISION_SetCollisionMask(pRoom2, nX2, nY2, nMask);
 		break;
 
-	case 2:
+	case COLLISION_UNIT_SIZE_SMALL:
 		COLLISION_SetCollisionMask(pRoom2, nX2 - 1, nY2, nMask);
 		COLLISION_SetCollisionMask(pRoom2, nX2, nY2, nMask);
 		COLLISION_SetCollisionMask(pRoom2, nX2 + 1, nY2, nMask);
@@ -1503,7 +1477,7 @@ uint16_t __fastcall sub_6FD44E00(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStr
 		COLLISION_SetCollisionMask(pRoom2, nX2, nY2 + 1, nMask);
 		break;
 
-	case 3:
+	case COLLISION_UNIT_SIZE_BIG:
 		COLLISION_CreateBoundingBox(&pBoundingBox, nX2, nY2, 3, 3);
 		COLLISION_SetCollisionMaskForBoundingBoxRecursively(pRoom2, &pBoundingBox, nMask);
 		break;
@@ -1528,7 +1502,7 @@ int __fastcall sub_6FD44FF0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pR
 
 	switch (nCollisionPattern)
 	{
-	case 0:
+	case COLLISION_PATTERN_NONE:
 		nResult = COLLISION_CheckCollisionMask(pRoom2, nX2, nY2, nMask);
 		if (nResult)
 		{
@@ -1541,12 +1515,12 @@ int __fastcall sub_6FD44FF0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pR
 		else
 		{
 			COLLISION_SetMaskWithPattern(pRoom2, nX2, nY2, nCollisionPattern, nCollisionType);
-			return 0;
+			return COLLIDE_NONE;
 		}
 
-	case 1:
-	case 3:
-	case 5:
+	case COLLISION_PATTERN_SMALL_UNIT_PRESENCE:
+	case COLLISION_PATTERN_SMALL_PET_PRESENCE:
+	case COLLISION_PATTERN_SMALL_NO_PRESENCE:
 		nResult = sub_6FD42A30(pRoom2, nX2, nY2, nMask);
 		if (nResult)
 		{
@@ -1559,11 +1533,11 @@ int __fastcall sub_6FD44FF0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pR
 		else
 		{
 			COLLISION_SetMaskWithPattern(pRoom2, nX2, nY2, nCollisionPattern, nCollisionType);
-			return 0;
+			return COLLIDE_NONE;
 		}
 
-	case 2:
-	case 4:
+	case COLLISION_PATTERN_BIG_UNIT_PRESENCE:
+	case COLLISION_PATTERN_BIG_PET_PRESENCE:
 		COLLISION_CreateBoundingBox(&pBoundingBox, nX2, nY2, 3, 3);
 		nResult = sub_6FD428D0(pRoom2, &pBoundingBox, nMask);
 		if (nResult)
@@ -1577,7 +1551,7 @@ int __fastcall sub_6FD44FF0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pR
 		else
 		{
 			COLLISION_SetMaskWithPattern(pRoom2, nX2, nY2, nCollisionPattern, nCollisionType);
-			return 0;
+			return COLLIDE_NONE;
 		}
 
 	default:
@@ -1585,7 +1559,7 @@ int __fastcall sub_6FD44FF0(D2RoomStrc* pRoom1, int nX1, int nY1, D2RoomStrc* pR
 		{
 			COLLISION_SetMaskWithPattern(pRoom1, nX1, nY1, nCollisionPattern, nCollisionType);
 		}
-		return 1;
+		return COLLIDE_BLOCK_PLAYER;
 	}
 }
 

--- a/source/D2Common/src/D2Collision.cpp
+++ b/source/D2Common/src/D2Collision.cpp
@@ -859,9 +859,7 @@ void __fastcall COLLISION_SetCollisionMaskForBoundingBoxRecursively(D2RoomStrc* 
 //D2Common.0x6FD436F0 (#10130)
 void __stdcall COLLISION_SetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY, int nCollisionPattern, uint16_t nMask)
 {
-	D2RoomCollisionGridStrc* pCollisionGrid = NULL;
-	D2RoomStrc* pAdjacentRoom = NULL;
-	D2BoundingBoxStrc pBoundingBox = {};
+	D2BoundingBoxStrc tBoundingBox = {};
 
 	switch (nCollisionPattern)
 	{
@@ -879,8 +877,8 @@ void __stdcall COLLISION_SetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY, i
 		break;
 
 	case COLLISION_PATTERN_BIG_UNIT_PRESENCE:
-		COLLISION_CreateBoundingBox(&pBoundingBox, nX, nY, 3, 3);
-		COLLISION_SetCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nMask);
+		COLLISION_CreateBoundingBox(&tBoundingBox, nX, nY, 3, 3);
+		COLLISION_SetCollisionMaskForBoundingBoxRecursively(pRoom, &tBoundingBox, nMask);
 
 		if (nMask)
 		{
@@ -901,21 +899,13 @@ void __stdcall COLLISION_SetMaskWithPattern(D2RoomStrc* pRoom, int nX, int nY, i
 
 		if (nMask)
 		{
-			pAdjacentRoom = COLLISION_GetRoomBySubTileCoordinates(pRoom, nX, nY);
-			if (pAdjacentRoom)
-			{
-				pCollisionGrid = DUNGEON_GetCollisionGridFromRoom(pAdjacentRoom);
-				if (pCollisionGrid && pCollisionGrid->pCollisionMask)
-				{
-					pCollisionGrid->pCollisionMask[nX + pCollisionGrid->pRoomCoords.dwSubtilesWidth * (nY - pCollisionGrid->pRoomCoords.dwSubtilesTop) - pCollisionGrid->pRoomCoords.dwSubtilesLeft] |= COLLIDE_PET;
-				}
-			}
+			COLLISION_SetCollisionMask(pRoom, nX, nY, COLLIDE_PET);
 		}
 		break;
 
 	case COLLISION_PATTERN_BIG_PET_PRESENCE:
-		COLLISION_CreateBoundingBox(&pBoundingBox, nX, nY, 3, 3);
-		COLLISION_SetCollisionMaskForBoundingBoxRecursively(pRoom, &pBoundingBox, nMask);
+		COLLISION_CreateBoundingBox(&tBoundingBox, nX, nY, 3, 3);
+		COLLISION_SetCollisionMaskForBoundingBoxRecursively(pRoom, &tBoundingBox, nMask);
 
 		if (nMask)
 		{

--- a/source/D2Common/src/D2Skills.cpp
+++ b/source/D2Common/src/D2Skills.cpp
@@ -3288,7 +3288,7 @@ int __stdcall D2COMMON_11036_GetMonCurseResistanceSubtraction(int nLevel, int nS
 }
 
 //D2Common.0x6FDB3CB0 (#11037)
-BOOL __stdcall D2Common_11037(D2UnitStrc* pUnit1, D2UnitStrc* pUnit2, int* pX, int* pY)
+BOOL __stdcall SKILLS_CheckIfCanLeapTo(D2UnitStrc* pUnit1, D2UnitStrc* pUnit2, int* pX, int* pY)
 {
 	D2RoomStrc* pRoom = NULL;
 	int nDivisor = 0;
@@ -3323,19 +3323,19 @@ BOOL __stdcall D2Common_11037(D2UnitStrc* pUnit1, D2UnitStrc* pUnit2, int* pX, i
 		pRoom = UNITS_GetRoom(pUnit1);
 		D2_ASSERT(pRoom);
 
-		if (COLLISION_CheckMaskWithPattern2(pRoom, pCoord.nX, pCoord.nY, PATH_GetUnitCollisionPattern(pUnit1), 0x1C09))
+		if (COLLISION_CheckMaskWithPattern2(pRoom, pCoord.nX, pCoord.nY, PATH_GetUnitCollisionPattern(pUnit1), COLLIDE_MASK_WALKING_UNIT))
 		{
 			pCoord.nX = pCoords2.nX;
 			pCoord.nY = pCoords2.nY;
 
-			pRoom = COLLISION_GetFreeCoordinates(pRoom, &pCoord, UNITS_GetUnitSizeX(pUnit1), 0x1C09, 0);
+			pRoom = COLLISION_GetFreeCoordinates(pRoom, &pCoord, UNITS_GetUnitSizeX(pUnit1), COLLIDE_MASK_WALKING_UNIT, 0);
 			if (!pRoom)
 			{
 				return FALSE;
 			}
 		}
 		
-		if (!COLLISION_RayTrace(pRoom, &pCoords1, &pCoord, 0x804))
+		if (!COLLISION_RayTrace(pRoom, &pCoords1, &pCoord, COLLIDE_DOOR | COLLIDE_WALL))
 		{
 			*pX = pCoord.nX;
 			*pY = pCoord.nY;

--- a/source/D2Common/src/D2Skills.cpp
+++ b/source/D2Common/src/D2Skills.cpp
@@ -3323,7 +3323,7 @@ BOOL __stdcall SKILLS_CheckIfCanLeapTo(D2UnitStrc* pUnit1, D2UnitStrc* pUnit2, i
 		pRoom = UNITS_GetRoom(pUnit1);
 		D2_ASSERT(pRoom);
 
-		if (COLLISION_CheckMaskWithPattern2(pRoom, pCoord.nX, pCoord.nY, PATH_GetUnitCollisionPattern(pUnit1), COLLIDE_MASK_WALKING_UNIT))
+		if (COLLISION_CheckAnyCollisionWithPattern(pRoom, pCoord.nX, pCoord.nY, PATH_GetUnitCollisionPattern(pUnit1), COLLIDE_MASK_WALKING_UNIT))
 		{
 			pCoord.nX = pCoords2.nX;
 			pCoord.nY = pCoords2.nY;

--- a/source/D2Common/src/Path/IDAStar.cpp
+++ b/source/D2Common/src/Path/IDAStar.cpp
@@ -78,7 +78,7 @@ void __fastcall sub_6FDA6D10(D2PathInfoStrc** ppPathInfo, D2PathInfoStrc* pPathP
 //	v15 = *(_DWORD *)(a1 + 44);
 //	v16 = *(_DWORD *)(a1 + 40);
 //	v17 = *(_DWORD *)(a1 + 8);
-//	if (!COLLISION_CheckMaskWithPattern2(*(D2RoomStrc**)(a1 + 8), v4, v5, *(_DWORD *)(a1 + 40), *(_DWORD *)(a1 + 44)))
+//	if (!COLLISION_CheckAnyCollisionWithPattern(*(D2RoomStrc**)(a1 + 8), v4, v5, *(_DWORD *)(a1 + 40), *(_DWORD *)(a1 + 44)))
 //	{
 //		if (*(_WORD *)a3 == v4 || (v6 = 3, *(_WORD *)(a3 + 2) == v5))
 //			v6 = 2;
@@ -277,37 +277,37 @@ void __fastcall sub_6FDA6D10(D2PathInfoStrc** ppPathInfo, D2PathInfoStrc* pPathP
 //	}
 //	LOWORD(v19) = *(_WORD *)a3 - 1;
 //	HIWORD(v19) = *(_WORD *)(a3 + 2) + 1;
-//	if (COLLISION_CheckMaskWithPattern2((D2RoomStrc*)v17, (unsigned __int16)v19, HIWORD(v19), v16, v15)
+//	if (COLLISION_CheckAnyCollisionWithPattern((D2RoomStrc*)v17, (unsigned __int16)v19, HIWORD(v19), v16, v15)
 //		|| (result = sub_6FDA7490(v14, v17, a3, v19, a4)) != 0)
 //	{
 //		HIWORD(v20) = *(_WORD *)(a3 + 2) - 1;
 //		LOWORD(v20) = *(_WORD *)a3 + 1;
-//		if (COLLISION_CheckMaskWithPattern2((D2RoomStrc*)v17, (unsigned __int16)(*(_WORD *)a3 + 1), HIWORD(v20), v16, v15)
+//		if (COLLISION_CheckAnyCollisionWithPattern((D2RoomStrc*)v17, (unsigned __int16)(*(_WORD *)a3 + 1), HIWORD(v20), v16, v15)
 //			|| (result = sub_6FDA7490(v14, v17, a3, v20, a4)) != 0)
 //		{
 //			HIWORD(v21) = *(_WORD *)(a3 + 2) + 1;
 //			LOWORD(v21) = *(_WORD *)a3 + 1;
-//			if (COLLISION_CheckMaskWithPattern2((D2RoomStrc*)v17, (unsigned __int16)(*(_WORD *)a3 + 1), HIWORD(v21), v16, v15)
+//			if (COLLISION_CheckAnyCollisionWithPattern((D2RoomStrc*)v17, (unsigned __int16)(*(_WORD *)a3 + 1), HIWORD(v21), v16, v15)
 //				|| (result = sub_6FDA7490(v14, v17, a3, v21, a4)) != 0)
 //			{
 //				HIWORD(v22) = *(_WORD *)(a3 + 2);
 //				LOWORD(v22) = *(_WORD *)a3 - 1;
-//				if (COLLISION_CheckMaskWithPattern2((D2RoomStrc*)v17, (unsigned __int16)(*(_WORD *)a3 - 1), HIWORD(v22), v16, v15)
+//				if (COLLISION_CheckAnyCollisionWithPattern((D2RoomStrc*)v17, (unsigned __int16)(*(_WORD *)a3 - 1), HIWORD(v22), v16, v15)
 //					|| (result = sub_6FDA7490(v14, v17, a3, v22, a4)) != 0)
 //				{
 //					LOWORD(v23) = *(_WORD *)a3;
 //					HIWORD(v23) = *(_WORD *)(a3 + 2) - 1;
-//					if (COLLISION_CheckMaskWithPattern2((D2RoomStrc*)v17, *(_WORD *)a3, HIWORD(v23), v16, v15)
+//					if (COLLISION_CheckAnyCollisionWithPattern((D2RoomStrc*)v17, *(_WORD *)a3, HIWORD(v23), v16, v15)
 //						|| (result = sub_6FDA7490(v14, v17, a3, v23, a4)) != 0)
 //					{
 //						HIWORD(v24) = *(_WORD *)(a3 + 2);
 //						LOWORD(v24) = *(_WORD *)a3 + 1;
-//						if (COLLISION_CheckMaskWithPattern2(//							(D2RoomStrc*)v17, //							(unsigned __int16)(*(_WORD *)a3 + 1), //							HIWORD(v24), //							v16, //							v15)
+//						if (COLLISION_CheckAnyCollisionWithPattern(//							(D2RoomStrc*)v17, //							(unsigned __int16)(*(_WORD *)a3 + 1), //							HIWORD(v24), //							v16, //							v15)
 //							|| (result = sub_6FDA7490(v14, v17, a3, v24, a4)) != 0)
 //						{
 //							LOWORD(v25) = *(_WORD *)a3;
 //							HIWORD(v25) = *(_WORD *)(a3 + 2) + 1;
-//							if (!COLLISION_CheckMaskWithPattern2((D2RoomStrc*)v17, *(_WORD *)a3, HIWORD(v25), v16, v15)
+//							if (!COLLISION_CheckAnyCollisionWithPattern((D2RoomStrc*)v17, *(_WORD *)a3, HIWORD(v25), v16, v15)
 //								&& !sub_6FDA7490(v14, v17, a3, v25, a4))
 //								return 0;
 //							result = 1;
@@ -941,7 +941,7 @@ int __fastcall sub_6FDA7970(D2PathInfoStrc* pPathInfo)
 //					v38 = v17;
 //					if (!v6)
 //						break;
-//					if (!COLLISION_CheckMaskWithPattern2(*(D2RoomStrc**)(a3 + 8), v13, v12, *(_DWORD *)(a3 + 40), *(_DWORD *)(a3 + 44)))
+//					if (!COLLISION_CheckAnyCollisionWithPattern(*(D2RoomStrc**)(a3 + 8), v13, v12, *(_DWORD *)(a3 + 40), *(_DWORD *)(a3 + 44)))
 //					{
 //						v14 = v39;
 //						v17 = v38;

--- a/source/D2Common/src/Path/Path.cpp
+++ b/source/D2Common/src/Path/Path.cpp
@@ -1129,7 +1129,7 @@ int __stdcall PATH_GetCollisionType(D2DynamicPathStrc* pDynamicPath)
 		return pDynamicPath->dwCollisionType;
 	}
 	
-	// Original game uses 0xFFFF because collisions fit on 16btis, but intent is to return all bits set.
+	// Note: this returns 0xFFFF not 0xFFFFFFFF because D2C_CollisionFlags is 16bits.
 	return COLLIDE_ALL_MASK;
 }
 

--- a/source/D2Common/src/Path/Path.cpp
+++ b/source/D2Common/src/Path/Path.cpp
@@ -374,7 +374,7 @@ void __fastcall sub_6FDA8FE0(D2PathInfoStrc* pPathInfo)
 			nX += nOffsetX;
 			nY += nOffsetY;
 
-			if (COLLISION_CheckMaskWithPattern2(pPathInfo->pRoom, nX, nY, pPathInfo->nCollisionPattern, pPathInfo->nCollisionType))
+			if (COLLISION_CheckAnyCollisionWithPattern(pPathInfo->pRoom, nX, nY, pPathInfo->nCollisionPattern, pPathInfo->nCollisionType))
 			{
 				break;
 			}

--- a/source/D2Common/src/Path/PathMisc.cpp
+++ b/source/D2Common/src/Path/PathMisc.cpp
@@ -1179,7 +1179,7 @@ BOOL __fastcall sub_6FDAD5E0(D2DynamicPathStrc* pDynamicPath, D2RoomStrc* pDestR
 			{
 				pDynamicPath->dwFlags |= PATH_UNKNOWN_FLAG_0x00008;
 			}
-			pDynamicPath->unk0x54 = sub_6FD44BB0(
+			pDynamicPath->unk0x54 = COLLISION_ForceTeleportUnitCollisionMaskAndGetCollision(
 				pDynamicPath->pRoom, pDynamicPath->tGameCoords.wPosX, pDynamicPath->tGameCoords.wPosY,
 				pDestRoom, tDest.X, tDest.Y,
 				pDynamicPath->dwUnitSize,
@@ -1194,7 +1194,7 @@ BOOL __fastcall sub_6FDAD5E0(D2DynamicPathStrc* pDynamicPath, D2RoomStrc* pDestR
 	{
 		if (tDest.X || tDest.Y)
 		{
-			D2Common_10133(
+			COLLISION_SetUnitCollisionMask(
 				pDynamicPath->pRoom, pDynamicPath->tGameCoords.wPosX, pDynamicPath->tGameCoords.wPosY,
 				pDestRoom, tDest.X, tDest.Y,
 				pDynamicPath->dwCollisionPattern,

--- a/source/D2Common/src/Path/PathMisc.cpp
+++ b/source/D2Common/src/Path/PathMisc.cpp
@@ -151,13 +151,13 @@ BOOL __fastcall sub_6FDAA880(D2PathInfoStrc* pPathInfo, int* pTestDir, D2PathPoi
 
 	D2_ASSERT(pUnit && (pUnit->dwUnitType == UNIT_PLAYER || pUnit->dwUnitType == UNIT_MONSTER));
 
-	if (!COLLISION_CheckMaskWithPattern2(pPathInfo->pRoom, (pPoint.X + gatDirectionToOffset_6FDD2118[pTestDir[0]].nX), (pPoint.Y + gatDirectionToOffset_6FDD2118[pTestDir[0]].nY), pPathInfo->nCollisionPattern, pPathInfo->nCollisionType))
+	if (!COLLISION_CheckAnyCollisionWithPattern(pPathInfo->pRoom, (pPoint.X + gatDirectionToOffset_6FDD2118[pTestDir[0]].nX), (pPoint.Y + gatDirectionToOffset_6FDD2118[pTestDir[0]].nY), pPathInfo->nCollisionPattern, pPathInfo->nCollisionType))
 	{
 		*pDirection = pTestDir[0];
 		return TRUE;
 	}
 
-	if (!COLLISION_CheckMaskWithPattern2(pPathInfo->pRoom, (pPoint.X + gatDirectionToOffset_6FDD2118[pTestDir[1]].nX), (pPoint.Y + gatDirectionToOffset_6FDD2118[pTestDir[1]].nY), pPathInfo->nCollisionPattern, pPathInfo->nCollisionType))
+	if (!COLLISION_CheckAnyCollisionWithPattern(pPathInfo->pRoom, (pPoint.X + gatDirectionToOffset_6FDD2118[pTestDir[1]].nX), (pPoint.Y + gatDirectionToOffset_6FDD2118[pTestDir[1]].nY), pPathInfo->nCollisionPattern, pPathInfo->nCollisionType))
 	{
 		*pDirection = pTestDir[1];
 		return TRUE;
@@ -165,7 +165,7 @@ BOOL __fastcall sub_6FDAA880(D2PathInfoStrc* pPathInfo, int* pTestDir, D2PathPoi
 
 	D2_ASSERT(pTestDir[2] != PATH_DIR_NULL);
 
-	if (!COLLISION_CheckMaskWithPattern2(pPathInfo->pRoom, (pPoint.X + gatDirectionToOffset_6FDD2118[pTestDir[2]].nX), (pPoint.Y + gatDirectionToOffset_6FDD2118[pTestDir[2]].nY), pPathInfo->nCollisionPattern, pPathInfo->nCollisionType))
+	if (!COLLISION_CheckAnyCollisionWithPattern(pPathInfo->pRoom, (pPoint.X + gatDirectionToOffset_6FDD2118[pTestDir[2]].nX), (pPoint.Y + gatDirectionToOffset_6FDD2118[pTestDir[2]].nY), pPathInfo->nCollisionPattern, pPathInfo->nCollisionType))
 	{
 		*pDirection = pTestDir[2];
 		return TRUE;

--- a/source/D2Common/src/Units/Units.cpp
+++ b/source/D2Common/src/Units/Units.cpp
@@ -202,7 +202,7 @@ int __stdcall UNITS_GetUnitSizeX(D2UnitStrc* pUnit)
 		switch (pUnit->dwUnitType)
 		{
 		case UNIT_PLAYER:
-			return 2;
+			return COLLISION_UNIT_SIZE_SMALL;
 
 		case UNIT_MONSTER:
 			pMonStats2TxtRecord = UNITS_GetMonStats2TxtRecordFromMonsterId(pUnit->dwClassId);
@@ -210,13 +210,13 @@ int __stdcall UNITS_GetUnitSizeX(D2UnitStrc* pUnit)
 			{
 				return pMonStats2TxtRecord->nSizeX;
 			}
-			return 0;
+			return COLLISION_UNIT_SIZE_NONE;
 
 		case UNIT_OBJECT:
 			return pUnit->pObjectData->pObjectTxt->dwSizeX;
 
 		case UNIT_ITEM:
-			return 1;
+			return COLLISION_UNIT_SIZE_POINT;
 
 		case UNIT_MISSILE:
 			pMissilesTxtRecord = DATATBLS_GetMissilesTxtRecord(pUnit->dwClassId);
@@ -224,14 +224,14 @@ int __stdcall UNITS_GetUnitSizeX(D2UnitStrc* pUnit)
 			{
 				return pMissilesTxtRecord->nSize;
 			}
-			return 0;
+			return COLLISION_UNIT_SIZE_NONE;
 
 		default:
-			return 0;
+			return COLLISION_UNIT_SIZE_NONE;
 		}
 	}
 	
-	return 0;
+	return COLLISION_UNIT_SIZE_NONE;
 }
 
 //D2Common.0x6FDBDA00 (#10337)

--- a/source/D2Game/src/AI/AiBaal.cpp
+++ b/source/D2Game/src/AI/AiBaal.cpp
@@ -308,7 +308,7 @@ int32_t __fastcall AIBAAL_RollRandomAiParam(D2GameStrc* pGame, D2UnitStrc* pUnit
 
 	if (!pTarget)
 	{
-		if (COLLISION_CheckMaskWithPattern2(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), 2, COLLIDE_MISSILE))
+		if (COLLISION_CheckAnyCollisionWithPattern(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), 2, COLLIDE_MISSILE))
 		{
 			return 4;
 		}

--- a/source/D2Game/src/AI/AiTactics.cpp
+++ b/source/D2Game/src/AI/AiTactics.cpp
@@ -36,7 +36,7 @@ D2UnitStrc* __fastcall sub_6FCCF9D0(D2GameStrc* pGame, D2UnitStrc* pUnit, D2AiCo
 		return pResult;
 	}
 
-	if ((sub_6FCF2E70(pUnit) && pUnit) || COLLISION_CheckMaskWithPattern2(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), PATH_GetUnitCollisionPattern(pUnit), COLLIDE_MISSILE))
+	if ((sub_6FCF2E70(pUnit) && pUnit) || COLLISION_CheckAnyCollisionWithPattern(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), PATH_GetUnitCollisionPattern(pUnit), COLLIDE_MISSILE))
 	{
 		D2MonStats2Txt* pMonStats2TxtRecord = MONSTERREGION_GetMonStats2TxtRecord(pUnit->dwClassId);
 		if (pMonStats2TxtRecord && pMonStats2TxtRecord->dwModeFlags & gdwBitMasks[MONMODE_WALK])
@@ -74,7 +74,7 @@ D2UnitStrc* __fastcall sub_6FCCFC00(D2GameStrc* pGame, D2UnitStrc* pUnit, D2AiCo
 		return pResult;
 	}
 
-	if (COLLISION_CheckMaskWithPattern2(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), PATH_GetUnitCollisionPattern(pUnit), COLLIDE_MISSILE))
+	if (COLLISION_CheckAnyCollisionWithPattern(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), PATH_GetUnitCollisionPattern(pUnit), COLLIDE_MISSILE))
 	{
 		D2MonStats2Txt* pMonStats2TxtRecord = MONSTERREGION_GetMonStats2TxtRecord(pUnit->dwClassId);
 		if (pMonStats2TxtRecord && pMonStats2TxtRecord->dwModeFlags & gdwBitMasks[MONMODE_WALK])

--- a/source/D2Game/src/AI/AiThink.cpp
+++ b/source/D2Game/src/AI/AiThink.cpp
@@ -8330,7 +8330,7 @@ void __fastcall AITHINK_Fn061_Hireable(D2GameStrc* pGame, D2UnitStrc* pUnit, D2A
 	if (nAnimMode == MONMODE_NEUTRAL)
 	{
 		int32_t bWalk = 0;
-		if (COLLISION_CheckMaskWithPattern2(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), PATH_GetUnitCollisionPattern(pUnit), COLLIDE_MISSILE))
+		if (COLLISION_CheckAnyCollisionWithPattern(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), PATH_GetUnitCollisionPattern(pUnit), COLLIDE_MISSILE))
 		{
 			bWalk = 1;
 
@@ -11034,7 +11034,7 @@ void __fastcall AITHINK_Fn051_Diablo(D2GameStrc* pGame, D2UnitStrc* pUnit, D2AiT
 	{
 		if (!pTarget)
 		{
-			if (COLLISION_CheckMaskWithPattern2(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), 2, COLLIDE_MISSILE))
+			if (COLLISION_CheckAnyCollisionWithPattern(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), 2, COLLIDE_MISSILE))
 			{
 				nParam = 16;
 			}

--- a/source/D2Game/src/AI/AiThink.cpp
+++ b/source/D2Game/src/AI/AiThink.cpp
@@ -1862,7 +1862,7 @@ void __fastcall AITHINK_Fn023_Vulture(D2GameStrc* pGame, D2UnitStrc* pUnit, D2Ai
 		COLLISION_ResetMask(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), COLLIDE_UNIT_RELATED);
 		COLLISION_ResetMask(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), COLLIDE_MONSTER);
 
-		PATH_SetUnitCollisionPattern(pUnit, 5u);
+		PATH_SetUnitCollisionPattern(pUnit, COLLISION_PATTERN_SMALL_NO_PRESENCE);
 		D2Common_10184(pUnit->pDynamicPath, 0);
 		AITACTICS_Idle(pGame, pUnit, 12);
 
@@ -1886,7 +1886,7 @@ void __fastcall AITHINK_Fn023_Vulture(D2GameStrc* pGame, D2UnitStrc* pUnit, D2Ai
 			COLLISION_ResetMask(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), COLLIDE_UNIT_RELATED);
 			COLLISION_ResetMask(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), COLLIDE_MONSTER);
 
-			PATH_SetUnitCollisionPattern(pUnit, 5u);
+			PATH_SetUnitCollisionPattern(pUnit, COLLISION_PATTERN_SMALL_NO_PRESENCE);
 			D2Common_10184(pUnit->pDynamicPath, 0);
 			AITACTICS_Idle(pGame, pUnit, 12);
 
@@ -2027,13 +2027,13 @@ int32_t __fastcall sub_6FCD55D0(D2GameStrc* pGame, D2UnitStrc* pUnit)
 	const int32_t nX = CLIENTS_GetUnitX(pUnit);
 	const int32_t nY = CLIENTS_GetUnitY(pUnit);
 
-	if (PATH_GetUnitCollisionPattern(pUnit) == 1 || !sub_6FCBDFE0(pGame, pUnit, pRoom, nX, nY, 0, 0))
+	if (PATH_GetUnitCollisionPattern(pUnit) == COLLISION_PATTERN_SMALL_UNIT_PRESENCE || !sub_6FCBDFE0(pGame, pUnit, pRoom, nX, nY, 0, 0))
 	{
 		return 0;
 	}
 
 	COLLISION_SetMaskWithPattern(pRoom, nX, nY, 1, COLLIDE_MONSTER);
-	PATH_SetUnitCollisionPattern(pUnit, 1u);
+	PATH_SetUnitCollisionPattern(pUnit, COLLISION_PATTERN_SMALL_UNIT_PRESENCE);
 	D2Common_10184(pUnit->pDynamicPath, 0x3C01);
 	AITACTICS_Idle(pGame, pUnit, 12);
 	return 1;
@@ -4358,7 +4358,7 @@ void __fastcall D2GAME_AI_Unk052_6FCDA910(D2GameStrc* pGame, D2UnitStrc* pUnit, 
 
 	COLLISION_ResetMask(pRoom, nX, nY, COLLIDE_UNIT_RELATED);
 	COLLISION_ResetMask(pRoom, nX, nY, COLLIDE_MONSTER);
-	PATH_SetUnitCollisionPattern(pUnit, 5u);
+	PATH_SetUnitCollisionPattern(pUnit, COLLISION_PATTERN_SMALL_NO_PRESENCE);
 	D2Common_10184(pUnit->pDynamicPath, 0);
 	AITACTICS_Idle(pGame, pUnit, 12);
 }
@@ -4379,7 +4379,7 @@ void __fastcall AITHINK_Fn052_FrogDemon(D2GameStrc* pGame, D2UnitStrc* pUnit, D2
 
 			COLLISION_ResetMask(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), COLLIDE_UNIT_RELATED);
 			COLLISION_ResetMask(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), COLLIDE_MONSTER);
-			PATH_SetUnitCollisionPattern(pUnit, 5u);
+			PATH_SetUnitCollisionPattern(pUnit, COLLISION_PATTERN_SMALL_NO_PRESENCE);
 			D2Common_10184(pUnit->pDynamicPath, 0);
 			AITACTICS_Idle(pGame, pUnit, 12);
 			return;
@@ -4425,7 +4425,7 @@ void __fastcall AITHINK_Fn052_FrogDemon(D2GameStrc* pGame, D2UnitStrc* pUnit, D2
 
 		COLLISION_ResetMask(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), COLLIDE_UNIT_RELATED);
 		COLLISION_ResetMask(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), COLLIDE_MONSTER);
-		PATH_SetUnitCollisionPattern(pUnit, 5u);
+		PATH_SetUnitCollisionPattern(pUnit, COLLISION_PATTERN_SMALL_NO_PRESENCE);
 		D2Common_10184(pUnit->pDynamicPath, 0);
 		AITACTICS_Idle(pGame, pUnit, 12);
 		AITACTICS_Idle(pGame, pUnit, 24);

--- a/source/D2Game/src/MONSTER/MonsterSpawn.cpp
+++ b/source/D2Game/src/MONSTER/MonsterSpawn.cpp
@@ -109,7 +109,7 @@ int32_t __fastcall sub_6FC68630(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nS
     {
         if (pTarget && pTarget->dwFlags & UNITFLAG_TARGETABLE)
         {
-            return COLLISION_CheckMaskWithPattern2(UNITS_GetRoom(pTarget), CLIENTS_GetUnitX(pTarget), CLIENTS_GetUnitY(pTarget), PATH_GetUnitCollisionPattern(pTarget), 0x3C01u) == 0;
+            return COLLISION_CheckAnyCollisionWithPattern(UNITS_GetRoom(pTarget), CLIENTS_GetUnitX(pTarget), CLIENTS_GetUnitY(pTarget), PATH_GetUnitCollisionPattern(pTarget), 0x3C01u) == 0;
         }
 
         return 0;
@@ -139,7 +139,7 @@ int32_t __fastcall sub_6FC68630(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nS
         coords.nY = nTargetY;
         
         D2RoomStrc* pRoom = COLLISION_GetFreeCoordinates(UNITS_GetRoom(pUnit), &coords, UNITS_GetUnitSizeX(pUnit), 0x3C01u, 0);
-        if (!pRoom || DUNGEON_IsRoomInTown(pRoom) || COLLISION_CheckMaskWithPattern2(pRoom, nTargetX, nTargetY, PATH_GetUnitCollisionPattern(pUnit), 0x3C01u))
+        if (!pRoom || DUNGEON_IsRoomInTown(pRoom) || COLLISION_CheckAnyCollisionWithPattern(pRoom, nTargetX, nTargetY, PATH_GetUnitCollisionPattern(pUnit), 0x3C01u))
         {
             return 0;
         }
@@ -160,7 +160,7 @@ int32_t __fastcall sub_6FC68630(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nS
         }
 
         D2RoomStrc* pRoom = D2GAME_GetRoom_6FC52070(UNITS_GetRoom(pUnit), nX, nY);
-        if (!pRoom || DUNGEON_IsRoomInTown(pRoom) || COLLISION_CheckMaskWithPattern2(pRoom, nX, nY, PATH_GetUnitCollisionPattern(pUnit), 0x3C01u))
+        if (!pRoom || DUNGEON_IsRoomInTown(pRoom) || COLLISION_CheckAnyCollisionWithPattern(pRoom, nX, nY, PATH_GetUnitCollisionPattern(pUnit), 0x3C01u))
         {
             return 0;
         }

--- a/source/D2Game/src/MONSTER/MonsterUnique.cpp
+++ b/source/D2Game/src/MONSTER/MonsterUnique.cpp
@@ -1692,7 +1692,7 @@ void __fastcall sub_6FC6DDE0(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nUMod
         return;
     }
 
-    if (COLLISION_CheckMaskWithPattern1(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), 1, 0x3C01u))
+    if (COLLISION_CheckMaskWithPattern(UNITS_GetRoom(pUnit), CLIENTS_GetUnitX(pUnit), CLIENTS_GetUnitY(pUnit), 1, 0x3C01u))
     {
         EVENT_SetEvent(pGame, pUnit, UNITEVENTCALLBACK_MONUMOD, pGame->dwGameFrame + 10 * pMonStatsTxtRecord->wAiParam[0][pGame->nDifficulty] + 1, 0, 0);
     }

--- a/source/D2Game/src/SKILLS/SkillBar.cpp
+++ b/source/D2Game/src/SKILLS/SkillBar.cpp
@@ -1572,7 +1572,7 @@ int32_t __fastcall SKILLS_SrvSt41_LeapAttack(D2GameStrc* pGame, D2UnitStrc* pUni
     
     int32_t nX = 0;
     int32_t nY = 0;
-    if (!D2Common_11037(pUnit, pTarget, &nX, &nY))
+    if (!SKILLS_CheckIfCanLeapTo(pUnit, pTarget, &nX, &nY))
     {
         if (pTarget && UNITS_IsInMeleeRange(pUnit, pTarget, 0))
         {
@@ -1589,7 +1589,7 @@ int32_t __fastcall SKILLS_SrvSt41_LeapAttack(D2GameStrc* pGame, D2UnitStrc* pUni
         return 0;
     }
 
-    COLLISION_SetMaskWithPattern(pRoom, nX, nY, PATH_GetUnitCollisionPattern(pUnit), 0x80u);
+    COLLISION_SetMaskWithPattern(pRoom, nX, nY, PATH_GetUnitCollisionPattern(pUnit), COLLIDE_PLAYER);
 
     sub_6FCBDE90(pUnit, 1);
     SKILLS_SetParam1(pSkill, nX);

--- a/source/D2Game/src/SKILLS/SkillBar.cpp
+++ b/source/D2Game/src/SKILLS/SkillBar.cpp
@@ -1337,7 +1337,7 @@ int32_t __fastcall SKILLS_FindLeapTargetPosition(D2UnitStrc* pUnit, int32_t nSki
         D2RoomStrc* pRoom = COLLISION_GetFreeCoordinates(D2GAME_GetRoom_6FC52070(UNITS_GetRoom(pUnit), coords.nX, coords.nY), &coords, UNITS_GetUnitSizeX(pUnit), 0x1C09u, 1);
         nX = coords.nX;
         nY = coords.nY;
-        if (pRoom && !COLLISION_CheckMaskWithPattern2(pRoom, nX, nY, PATH_GetUnitCollisionPattern(pUnit), 0x1C09) && D2Common_11025(nUnitX, nUnitY, nX, nY, pRoom, 0x804) && UNITS_GetDistanceToCoordinates(pUnit, nX, nY) <= nAuraRange)
+        if (pRoom && !COLLISION_CheckAnyCollisionWithPattern(pRoom, nX, nY, PATH_GetUnitCollisionPattern(pUnit), 0x1C09) && D2Common_11025(nUnitX, nUnitY, nX, nY, pRoom, 0x804) && UNITS_GetDistanceToCoordinates(pUnit, nX, nY) <= nAuraRange)
         {
             *pX = nX;
             *pY = nY;

--- a/source/D2Game/src/SKILLS/SkillItem.cpp
+++ b/source/D2Game/src/SKILLS/SkillItem.cpp
@@ -1924,7 +1924,7 @@ int32_t __fastcall SKILLITEM_HandleItemEffectSkill(D2GameStrc* pGame, D2UnitStrc
 
     switch (pSkillsTxtRecord->nItemTarget)
     {
-    case 1u:
+    case SKILLSITEMTARGET_CASTER:
     {
         UNITS_SetTargetUnitForDynamicUnit(pUnit, pUnit);
         if (pUnitType)
@@ -1939,7 +1939,7 @@ int32_t __fastcall SKILLITEM_HandleItemEffectSkill(D2GameStrc* pGame, D2UnitStrc
         }
         break;
     }
-    case 2u:
+    case SKILLSITEMTARGET_RANDOM:
     {
         if (SKILLITEM_FindTargetPosition(pGame, pUnit, nSkillId, nSkillLevel))
         {
@@ -1960,7 +1960,7 @@ int32_t __fastcall SKILLITEM_HandleItemEffectSkill(D2GameStrc* pGame, D2UnitStrc
         }
         break;
     }
-    case 3u:
+    case SKILLSITEMTARGET_RANDOM_CORPSE:
     {
         D2UnitStrc* pTarget = sub_6FD15210(pUnit, SUNIT_GetTargetUnit(pGame, pUnit), nSkillId, nSkillLevel);
         if (pTarget)
@@ -1979,7 +1979,7 @@ int32_t __fastcall SKILLITEM_HandleItemEffectSkill(D2GameStrc* pGame, D2UnitStrc
         }
         break;
     }
-    case 4u:
+    case SKILLSITEMTARGET_LAST_ATTACKER:
     {
         if (!SUNIT_GetTargetUnit(pGame, pUnit))
         {

--- a/source/D2Game/src/SKILLS/SkillItem.cpp
+++ b/source/D2Game/src/SKILLS/SkillItem.cpp
@@ -1874,7 +1874,7 @@ int32_t __fastcall SKILLITEM_FindTargetPosition(D2GameStrc* pGame, D2UnitStrc* p
     {
         const int32_t nX = nUnitX + ITEMS_RollRandomNumber(&pUnit->pSeed) % 40 - 20;
         const int32_t nY = nUnitY + ITEMS_RollRandomNumber(&pUnit->pSeed) % 40 - 20;
-        if (!COLLISION_CheckMaskWithPattern1(pRoom, nX, nY, nCollisionPattern, nMask))
+        if (!COLLISION_CheckMaskWithPattern(pRoom, nX, nY, nCollisionPattern, nMask))
         {
             D2COMMON_10170_PathSetTargetPos(pUnit->pDynamicPath, nX, nY);
             return 1;

--- a/source/D2Game/src/SKILLS/SkillMonst.cpp
+++ b/source/D2Game/src/SKILLS/SkillMonst.cpp
@@ -1315,7 +1315,7 @@ int32_t __fastcall SKILLS_SrvDo097_Resurrect(D2GameStrc* pGame, D2UnitStrc* pUni
     const int32_t nY = CLIENTS_GetUnitY(pTarget);
 
     D2RoomStrc* pRoom = UNITS_GetRoom(pTarget);
-    if (pRoom && !COLLISION_CheckMaskWithPattern2(pRoom, nX, nY, PATH_GetUnitCollisionPattern(pTarget), pTarget->dwUnitType != UNIT_PLAYER ? 0x3C01u : 0x1C09u))
+    if (pRoom && !COLLISION_CheckAnyCollisionWithPattern(pRoom, nX, nY, PATH_GetUnitCollisionPattern(pTarget), pTarget->dwUnitType != UNIT_PLAYER ? 0x3C01u : 0x1C09u))
     {
         PATH_SetTargetUnit(pUnit->pDynamicPath, pTarget);
         SKILLS_ResurrectUnit(pGame, pTarget);

--- a/source/D2Game/src/UNIT/SUnit.cpp
+++ b/source/D2Game/src/UNIT/SUnit.cpp
@@ -572,7 +572,7 @@ D2UnitStrc* __fastcall SUNIT_AllocUnitData(int32_t nUnitType, int32_t nClassId, 
             if (pUnit->dwAnimMode == PLRMODE_DEAD || pUnit->dwAnimMode == PLRMODE_DEATH)
             {
                 D2Common_10223(pUnit, 1);
-                PATH_SetUnitCollisionPattern(pUnit, 5);
+                PATH_SetUnitCollisionPattern(pUnit, COLLISION_PATTERN_SMALL_NO_PRESENCE);
                 PATH_SetCollisionType(pUnit->pDynamicPath, 0x8000u);
             }
         }
@@ -584,7 +584,7 @@ D2UnitStrc* __fastcall SUNIT_AllocUnitData(int32_t nUnitType, int32_t nClassId, 
                 if (!pMonStatsTxt2Record || !(pMonStatsTxt2Record->dwFlags & gdwBitMasks[MONSTATS2FLAGINDEX_DEADCOL]))
                 {
                     D2Common_10223(pUnit, 1);
-                    PATH_SetUnitCollisionPattern(pUnit, 5);
+                    PATH_SetUnitCollisionPattern(pUnit, COLLISION_PATTERN_SMALL_NO_PRESENCE);
                     PATH_SetCollisionType(pUnit->pDynamicPath, 0x8000u);
                     return pUnit;
                 }
@@ -799,7 +799,7 @@ void __fastcall SUNIT_Restore(D2GameStrc* pGame, D2UnitStrc* pUnit, D2RoomStrc* 
         if (pUnit->dwAnimMode == PLRMODE_DEAD || pUnit->dwAnimMode == PLRMODE_DEATH)
         {
             D2Common_10223(pUnit, 1);
-            PATH_SetUnitCollisionPattern(pUnit, 5);
+            PATH_SetUnitCollisionPattern(pUnit, COLLISION_PATTERN_SMALL_NO_PRESENCE);
             PATH_SetCollisionType(pUnit->pDynamicPath, 0x8000);
         }
         break;
@@ -825,7 +825,7 @@ void __fastcall SUNIT_Restore(D2GameStrc* pGame, D2UnitStrc* pUnit, D2RoomStrc* 
         if (MONSTERS_IsDead(pUnit))
         {
             D2Common_10223(pUnit, 1);
-            PATH_SetUnitCollisionPattern(pUnit, 5);
+            PATH_SetUnitCollisionPattern(pUnit, COLLISION_PATTERN_SMALL_NO_PRESENCE);
             PATH_SetCollisionType(pUnit->pDynamicPath, 0x8000);
         }
         break;


### PR DESCRIPTION
This fixes a few colllision mask related functions as well as cleans the code.
New `D2C_CollisionUnitSize` and `D2C_CollisionPattern` enums were introduced to fix the previously wrong usage of `D2C_CollisionFlags` in some places.

A new `D2C_SkillsTxtItemTarget` enum has also been introduced as some functions using the collision patterns needed.

I'm not very pleased with some of the function names, but this will have to do for now.