### PR TITLE
MISSILES_CreateMissileFromParams-rangeFix

### DIFF
--- a/source/D2Game/src/MISSILES/Missiles.cpp
+++ b/source/D2Game/src/MISSILES/Missiles.cpp
@@ -202,7 +202,7 @@ D2UnitStrc* __fastcall MISSILES_CreateMissileFromParams(D2GameStrc* pGame, D2Mis
     }
 
     int32_t nRange = 0;
-    if (missileParams->dwFlags & 0x8000)
+    if (!(missileParams->dwFlags & 0x8000))
     {
         nRange = pMissilesTxtRecord->wRange + missileParams->nSkillLevel * pMissilesTxtRecord->wLevRange;
         if (missileParams->dwFlags & 8 && pMissilesTxtRecord->nSubLoop)


### PR DESCRIPTION
D2Game.0x6FC55360 MISSILES_CreateMissileFromParams

nRange should come from pMissilesTxtRecord when the high bit of byte (dwFlags>> 8) is not set. The comparison can be found at D2Game.0x6FC557D9