### PR TITLE
Add Clientstate enum and rename some functions

### DIFF
--- a/source/D2Game/include/GAME/Clients.h
+++ b/source/D2Game/include/GAME/Clients.h
@@ -37,7 +37,7 @@ enum D2SystemError
 	SYSERROR_NOTLADDERGAME = 26,
 };
 
-enum D2ClientState
+enum D2ClientState : uint32_t
 {
 	CLIENTSTATE_JUST_CREATED = 0,
 	CLIENTSTATE_GAME_INIT_SENT = 1,
@@ -162,7 +162,7 @@ struct D2GuildInformationStrc
 struct D2ClientStrc
 {
 	uint32_t dwClientId;						//0x00
-	uint32_t dwClientState;						//0x04 D2ClientState
+	D2ClientState dwClientState;				//0x04
 	uint8_t nClassId;							//0x08
 	uint8_t unk0x09;							//0x09
 	uint16_t nSaveFlags;						//0x0A D2ClientSaveFlags
@@ -297,7 +297,7 @@ int32_t __fastcall CLIENTS_CheckFlag(D2ClientStrc* pClient, uint16_t nFlag);
 //D2Game.0x6FC33A70
 void __fastcall CLIENTS_UpdateCharacterProgression(D2ClientStrc* pClient, uint16_t nAct, uint16_t nDifficulty);
 //D2Game.0x6FC33AC0
-void __fastcall CLIENTS_SetClientState(D2ClientStrc* pClient, uint32_t nClientState);
+void __fastcall CLIENTS_SetClientState(D2ClientStrc* pClient, D2ClientState nClientState);
 //D2Game.0x6FC33AF0
 void __fastcall CLIENTS_SetIronGolemItemGUID(D2ClientStrc* pClient, int32_t nIronGolemItemGUID);
 //D2Game.0x6FC33B20
@@ -313,7 +313,7 @@ char* __fastcall CLIENTS_GetName(D2ClientStrc* pClient);
 //D2Game.0x6FC33C10
 uint32_t __fastcall sub_6FC33C10(D2ClientStrc* pClient);
 //D2Game.0x6FC33C50
-BOOL __fastcall CLIENTS_CheckState(int32_t nClientId, int32_t nExpectedClientState);
+BOOL __fastcall CLIENTS_CheckState(int32_t nClientId, D2ClientState nExpectedClientState);
 //D2Game.0x6FC33CD0
 void __fastcall CLIENTS_UpdatePing(int32_t nClientId, int32_t a2, int32_t arg_0);
 //D2Game.0x6FC33EA0

--- a/source/D2Game/include/GAME/Clients.h
+++ b/source/D2Game/include/GAME/Clients.h
@@ -37,6 +37,16 @@ enum D2SystemError
 	SYSERROR_NOTLADDERGAME = 26,
 };
 
+enum D2ClientState
+{
+	CLIENTSTATE_JUST_CREATED = 0,
+	CLIENTSTATE_GAME_INIT_SENT = 1,
+	CLIENTSTATE_ACT_INIT_SENT = 2,
+	CLIENTSTATE_PLAYER_SPAWNED = 3,
+	CLIENTSTATE_INGAME = 4,
+	CLIENTSTATE_CHANGING_ACT = 5,
+};
+
 // Character information flags
 enum D2ClientSaveFlags
 {
@@ -152,7 +162,7 @@ struct D2GuildInformationStrc
 struct D2ClientStrc
 {
 	uint32_t dwClientId;						//0x00
-	uint32_t dwClientState;						//0x04
+	uint32_t dwClientState;						//0x04 D2ClientState
 	uint8_t nClassId;							//0x08
 	uint8_t unk0x09;							//0x09
 	uint16_t nSaveFlags;						//0x0A D2ClientSaveFlags
@@ -303,7 +313,7 @@ char* __fastcall CLIENTS_GetName(D2ClientStrc* pClient);
 //D2Game.0x6FC33C10
 uint32_t __fastcall sub_6FC33C10(D2ClientStrc* pClient);
 //D2Game.0x6FC33C50
-int32_t __fastcall CLIENTS_Verify(int32_t nClientId, int32_t dwFlags);
+BOOL __fastcall CLIENTS_CheckState(int32_t nClientId, int32_t nExpectedClientState);
 //D2Game.0x6FC33CD0
 void __fastcall CLIENTS_UpdatePing(int32_t nClientId, int32_t a2, int32_t arg_0);
 //D2Game.0x6FC33EA0

--- a/source/D2Game/include/GAME/Game.h
+++ b/source/D2Game/include/GAME/Game.h
@@ -367,7 +367,7 @@ void __stdcall D2Game_10021(int32_t a1, int32_t nPacketParam, const char* szMess
 //D2Game.0x6FC3AFB0
 void __stdcall D2Game_10022(uint16_t a1, const char* Str2);
 //D2Game.0x6FC3B0E0
-void __fastcall GAME_SendPacketToAllConnectedClients(D2GameStrc* pGame, void(__fastcall* pFn)(D2ClientStrc*, void*), void* pPacket);
+void __fastcall GAME_ForEachIngameClient(D2GameStrc* pGame, void(__fastcall* pFn)(D2ClientStrc*, void*), void* pContext);
 //D2Game.0x6FC3B160
 D2GameStrc* __fastcall sub_6FC3B160();
 //D2Game.0x6FC3B220

--- a/source/D2Game/include/GAME/SCmd.h
+++ b/source/D2Game/include/GAME/SCmd.h
@@ -14,7 +14,7 @@ void __fastcall sub_6FC3C6B0(int32_t nClientId);
 //D2Game.0x6FC3C6D0
 void __fastcall sub_6FC3C6D0(int32_t nClientId, uint32_t nErrorCode);
 //D2Game.0x6FC3C6F0
-void __fastcall D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(D2ClientStrc* pClient, uint8_t nHeader);
+void __fastcall D2GAME_PACKETS_SendHeaderOnlyPacket(D2ClientStrc* pClient, uint8_t nHeader);
 //D2Game.0x6FC3C710
 void __fastcall D2GAME_PACKETS_SendPacket_6FC3C710(D2ClientStrc* pClient, void* pPacket, int32_t nPacketSize);
 //D2Game.0x6FC3C7C0

--- a/source/D2Game/include/GAME/SCmd.h
+++ b/source/D2Game/include/GAME/SCmd.h
@@ -14,7 +14,7 @@ void __fastcall sub_6FC3C6B0(int32_t nClientId);
 //D2Game.0x6FC3C6D0
 void __fastcall sub_6FC3C6D0(int32_t nClientId, uint32_t nErrorCode);
 //D2Game.0x6FC3C6F0
-void __fastcall D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(D2ClientStrc* pClient, uint8_t nHeader);
+void __fastcall D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(D2ClientStrc* pClient, uint8_t nHeader);
 //D2Game.0x6FC3C710
 void __fastcall D2GAME_PACKETS_SendPacket_6FC3C710(D2ClientStrc* pClient, void* pPacket, int32_t nPacketSize);
 //D2Game.0x6FC3C7C0

--- a/source/D2Game/src/GAME/Arena.cpp
+++ b/source/D2Game/src/GAME/Arena.cpp
@@ -192,7 +192,7 @@ void __fastcall ARENA_SynchronizeWithClients(D2GameStrc* pGame, D2ClientStrc* pC
     for (D2ClientStrc* i = pGame->pClientList; i; i = i->pNext)
     {
         D2UnitStrc* pOtherPlayer = CLIENTS_GetPlayerFromClient(i, 0);
-        if (i->dwClientState == 4 && pOtherPlayer && pOtherPlayer != pLocalPlayer)
+        if (i->dwClientState == CLIENTSTATE_INGAME && pOtherPlayer && pOtherPlayer != pLocalPlayer)
         {
             D2ArenaUnitStrc* pArenaUnit = UNITS_GetPlayerData(pOtherPlayer)->pArenaUnit;
             D2_ASSERT(pArenaUnit);
@@ -211,7 +211,7 @@ void __fastcall ARENA_SendScoresToClient(D2GameStrc* pGame, D2ClientStrc* pClien
     for (D2ClientStrc* i = pGame->pClientList; i; i = i->pNext)
     {
         D2UnitStrc* pPlayer = CLIENTS_GetPlayerFromClient(i, 0);
-        if (i->dwClientState == 4 && pPlayer)
+        if (i->dwClientState == CLIENTSTATE_INGAME && pPlayer)
         {
             D2ArenaUnitStrc* pArenaUnit = UNITS_GetPlayerData(pPlayer)->pArenaUnit;
             D2_ASSERT(pArenaUnit);
@@ -220,7 +220,7 @@ void __fastcall ARENA_SendScoresToClient(D2GameStrc* pGame, D2ClientStrc* pClien
     }
     
     D2UnitStrc* pPlayer = CLIENTS_GetPlayerFromClient(pClient, 1);
-    if (pClient->dwClientState != 4 && pPlayer)
+    if (pClient->dwClientState != CLIENTSTATE_INGAME && pPlayer)
     {
         D2ArenaUnitStrc* pArenaUnit = UNITS_GetPlayerData(pPlayer)->pArenaUnit;
         D2_ASSERT(pArenaUnit);

--- a/source/D2Game/src/GAME/Clients.cpp
+++ b/source/D2Game/src/GAME/Clients.cpp
@@ -482,7 +482,7 @@ D2ClientStrc* __fastcall CLIENTS_AddToGame(D2GameStrc* pGame, int32_t nClientId,
     pClient->unk0x60 = a6;
     pClient->pClientInfo = 0;
     pClient->dwExpLost = nExpLost;
-    pClient->dwClientState = 0;
+    pClient->dwClientState = CLIENTSTATE_JUST_CREATED;
     pClient->tPacketDataList.pHead = nullptr;
     pClient->tPacketDataList.pTail = nullptr;
     pClient->tPacketDataList.pPacketDataPool = nullptr;
@@ -1307,7 +1307,7 @@ uint32_t __fastcall sub_6FC33C10(D2ClientStrc* pClient)
 }
 
 //D2Game.0x6FC33C50
-int32_t __fastcall CLIENTS_Verify(int32_t nClientId, int32_t dwFlags)
+BOOL __fastcall CLIENTS_CheckState(int32_t nClientId, int32_t nExpectedClientState)
 {
     if (gbClientListInitialized_6FD447E8)
     {
@@ -1317,7 +1317,7 @@ int32_t __fastcall CLIENTS_Verify(int32_t nClientId, int32_t dwFlags)
         {
             if (pClient->dwClientId == nClientId)
             {
-                const int32_t result = pClient->dwClientState == dwFlags;
+                const BOOL result = pClient->dwClientState == nExpectedClientState;
                 LeaveCriticalSection(&gClientListLock_6FD447D0);
                 return result;
             }
@@ -1326,7 +1326,7 @@ int32_t __fastcall CLIENTS_Verify(int32_t nClientId, int32_t dwFlags)
         LeaveCriticalSection(&gClientListLock_6FD447D0);
     }
 
-    return 0;
+    return FALSE;
 }
 
 //D2Game.0x6FC33CD0

--- a/source/D2Game/src/GAME/Clients.cpp
+++ b/source/D2Game/src/GAME/Clients.cpp
@@ -1232,7 +1232,7 @@ void __fastcall CLIENTS_UpdateCharacterProgression(D2ClientStrc* pClient, uint16
 }
 
 //D2Game.0x6FC33AC0
-void __fastcall CLIENTS_SetClientState(D2ClientStrc* pClient, uint32_t nClientState)
+void __fastcall CLIENTS_SetClientState(D2ClientStrc* pClient, D2ClientState nClientState)
 {
     D2_ASSERT(pClient);
 
@@ -1307,7 +1307,7 @@ uint32_t __fastcall sub_6FC33C10(D2ClientStrc* pClient)
 }
 
 //D2Game.0x6FC33C50
-BOOL __fastcall CLIENTS_CheckState(int32_t nClientId, int32_t nExpectedClientState)
+BOOL __fastcall CLIENTS_CheckState(int32_t nClientId, D2ClientState nExpectedClientState)
 {
     if (gbClientListInitialized_6FD447E8)
     {

--- a/source/D2Game/src/GAME/Game.cpp
+++ b/source/D2Game/src/GAME/Game.cpp
@@ -1749,7 +1749,7 @@ void __fastcall GAME_EndGame(int32_t nClientId, int32_t a2)
 void __fastcall sub_6FC37FB0(D2GameStrc* pGame, D2ClientStrc* pClient)
 {
     D2ClientStrc* pCheckedClient = nullptr;
-    GAME_SendPacketToAllConnectedClients(pGame, sub_6FC380D0, &pCheckedClient);
+    GAME_ForEachIngameClient(pGame, sub_6FC380D0, &pCheckedClient);
 
     if (pCheckedClient)
     {
@@ -1764,7 +1764,7 @@ void __fastcall sub_6FC37FB0(D2GameStrc* pGame, D2ClientStrc* pClient)
     }
 
     pCheckedClient = nullptr;
-    GAME_SendPacketToAllConnectedClients(pGame, sub_6FC380D0, &pCheckedClient);
+    GAME_ForEachIngameClient(pGame, sub_6FC380D0, &pCheckedClient);
 
     if (pCheckedClient)
     {
@@ -3716,7 +3716,7 @@ void __stdcall D2Game_10022(uint16_t nGameId, char* a2)
 }
 
 //D2Game.0x6FC3B0E0
-void __fastcall GAME_SendPacketToAllConnectedClients(D2GameStrc* pGame, void(__fastcall* pFn)(D2ClientStrc*, void*), void* pPacket)
+void __fastcall GAME_ForEachIngameClient(D2GameStrc* pGame, void(__fastcall* pFn)(D2ClientStrc*, void*), void* pContext)
 {
     D2_ASSERT(pGame);
 
@@ -3730,7 +3730,7 @@ void __fastcall GAME_SendPacketToAllConnectedClients(D2GameStrc* pGame, void(__f
     {
         if (pClient->dwClientState == CLIENTSTATE_INGAME)
         {
-            pFn(pClient, pPacket);
+            pFn(pClient, pContext);
         }
     }
 }

--- a/source/D2Game/src/GAME/Game.cpp
+++ b/source/D2Game/src/GAME/Game.cpp
@@ -2230,7 +2230,7 @@ void __fastcall D2GAME_UpdateAllClients_6FC389C0(D2GameStrc* pGame)
             if (D2Common_10073(pClient->pRoom) && CLIENTS_GetPlayerFromClient(pClient, 0))
             {
                 D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 4u);
-                CLIENTS_SetClientState(pClient, 4u);
+                CLIENTS_SetClientState(pClient, CLIENTSTATE_INGAME);
 
                 D2UnitStrc* pPlayer = CLIENTS_GetPlayerFromClient(pClient, 0);
                 if (pPlayer)

--- a/source/D2Game/src/GAME/Game.cpp
+++ b/source/D2Game/src/GAME/Game.cpp
@@ -649,7 +649,7 @@ int32_t __stdcall GAME_ReceiveDatabaseCharacter(int32_t nClientId, const uint8_t
     D2_ASSERT(pGame->lpCriticalSection);
     LeaveCriticalSection(pGame->lpCriticalSection);
 
-    D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 2u);
+    D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 2u);
     GAME_LogMessage(6, "[SERVER]  SrvRecvDatabaseCharacter: Sent ACTINITDONE for client %d '%s'", nClientId, pClient->szName);
     return nTotalSize;
 }
@@ -827,7 +827,7 @@ void __fastcall GAME_SendGameInit(int32_t nClientId, char* szGameName, uint8_t n
     LeaveCriticalSection(&gCriticalSection_6FD45800);
 
     D2GAME_PACKETS_SendPacket0x01_6FC3C7C0(pClient, 1, pGame);
-    D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 0);
+    D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 0);
     CLIENTS_SetClientState(pClient, CLIENTSTATE_GAME_INIT_SENT);
     GAME_LogMessage(6, "[SERVER]  sSrvSendGameInit:      Sent game init to client %d '%s' for game %d '%s'", pClient->dwClientId, pClient->szName, pGame->nServerToken, pGame->szGameName);
     CLIENTS_SetActNo(pClient, gnAct_6FD45824);
@@ -847,7 +847,7 @@ void __fastcall GAME_SendGameInit(int32_t nClientId, char* szGameName, uint8_t n
         exit(-1);
     }
 
-    D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 2u);
+    D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 2u);
 }
 
 //D2Game.0x6FC369C0
@@ -1223,7 +1223,7 @@ void __fastcall GAME_JoinGame(int32_t dwClientId, uint16_t nGameId, int32_t a3, 
     if (pClient)
     {
         D2GAME_PACKETS_SendPacket0x01_6FC3C7C0(pClient, 1, pGame);
-        D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 0);
+        D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 0);
         CLIENTS_SetClientState(pClient, CLIENTSTATE_GAME_INIT_SENT);
         GAME_LogMessage(6, "[SERVER]  sSrvSendGameInit:      Sent game init to client %d '%s' for game %d '%s'", pClient->dwClientId, pClient->szName, pGame->nServerToken, pGame->szGameName);
         pClient->nAct = gnAct_6FD45824;
@@ -1246,7 +1246,7 @@ void __fastcall GAME_JoinGame(int32_t dwClientId, uint16_t nGameId, int32_t a3, 
         }
         else
         {
-            D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 2u);
+            D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 2u);
         }
     }
     else
@@ -1686,7 +1686,7 @@ void __fastcall GAME_EndGame(int32_t nClientId, int32_t a2)
     {
         while (1)
         {
-            D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 5u);
+            D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 5u);
 
             if ((pGame->nGameType == 1 || pGame->nGameType == 2) && CLIENT_GetSaveHeader_6FC34350(pClient))
             {
@@ -1697,7 +1697,7 @@ void __fastcall GAME_EndGame(int32_t nClientId, int32_t a2)
                 while (CLIENT_GetSaveHeader_6FC34350(pClient));
             }
 
-            D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 6u);
+            D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 6u);
 
             sub_6FC3C690(nClientId);
             sub_6FC39030(pGame, pClient, 0, 0);
@@ -2229,7 +2229,7 @@ void __fastcall D2GAME_UpdateAllClients_6FC389C0(D2GameStrc* pGame)
 
             if (D2Common_10073(pClient->pRoom) && CLIENTS_GetPlayerFromClient(pClient, 0))
             {
-                D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 4u);
+                D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 4u);
                 CLIENTS_SetClientState(pClient, 4u);
 
                 D2UnitStrc* pPlayer = CLIENTS_GetPlayerFromClient(pClient, 0);
@@ -2283,7 +2283,7 @@ void __fastcall D2GAME_UpdateAllClients_6FC389C0(D2GameStrc* pGame)
 
             if (D2Common_10073(pClient->pRoom))
             {
-                D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 4u);
+                D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 4u);
                 CLIENTS_SetClientState(pClient, CLIENTSTATE_INGAME);
 
                 D2UnitStrc* pPlayer = CLIENTS_GetPlayerFromClient(pClient, 0);

--- a/source/D2Game/src/GAME/Game.cpp
+++ b/source/D2Game/src/GAME/Game.cpp
@@ -649,7 +649,7 @@ int32_t __stdcall GAME_ReceiveDatabaseCharacter(int32_t nClientId, const uint8_t
     D2_ASSERT(pGame->lpCriticalSection);
     LeaveCriticalSection(pGame->lpCriticalSection);
 
-    D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 2u);
+    D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 2u);
     GAME_LogMessage(6, "[SERVER]  SrvRecvDatabaseCharacter: Sent ACTINITDONE for client %d '%s'", nClientId, pClient->szName);
     return nTotalSize;
 }
@@ -827,7 +827,7 @@ void __fastcall GAME_SendGameInit(int32_t nClientId, char* szGameName, uint8_t n
     LeaveCriticalSection(&gCriticalSection_6FD45800);
 
     D2GAME_PACKETS_SendPacket0x01_6FC3C7C0(pClient, 1, pGame);
-    D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 0);
+    D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 0);
     CLIENTS_SetClientState(pClient, CLIENTSTATE_GAME_INIT_SENT);
     GAME_LogMessage(6, "[SERVER]  sSrvSendGameInit:      Sent game init to client %d '%s' for game %d '%s'", pClient->dwClientId, pClient->szName, pGame->nServerToken, pGame->szGameName);
     CLIENTS_SetActNo(pClient, gnAct_6FD45824);
@@ -847,7 +847,7 @@ void __fastcall GAME_SendGameInit(int32_t nClientId, char* szGameName, uint8_t n
         exit(-1);
     }
 
-    D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 2u);
+    D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 2u);
 }
 
 //D2Game.0x6FC369C0
@@ -1223,7 +1223,7 @@ void __fastcall GAME_JoinGame(int32_t dwClientId, uint16_t nGameId, int32_t a3, 
     if (pClient)
     {
         D2GAME_PACKETS_SendPacket0x01_6FC3C7C0(pClient, 1, pGame);
-        D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 0);
+        D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 0);
         CLIENTS_SetClientState(pClient, CLIENTSTATE_GAME_INIT_SENT);
         GAME_LogMessage(6, "[SERVER]  sSrvSendGameInit:      Sent game init to client %d '%s' for game %d '%s'", pClient->dwClientId, pClient->szName, pGame->nServerToken, pGame->szGameName);
         pClient->nAct = gnAct_6FD45824;
@@ -1246,7 +1246,7 @@ void __fastcall GAME_JoinGame(int32_t dwClientId, uint16_t nGameId, int32_t a3, 
         }
         else
         {
-            D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 2u);
+            D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 2u);
         }
     }
     else
@@ -1686,7 +1686,7 @@ void __fastcall GAME_EndGame(int32_t nClientId, int32_t a2)
     {
         while (1)
         {
-            D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 5u);
+            D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 5u);
 
             if ((pGame->nGameType == 1 || pGame->nGameType == 2) && CLIENT_GetSaveHeader_6FC34350(pClient))
             {
@@ -1697,7 +1697,7 @@ void __fastcall GAME_EndGame(int32_t nClientId, int32_t a2)
                 while (CLIENT_GetSaveHeader_6FC34350(pClient));
             }
 
-            D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 6u);
+            D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 6u);
 
             sub_6FC3C690(nClientId);
             sub_6FC39030(pGame, pClient, 0, 0);
@@ -2229,7 +2229,7 @@ void __fastcall D2GAME_UpdateAllClients_6FC389C0(D2GameStrc* pGame)
 
             if (D2Common_10073(pClient->pRoom) && CLIENTS_GetPlayerFromClient(pClient, 0))
             {
-                D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 4u);
+                D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 4u);
                 CLIENTS_SetClientState(pClient, CLIENTSTATE_INGAME);
 
                 D2UnitStrc* pPlayer = CLIENTS_GetPlayerFromClient(pClient, 0);
@@ -2283,7 +2283,7 @@ void __fastcall D2GAME_UpdateAllClients_6FC389C0(D2GameStrc* pGame)
 
             if (D2Common_10073(pClient->pRoom))
             {
-                D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 4u);
+                D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 4u);
                 CLIENTS_SetClientState(pClient, CLIENTSTATE_INGAME);
 
                 D2UnitStrc* pPlayer = CLIENTS_GetPlayerFromClient(pClient, 0);

--- a/source/D2Game/src/GAME/Level.cpp
+++ b/source/D2Game/src/GAME/Level.cpp
@@ -244,7 +244,7 @@ void __fastcall LEVEL_ChangeAct(D2GameStrc* pGame, D2ClientStrc* pClient, int32_
 
     LEVEL_LoadAct(pGame, nNewAct);
 
-    CLIENTS_SetClientState(pClient, 5u);
+    CLIENTS_SetClientState(pClient, CLIENTSTATE_CHANGING_ACT);
 
     D2UnitStrc* pUnit = CLIENTS_GetPlayerFromClient(pClient, 0);
     D2_ASSERT(pUnit);

--- a/source/D2Game/src/GAME/Level.cpp
+++ b/source/D2Game/src/GAME/Level.cpp
@@ -292,7 +292,7 @@ void __fastcall LEVEL_ChangeAct(D2GameStrc* pGame, D2ClientStrc* pClient, int32_
     }
 
     CLIENTS_SetRoomInClient(pClient, nullptr);
-    D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 5u);
+    D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 5u);
     CLIENTS_SetActNo(pClient, nNewAct);
     pUnit->nAct = nNewAct;
     pUnit->pDrlgAct = pGame->pAct[nNewAct];

--- a/source/D2Game/src/GAME/Level.cpp
+++ b/source/D2Game/src/GAME/Level.cpp
@@ -292,7 +292,7 @@ void __fastcall LEVEL_ChangeAct(D2GameStrc* pGame, D2ClientStrc* pClient, int32_
     }
 
     CLIENTS_SetRoomInClient(pClient, nullptr);
-    D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 5u);
+    D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 5u);
     CLIENTS_SetActNo(pClient, nNewAct);
     pUnit->nAct = nNewAct;
     pUnit->pDrlgAct = pGame->pAct[nNewAct];

--- a/source/D2Game/src/GAME/SCmd.cpp
+++ b/source/D2Game/src/GAME/SCmd.cpp
@@ -92,7 +92,7 @@ void __fastcall sub_6FC3C6D0(int32_t nClientId, uint32_t nErrorCode)
 }
 
 //D2Game.0x6FC3C6F0
-void __fastcall D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(D2ClientStrc* pClient, uint8_t nHeader)
+void __fastcall D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(D2ClientStrc* pClient, uint8_t nHeader)
 {
     D2GSPacketSrv4F packet4F = {};
 

--- a/source/D2Game/src/GAME/SCmd.cpp
+++ b/source/D2Game/src/GAME/SCmd.cpp
@@ -92,13 +92,10 @@ void __fastcall sub_6FC3C6D0(int32_t nClientId, uint32_t nErrorCode)
 }
 
 //D2Game.0x6FC3C6F0
-void __fastcall D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(D2ClientStrc* pClient, uint8_t nHeader)
+//It seems there were multiple functions for header only packets that got merged by the linker into a single one.
+void __fastcall D2GAME_PACKETS_SendHeaderOnlyPacket(D2ClientStrc* pClient, uint8_t nHeader)
 {
-    D2GSPacketSrv4F packet4F = {};
-
-    packet4F.nHeader = nHeader;
-
-    D2GAME_PACKETS_SendPacket_6FC3C710(pClient, &packet4F, sizeof(packet4F));
+    D2GAME_PACKETS_SendPacket_6FC3C710(pClient, &nHeader, sizeof(nHeader));
 }
 
 //D2Game.0x6FC3C710

--- a/source/D2Game/src/PLAYER/PlrMsg.cpp
+++ b/source/D2Game/src/PLAYER/PlrMsg.cpp
@@ -1704,7 +1704,7 @@ int32_t __fastcall D2GAME_PACKETCALLBACK_Rcv0x15_HandleChatMessage_6FC84950(D2Ga
         packet26Args.nUnitId = -1;
     }
 
-    GAME_SendPacketToAllConnectedClients(pGame, pFn, &packet26Args);
+    GAME_ForEachIngameClient(pGame, pFn, &packet26Args);
 
     if (packet26.nMessageType == 2)
     {
@@ -1766,7 +1766,7 @@ void __fastcall sub_6FC84C70(D2GameStrc* pGame, const char* szMessage, uint8_t n
     pPacket.nMessageColor = nColor;
     memcpy(pPacket.szMessage, szMessage, sizeof(pPacket.szMessage));
 
-    GAME_SendPacketToAllConnectedClients(pGame, j_D2GAME_PACKETS_SendPacket0x26_ServerMessage_6FC3DDF0, &pPacket);
+    GAME_ForEachIngameClient(pGame, j_D2GAME_PACKETS_SendPacket0x26_ServerMessage_6FC3DDF0, &pPacket);
 }
 
 //D2Game.0x6FC84CD0
@@ -1782,7 +1782,7 @@ void __fastcall sub_6FC84CD0(D2GameStrc* pGame, const char* szMessage, uint8_t n
     pPacket.nLang = 0;
     memcpy(pPacket.szMessage, szMessage, sizeof(pPacket.szMessage));
 
-    GAME_SendPacketToAllConnectedClients(pGame, j_D2GAME_PACKETS_SendPacket0x26_ServerMessage_6FC3DDF0, &pPacket);
+    GAME_ForEachIngameClient(pGame, j_D2GAME_PACKETS_SendPacket0x26_ServerMessage_6FC3DDF0, &pPacket);
 }
 
 //D2Game.0x6FC84D30
@@ -1798,7 +1798,7 @@ void __fastcall sub_6FC84D40(D2GameStrc* pGame, D2GSPacketSrv5A* pPacket5A)
     {
         if (!pPacket5A->szText[i])
         {
-            GAME_SendPacketToAllConnectedClients(pGame, j_D2GAME_SendPacket0x5A_6FC3DEC0, pPacket5A);
+            GAME_ForEachIngameClient(pGame, j_D2GAME_SendPacket0x5A_6FC3DEC0, pPacket5A);
             return;
         }
     }
@@ -4416,7 +4416,7 @@ void __fastcall D2GAME_PLRMSG_Last_6FC89450(D2GameStrc* pGame, D2UnitStrc* pAtta
     {
         if (!packet5A.szText[i])
         {
-            GAME_SendPacketToAllConnectedClients(pGame, j_D2GAME_SendPacket0x5A_6FC3DEC0, &packet5A);
+            GAME_ForEachIngameClient(pGame, j_D2GAME_SendPacket0x5A_6FC3DEC0, &packet5A);
             return;
         }
     }

--- a/source/D2Game/src/UNIT/SUnitNpc.cpp
+++ b/source/D2Game/src/UNIT/SUnitNpc.cpp
@@ -334,7 +334,7 @@ void __fastcall D2GAME_NPC_BuildHirelingList_6FCC6FF0(D2GameStrc* pGame, D2Clien
         return;
     }
 
-    D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 0x4Fu);
+    D2GAME_PACKETS_SendHeaderOnlyPacket(pClient, 0x4Fu);
 
     int32_t nUnused = 0;
     D2NpcRecordStrc* pNpcRecord = SUNITPROXY_GetNpcRecordFromUnit(CLIENTS_GetGame(pClient), pUnit, &nUnused);

--- a/source/D2Game/src/UNIT/SUnitNpc.cpp
+++ b/source/D2Game/src/UNIT/SUnitNpc.cpp
@@ -334,7 +334,7 @@ void __fastcall D2GAME_NPC_BuildHirelingList_6FCC6FF0(D2GameStrc* pGame, D2Clien
         return;
     }
 
-    D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0(pClient, 0x4Fu);
+    D2GAME_PACKETS_SendPacket0x4F_UpdateClientState(pClient, 0x4Fu);
 
     int32_t nUnused = 0;
     D2NpcRecordStrc* pNpcRecord = SUNITPROXY_GetNpcRecordFromUnit(CLIENTS_GetGame(pClient), pUnit, &nUnused);


### PR DESCRIPTION
As per the discussion in #118 , this adds a new enum for the client state : `D2ClientState`.

This also fixes the name for:
- D2Game.0x6FC33C50 `CLIENTS_Verify` => `CLIENTS_CheckState`
- D2Game.0x6FC3B0E0 `GAME_SendPacketToAllConnectedClients` => `GAME_ForEachIngameClient`
- D2Game.0x6FC3C6F0 `D2GAME_PACKETS_SendPacket0x4F_StartMercList_6FC3C6F0` => ~~`D2GAME_PACKETS_SendPacket0x4F_UpdateClientState`~~ `D2GAME_PACKETS_SendHeaderOnlyPacket`
  - ~~We might want to change this as it seems that it does not send the client state exactly. Some other closely related state ?~~