### PR TITLE
Fix MONSTERUNIQUE_CalculatePercentage order of operations

### DIFF
--- a/source/D2Game/src/MONSTER/MonsterUnique.cpp
+++ b/source/D2Game/src/MONSTER/MonsterUnique.cpp
@@ -246,14 +246,14 @@ int32_t __fastcall MONSTERUNIQUE_CalculatePercentage(int32_t a1, int32_t a2, int
 
         if (a3 <= a2 >> 4)
         {
-            return a1 * a2 / a3;
+            return a1 * (a2 / a3);
         }
     }
     else
     {
         if (a3 <= a1 >> 4)
         {
-            return a2 * a1 / a3;
+            return a2 * (a1 / a3);
         }
     }
 


### PR DESCRIPTION
Division happens before multiply in these two cases. Important for large values where you start encountering the possibility of overflow