### PR TITLE
Update game statistics related code

### DIFF
--- a/source/D2CommonDefinitions/include/D2Constants.h
+++ b/source/D2CommonDefinitions/include/D2Constants.h
@@ -3,6 +3,7 @@
 enum D2HarcodedConstants
 {
 	HARDCODEDCST_MAX_LEVEL = 99, // Should be using DATATBLS_GetMaxLevel instead
+	DEFAULT_FRAMES_PER_SECOND = 25
 };
 
 enum D2GameTypeMode

--- a/source/D2Game/include/GAME/Arena.h
+++ b/source/D2Game/include/GAME/Arena.h
@@ -17,29 +17,18 @@ enum D2ArenaScoreTypes
     NUM_ARENA_SCORES,
 };
 
-enum D2ArenaFlags
-{
-    ARENAFLAG_ARENAMODE     = 0x00000002,
-    ARENAFLAG_UPDATECLIENTS = 0x00000004,
-    ARENAFLAG_TEMPLATE      = 0x00000020,
-    ARENAFLAG_UPDATE        = 0x00000400,
-    ARENAFLAG_HARDCORE      = 0x00000800,
-    ARENAFLAG_ACTIVE        = 0x00010000,
-    ARENAFLAG_ALLOWPARTY    = 0x00100000
-};
-
 struct D2ArenaStrc
 {
     int32_t nAlternateStartTown;				//0x00
     int32_t nType;								//0x04
-    uint32_t fFlags;							//0x08 D2ArenaFlags
+    uint32_t fFlags;							//0x08 D2GameFlags
     int32_t nTemplate;							//0x0C - uint8_t with 3 pad
 };
 
 struct D2ArenaUnitStrc
 {
     int32_t nScore;								//0x00
-    BOOL bUpdateScore;						//0x04 
+    BOOL bUpdateScore;						    //0x04 
 };
 
 #pragma pack()

--- a/source/D2Game/include/GAME/Game.h
+++ b/source/D2Game/include/GAME/Game.h
@@ -23,6 +23,21 @@ enum D2PacketTypeAdmin
 	PACKET_ADMIN_GETGAMEINFO = 0xFD
 };
 
+enum D2GameFlags
+{
+	GAMEFLAG_ARENA_MODE          = 0x00000002,
+	GAMEFLAG_ARENA_UPDATECLIENTS = 0x00000004,
+	GAMEFLAG_ARENA_TEMPLATE      = 0x00000020,
+	GAMEFLAG_ARENA_UPDATE        = 0x00000400,
+	GAMEFLAG_ARENA_HARDCORE      = 0x00000800,
+	GAMEFLAG_ARENA_ACTIVE        = 0x00010000,
+	GAMEFLAG_ARENA_EXPANSION     = 0x00100000,
+	GAMEFLAG_ARENA_LADDER        = 0x00200000,
+
+	GAMEFLAG_DIFFICULTY_BIT      = 12,
+	GAMEFLAG_DIFFICULTY_MASK     = (0x7) << GAMEFLAG_DIFFICULTY_BIT,
+};
+
 using D2GameGUID = uint32_t;
 constexpr D2GameGUID D2GameInvalidGUID = (D2GameGUID)-1;
 
@@ -86,40 +101,35 @@ struct D2GameManagerStrc
 };
 
 struct D2GameInfoStrc {
-    int32_t nServerToken;
-    uint32_t nInitSeed;
-    int32_t nClients;
-    int32_t nPlayers;
-    int32_t nMonsters;
-    int32_t nObjects;
-    int32_t nItems;
-    int32_t nMissiles;
-    int32_t unk0x20;
-    int32_t unk0x24;
-    int32_t nSpawnedPlayers;
-    int32_t nSpawnedMonsters;
-    int32_t nSpawnedObjects;
-    int32_t nSpawnedMissiles;
-    int32_t nSpawnedItems;
-    int32_t nSpawnedTiles;
-    int32_t unk0x40;
-    int32_t unk0x44;
-    int32_t unk0x48;
-    int32_t unk0x4C;
-    int32_t unk0x50;
-    int32_t unk0x54;
-    int32_t unk0x58;
-    int32_t unk0x5C;
-    int32_t unk0x60;
-    char szGameName[16];
-    char szGamePassword[16];
-    char szGameDescription[32];
-    uint8_t nArenaTemplate;
-    uint8_t unk0xA5;
-    uint8_t unk0xA6;
-    uint8_t unk0xA7;
-    uint32_t nArenaFlags;
-    void* pMemoryPool;
+    int32_t nServerToken;							// 0x00 nGameId
+    uint32_t nInitSeed;								// 0x04
+    int32_t nClients;								// 0x08
+    int32_t nPlayers;								// 0x0C
+    int32_t nMonsters;								// 0x10
+	int32_t nObjects;								// 0x14
+	int32_t nItems;									// 0x18
+	int32_t nMissiles;								// 0x1C
+    int32_t nUniqueItems;							// 0x20
+	int32_t nNPCs;									// 0x24
+	uint32_t dwLastUsedUnitGUID[UNIT_TYPES_COUNT];	// 0x3C Tile = Warp
+    int32_t nPathTowardPct;							// 0x40
+	int32_t nPathClockPct;							// 0x44
+	int32_t nPathCounterPct;						// 0x48
+	int32_t nPathFoWallPct;							// 0x4C
+	int32_t nPathAStarPct;							// 0x50
+	int32_t nPathTotalCalls;						// 0x54
+	int32_t nFrames;								// 0x58 Frames / 100
+	int32_t nTime;									// 0x5C Time (minutes)
+    int32_t nFrameRate;								// 0x60
+	char szGameName[16];							// 0x64
+	char szGamePassword[16];						// 0x74
+	char szGameDescription[32];						// 0x84 Before 1.10f (unsure what version), struct used to have desc of 24 chars, and end here.
+	uint8_t nArenaTemplate;							// 0xA4
+	uint8_t unk0xA5;								// 0xA5
+	uint8_t unk0xA6;								// 0xA6
+	uint8_t unk0xA7;								// 0xA7
+    uint32_t nArenaFlags;							// 0xA8
+    void* pMemoryPool;								// 0xAC
 };
 
 struct D2TargetNodeStrc
@@ -161,7 +171,9 @@ struct D2GameStrc
 	uint32_t nClients;								//0x8C
 	uint32_t dwLastUsedUnitGUID[UNIT_TYPES_COUNT];	//0x90
 	int32_t dwGameFrame;							//0xA8
-	uint32_t unk0xAC[3];							//0xAC
+	uint32_t nFrameRate;							//0xAC
+	uint32_t nFramesSinceLastFrameRateUpdate;		//0xB0
+	uint32_t nPreviousUpdateTickCount;				//0xB4
 	D2EventTimerQueueStrc* pTimerQueue;				//0xB8
 	D2DrlgActStrc* pAct[5];							//0xBC
 	D2SeedStrc pGameSeed;							//0xD0

--- a/source/D2Game/include/GAME/Game.h
+++ b/source/D2Game/include/GAME/Game.h
@@ -119,7 +119,7 @@ struct D2GameInfoStrc {
 	int32_t nPathAStarPct;							// 0x50
 	int32_t nPathTotalCalls;						// 0x54
 	int32_t nFrames;								// 0x58 Frames / 100
-	int32_t nTime;									// 0x5C Time (minutes)
+	int32_t nTime;									// 0x5C Time (minutes) since game creation (bugged, actually returns machine uptime)
     int32_t nFrameRate;								// 0x60
 	char szGameName[16];							// 0x64
 	char szGamePassword[16];						// 0x74
@@ -192,8 +192,9 @@ struct D2GameStrc
 	uint8_t nBossFlagList[64];						//0x1D30
 	uint32_t dwMonModeData[17];						//0x1D70
 	uint32_t nMonModeData;							//0x1DB4
-	uint32_t unk0x1DB8[2];							//0x1DB8
-	uint32_t nTickRelated;							//0x1DC0
+	uint32_t nLastUpdateSystemTimeMs;				//0x1DB8
+	uint32_t nCreationTimeMs_Or_CPUTargetRatioFP10;	//0x1DBC Used to be the creation time, but now represents ratio of the budget used for last frame, in FP10 represenation (x/1024)
+	uint32_t nTickCountSinceNoClients;				//0x1DC0
 	uint32_t nSyncTimer;							//0x1DC4
 
 	uint32_t unk0x1DC8;								//0x1DC8

--- a/source/D2Game/include/GAME/Game.h
+++ b/source/D2Game/include/GAME/Game.h
@@ -128,7 +128,7 @@ struct D2GameInfoStrc
 	uint8_t nArenaTemplate;							// 0xA4
 	uint8_t unk0xA5;								// 0xA5
 	uint8_t unk0xA6;								// 0xA6
-	uint8_t unk0xA7;								// 0xA7
+	uint8_t padding0xA7;							// 0xA7
 	uint32_t nArenaFlags;							// 0xA8
 	void* pMemoryPool;								// 0xAC
 };

--- a/source/D2Game/include/GAME/Game.h
+++ b/source/D2Game/include/GAME/Game.h
@@ -100,19 +100,20 @@ struct D2GameManagerStrc
 	CRITICAL_SECTION pLock;
 };
 
-struct D2GameInfoStrc {
-    int32_t nServerToken;							// 0x00 nGameId
-    uint32_t nInitSeed;								// 0x04
-    int32_t nClients;								// 0x08
-    int32_t nPlayers;								// 0x0C
-    int32_t nMonsters;								// 0x10
+struct D2GameInfoStrc
+{
+	int32_t nServerToken;							// 0x00 nGameId
+	uint32_t nInitSeed;								// 0x04
+	int32_t nClients;								// 0x08
+	int32_t nPlayers;								// 0x0C
+	int32_t nMonsters;								// 0x10
 	int32_t nObjects;								// 0x14
 	int32_t nItems;									// 0x18
 	int32_t nMissiles;								// 0x1C
-    int32_t nUniqueItems;							// 0x20
+	int32_t nUniqueItems;							// 0x20
 	int32_t nNPCs;									// 0x24
 	uint32_t dwLastUsedUnitGUID[UNIT_TYPES_COUNT];	// 0x3C Tile = Warp
-    int32_t nPathTowardPct;							// 0x40
+	int32_t nPathTowardPct;							// 0x40
 	int32_t nPathClockPct;							// 0x44
 	int32_t nPathCounterPct;						// 0x48
 	int32_t nPathFoWallPct;							// 0x4C
@@ -120,7 +121,7 @@ struct D2GameInfoStrc {
 	int32_t nPathTotalCalls;						// 0x54
 	int32_t nFrames;								// 0x58 Frames / 100
 	int32_t nTime;									// 0x5C Time (minutes) since game creation (bugged, actually returns machine uptime)
-    int32_t nFrameRate;								// 0x60
+	int32_t nFrameRate;								// 0x60
 	char szGameName[16];							// 0x64
 	char szGamePassword[16];						// 0x74
 	char szGameDescription[32];						// 0x84 Before 1.10f (unsure what version), struct used to have desc of 24 chars, and end here.
@@ -128,8 +129,8 @@ struct D2GameInfoStrc {
 	uint8_t unk0xA5;								// 0xA5
 	uint8_t unk0xA6;								// 0xA6
 	uint8_t unk0xA7;								// 0xA7
-    uint32_t nArenaFlags;							// 0xA8
-    void* pMemoryPool;								// 0xAC
+	uint32_t nArenaFlags;							// 0xA8
+	void* pMemoryPool;								// 0xAC
 };
 
 struct D2TargetNodeStrc

--- a/source/D2Game/src/AI/AiThink.cpp
+++ b/source/D2Game/src/AI/AiThink.cpp
@@ -4994,7 +4994,7 @@ void __fastcall AITHINK_Fn056_Tentacle(D2GameStrc* pGame, D2UnitStrc* pUnit, D2A
 		{
 			AITACTICS_UseSkill(pGame, pUnit, pAiTickParam->pMonstatsTxt->nSkillMode[0], pAiTickParam->pMonstatsTxt->nSkill[0], pAiTickParam->pTarget, 0, 0);
 			AITACTICS_Idle(pGame, pUnit, 8);
-			pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + 25 * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_SUBMERGE_DURATION_SECONDS);
+			pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + DEFAULT_FRAMES_PER_SECOND * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_SUBMERGE_DURATION_SECONDS);
 			pAiTickParam->pAiControl->dwAiParam[2] = 1;
 			return;
 		}
@@ -5007,7 +5007,7 @@ void __fastcall AITHINK_Fn056_Tentacle(D2GameStrc* pGame, D2UnitStrc* pUnit, D2A
 			{
 				AITACTICS_UseSkill(pGame, pUnit, pAiTickParam->pMonstatsTxt->nSkillMode[0], pAiTickParam->pMonstatsTxt->nSkill[0], pAiTickParam->pTarget, 0, 0);
 				AITACTICS_Idle(pGame, pUnit, 8);
-				pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + 25 * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_SUBMERGE_DURATION_SECONDS);
+				pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + DEFAULT_FRAMES_PER_SECOND * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_SUBMERGE_DURATION_SECONDS);
 				pAiTickParam->pAiControl->dwAiParam[2] = 1;
 				return;
 			}
@@ -5034,7 +5034,7 @@ void __fastcall AITHINK_Fn056_Tentacle(D2GameStrc* pGame, D2UnitStrc* pUnit, D2A
 			if (pAiTickParam->bCombat || pAiTickParam->nTargetDistance < AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_ACTIVE_DISTANCE) || pOwner->dwAnimMode != MONMODE_SEQUENCE && (AI_RollPercentage(pUnit) < 5))
 			{
 				AITACTICS_UseSkill(pGame, pUnit, pAiTickParam->pMonstatsTxt->nSkillMode[1], pAiTickParam->pMonstatsTxt->nSkill[1], pUnit, 0, 0);
-				pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + 25 * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_EMERGE_DURATION_SECONDS);
+				pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + DEFAULT_FRAMES_PER_SECOND * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_EMERGE_DURATION_SECONDS);
 				pAiTickParam->pAiControl->dwAiParam[2] = 2;
 				return;
 			}
@@ -5068,7 +5068,7 @@ void __fastcall AITHINK_Fn057_TentacleHead(D2GameStrc* pGame, D2UnitStrc* pUnit,
 			AITACTICS_UseSkill(pGame, pUnit, pAiTickParam->pMonstatsTxt->nSkillMode[0], pAiTickParam->pMonstatsTxt->nSkill[0], pAiTickParam->pTarget, 0, 0);
 			AITACTICS_Idle(pGame, pUnit, 8);
 			pAiTickParam->pAiControl->dwAiParam[2] = 1;
-			pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + 25 * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_SUBMERGE_DURATION_SECONDS);
+			pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + DEFAULT_FRAMES_PER_SECOND * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_SUBMERGE_DURATION_SECONDS);
 			return;
 		}
 
@@ -5079,7 +5079,7 @@ void __fastcall AITHINK_Fn057_TentacleHead(D2GameStrc* pGame, D2UnitStrc* pUnit,
 				AITACTICS_UseSkill(pGame, pUnit, pAiTickParam->pMonstatsTxt->nSkillMode[0], pAiTickParam->pMonstatsTxt->nSkill[0], pAiTickParam->pTarget, 0, 0);
 				AITACTICS_Idle(pGame, pUnit, 20);
 				pAiTickParam->pAiControl->dwAiParam[2] = 1;
-				pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + 25 * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_SUBMERGE_DURATION_SECONDS);
+				pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + DEFAULT_FRAMES_PER_SECOND * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_SUBMERGE_DURATION_SECONDS);
 				return;
 			}
 
@@ -5088,7 +5088,7 @@ void __fastcall AITHINK_Fn057_TentacleHead(D2GameStrc* pGame, D2UnitStrc* pUnit,
 				AITACTICS_UseSkill(pGame, pUnit, pAiTickParam->pMonstatsTxt->nSkillMode[0], pAiTickParam->pMonstatsTxt->nSkill[0], pAiTickParam->pTarget, 0, 0);
 				AITACTICS_Idle(pGame, pUnit, 20);
 				pAiTickParam->pAiControl->dwAiParam[2] = 1;
-				pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + 25 * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_SUBMERGE_DURATION_SECONDS);
+				pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + DEFAULT_FRAMES_PER_SECOND * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_SUBMERGE_DURATION_SECONDS);
 				return;
 			}
 		}
@@ -5098,7 +5098,7 @@ void __fastcall AITHINK_Fn057_TentacleHead(D2GameStrc* pGame, D2UnitStrc* pUnit,
 	{
 		AITACTICS_UseSkill(pGame, pUnit, pAiTickParam->pMonstatsTxt->nSkillMode[1], pAiTickParam->pMonstatsTxt->nSkill[1], pUnit, 0, 0);
 		pAiTickParam->pAiControl->dwAiParam[2] = 2;
-		pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + 25 * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_EMERGE_DURATION_SECONDS);
+		pAiTickParam->pAiControl->dwAiParam[1] = pGame->dwGameFrame + DEFAULT_FRAMES_PER_SECOND * AI_GetParamValue(pGame, pAiTickParam, TENTACLE_AI_PARAM_EMERGE_DURATION_SECONDS);
 		return;
 	}
 
@@ -5394,7 +5394,7 @@ void __fastcall AITHINK_Fn066_SandMaggotQueen(D2GameStrc* pGame, D2UnitStrc* pUn
 {
 	if (pAiTickParam->pAiControl->dwAiParam[2])
 	{
-		AITACTICS_IdleInNeutralMode(pGame, pUnit, 25 * AI_GetParamValue(pGame, pAiTickParam, SANDMAGGOTQUEEN_AI_PARAM_DELAY));
+		AITACTICS_IdleInNeutralMode(pGame, pUnit, DEFAULT_FRAMES_PER_SECOND * AI_GetParamValue(pGame, pAiTickParam, SANDMAGGOTQUEEN_AI_PARAM_DELAY));
 		pAiTickParam->pAiControl->dwAiParam[2] = 0;
 		return;
 	}

--- a/source/D2Game/src/GAME/Arena.cpp
+++ b/source/D2Game/src/GAME/Arena.cpp
@@ -26,7 +26,7 @@ void __fastcall ARENA_AllocArena(D2GameStrc* pGame, int32_t nUnused, uint32_t nF
     D2ArenaStrc* pArena = D2_CALLOC_STRC_POOL(pGame->pMemoryPool, D2ArenaStrc);
 
     pGame->pArenaCtrl = pArena;
-    pArena->fFlags = nFlags & (0x200000 | ARENAFLAG_ALLOWPARTY | ARENAFLAG_ACTIVE | 0x4000 | 0x2000 | 0x1000 | ARENAFLAG_HARDCORE | 0x100 | 0x80 | 0x40 | ARENAFLAG_UPDATECLIENTS | ARENAFLAG_ARENAMODE | 0x01);
+    pArena->fFlags = nFlags & (GAMEFLAG_ARENA_LADDER | GAMEFLAG_ARENA_EXPANSION | GAMEFLAG_ARENA_ACTIVE | 0x4000 | 0x2000 | 0x1000 | GAMEFLAG_ARENA_HARDCORE | 0x100 | 0x80 | 0x40 | GAMEFLAG_ARENA_UPDATECLIENTS | GAMEFLAG_ARENA_MODE | 0x01);
     pArena->nTemplate = nTemplate;
 }
 
@@ -158,7 +158,7 @@ void __fastcall ARENA_UpdateScore(D2GameStrc* pGame, D2UnitStrc* pAttacker, D2Un
 
     pArenaUnit->bUpdateScore = 1;
 
-    pArena->fFlags |= ARENAFLAG_UPDATE;
+    pArena->fFlags |= GAMEFLAG_ARENA_UPDATE;
     UNITROOM_RefreshUnit(pDefender);
 }
 
@@ -166,7 +166,7 @@ void __fastcall ARENA_UpdateScore(D2GameStrc* pGame, D2UnitStrc* pAttacker, D2Un
 void __fastcall ARENA_SynchronizeWithClients(D2GameStrc* pGame, D2ClientStrc* pClient)
 {
     D2ArenaStrc* pArena = pGame->pArenaCtrl;
-    if (!pArena || !(pArena->fFlags & ARENAFLAG_UPDATE))
+    if (!pArena || !(pArena->fFlags & GAMEFLAG_ARENA_UPDATE))
     {
         return;
     }
@@ -234,7 +234,7 @@ uint32_t __fastcall ARENA_NeedsClientUpdate(D2GameStrc* pGame)
     D2ArenaStrc* pArena = pGame->pArenaCtrl;
     D2_ASSERT(pArena);
 
-    return pArena->fFlags & ARENAFLAG_UPDATECLIENTS;
+    return pArena->fFlags & GAMEFLAG_ARENA_UPDATECLIENTS;
 }
 
 //D2Game.0x6FC316D0
@@ -243,7 +243,7 @@ uint32_t __fastcall ARENA_IsInArenaMode(D2GameStrc* pGame)
     D2ArenaStrc* pArena = pGame->pArenaCtrl;
     D2_ASSERT(pArena);
 
-    return pArena->fFlags & ARENAFLAG_ARENAMODE;
+    return pArena->fFlags & GAMEFLAG_ARENA_MODE;
 }
 
 //D2Game.0x6FC31710
@@ -252,7 +252,7 @@ uint32_t __fastcall ARENA_IsActive(D2GameStrc* pGame)
     D2ArenaStrc* pArena = pGame->pArenaCtrl;
     D2_ASSERT(pArena);
 
-    return pArena->fFlags & ARENAFLAG_ACTIVE;
+    return pArena->fFlags & GAMEFLAG_ARENA_ACTIVE;
 }
 
 //D2Game.0x6FC31750

--- a/source/D2Game/src/GAME/Clients.cpp
+++ b/source/D2Game/src/GAME/Clients.cpp
@@ -379,7 +379,7 @@ int32_t __fastcall CLIENTS_AddPlayerToGame(D2ClientStrc* pClient, D2GameStrc* pG
             return SYSERROR_DEADHARDCORE;
         }
 
-        if (!(ARENA_GetFlags(pGame) & ARENAFLAG_HARDCORE))
+        if (!(ARENA_GetFlags(pGame) & GAMEFLAG_ARENA_HARDCORE))
         {
             //Fog_10030(&unk_6FD447EC, "[PLAYER LOAD]  ClientAddPlayerToGame()  Error Loading:%s  Error:SYSERROR_HARDCOREJOINSOFTCORE", pClient->szName);
             pClient->pPlayer = nullptr;
@@ -388,7 +388,7 @@ int32_t __fastcall CLIENTS_AddPlayerToGame(D2ClientStrc* pClient, D2GameStrc* pG
     }
     else
     {
-        if (ARENA_GetFlags(pGame) & ARENAFLAG_HARDCORE)
+        if (ARENA_GetFlags(pGame) & GAMEFLAG_ARENA_HARDCORE)
         {
             //Fog_10030(&unk_6FD447EC, "[PLAYER LOAD]  ClientAddPlayerToGame()  Error Loading:%s  Error:SYSERROR_SOFTCOREJOINHARDCORE", pClient->szName);
             pClient->pPlayer = nullptr;

--- a/source/D2Game/src/GAME/Task.cpp
+++ b/source/D2Game/src/GAME/Task.cpp
@@ -362,13 +362,13 @@ void __fastcall TASK_ProcessGame(char nTaskNumber, D2TaskStrc* ptTask)
         int32_t nTick = GetTickCount();
         if (pGame->nClients)
         {
-            pGame->nTickRelated = 0;
+            pGame->nTickCountSinceNoClients = 0;
         }
         else
         {
-            if (!pGame->nTickRelated)
-                pGame->nTickRelated = nTick;
-            if (nTick - pGame->nTickRelated > 300000
+            if (!pGame->nTickCountSinceNoClients)
+                pGame->nTickCountSinceNoClients = nTick;
+            if (nTick - pGame->nTickCountSinceNoClients > 300000
                 || pGame->dwGameFrame > 1500 && pGame->dwGameFrame < 7500)
             {
                 GAME_LogMessage(6, "[SERVER]  Deleting game from sSrvTaskProcessGame(), empty game");

--- a/source/D2Game/src/PLAYER/PlrSave.cpp
+++ b/source/D2Game/src/PLAYER/PlrSave.cpp
@@ -823,14 +823,14 @@ int32_t __fastcall sub_6FC8A780(D2GameStrc* pGame, D2ClientStrc* pClient, uint8_
             return SYSERROR_DEADHARDCORE;
         }
 
-        if (!(ARENA_GetFlags(pGame) & ARENAFLAG_HARDCORE))
+        if (!(ARENA_GetFlags(pGame) & GAMEFLAG_ARENA_HARDCORE))
         {
             return SYSERROR_HARDCOREJOINSOFTCORE;
         }
     }
     else
     {
-        if (ARENA_GetFlags(pGame) & ARENAFLAG_HARDCORE)
+        if (ARENA_GetFlags(pGame) & GAMEFLAG_ARENA_HARDCORE)
         {
             return SYSERROR_SOFTCOREJOINHARDCORE;
         }

--- a/source/D2Game/src/PLAYER/PlrSave2.cpp
+++ b/source/D2Game/src/PLAYER/PlrSave2.cpp
@@ -667,14 +667,14 @@ int32_t __fastcall PLRSAVE2_CheckPlayerFlags(D2GameStrc* pGame, uint32_t dwFlags
             return PLRSAVE2ERROR_DEADHARDCORE;
         }
 
-        if (!(ARENA_GetFlags(pGame) & ARENAFLAG_HARDCORE))
+        if (!(ARENA_GetFlags(pGame) & GAMEFLAG_ARENA_HARDCORE))
         {
             return PLRSAVE2ERROR_HARDCOREJOINSOFTCORE;
         }
     }
     else
     {
-        if (ARENA_GetFlags(pGame) & ARENAFLAG_HARDCORE)
+        if (ARENA_GetFlags(pGame) & GAMEFLAG_ARENA_HARDCORE)
         {
             return PLRSAVE2ERROR_SOFTCOREJOINHARDCORE;
         }

--- a/source/D2Game/src/UNIT/SUnit.cpp
+++ b/source/D2Game/src/UNIT/SUnit.cpp
@@ -482,7 +482,11 @@ D2UnitStrc* __fastcall SUNIT_AllocUnitData(int32_t nUnitType, int32_t nClassId, 
     pUnit->dwFlags |= UNITFLAG_INITSEEDSET;
 
     uint32_t nUnitGUID = 0;
-    if (nUnitType != UNIT_MONSTER)
+    if (nUnitType == UNIT_MONSTER && (a7 & 2) != 0)
+    {
+        nUnitGUID = a3;
+    }
+    else
     {
         D2_ASSERT(nUnitType < 6);
 
@@ -493,23 +497,6 @@ D2UnitStrc* __fastcall SUNIT_AllocUnitData(int32_t nUnitType, int32_t nClassId, 
         }
 
         pGame->dwLastUsedUnitGUID[nUnitType] = nUnitGUID;
-    }
-    else
-    {
-        if (!(a7 & 2))
-        {
-            nUnitGUID = pGame->dwLastUsedUnitGUID[nUnitType] + 1;
-            if (pGame->dwLastUsedUnitGUID[nUnitType] == -2)
-            {
-                nUnitGUID = 1;
-            }
-
-            pGame->dwLastUsedUnitGUID[nUnitType] = nUnitGUID;
-        }
-        else
-        {
-            nUnitGUID = a3;
-        }
     }
 
     switch (nUnitGUID)


### PR DESCRIPTION
This almost completes the `D2GameInfoStrc` structure, only fields 0xA5 and 0xA6 are now unknown/unnamed. Those are passed as arguments by the server during game creation. (Local/TCP-IP games set them to 0).

This also introduces `DEFAULT_FRAMES_PER_SECOND` which can now be used for frame duration calculations instead of hardcoding `25` everywhere.