### PR TITLE
Fixed SKILLS_CalculateMasteryBonus (order of operations)

### DIFF
--- a/source/D2Common/src/D2Skills.cpp
+++ b/source/D2Common/src/D2Skills.cpp
@@ -2659,7 +2659,7 @@ int __stdcall SKILLS_GetMinElemDamage(D2UnitStrc* pUnit, int nSkillId, int nSkil
 //D2Common.0x6FDB29D0
 int __fastcall SKILLS_CalculateMasteryBonus(D2UnitStrc* pUnit, int nElemType, int nSrcDamage)
 {
-	int statId = 0;
+	int32_t statId = 0;
 
 	switch (nElemType)
 	{
@@ -2680,35 +2680,8 @@ int __fastcall SKILLS_CalculateMasteryBonus(D2UnitStrc* pUnit, int nElemType, in
 		return 0;
 	}
 
-	auto nPercentage = STATLIST_UnitGetStatValue(pUnit, statId, 0);
-
-	// NOTE: This is an exact copy of D2Game.0x6FC6AF70 (MONSTERUNIQUE_CalculatePercentage)
-	if (!nPercentage)
-	{
-		return 0;
-	}
-
-	if (nSrcDamage <= 0x100000)
-	{
-		if (nPercentage <= 0x10000)
-		{
-			return nSrcDamage * nPercentage / 100;
-		}
-
-		if ((nPercentage >> 4) >= 100)
-		{
-			return nSrcDamage * (nPercentage / 100);
-		}
-	}
-	else
-	{
-		if ((nSrcDamage >> 4) >= 100)
-		{
-			return nPercentage * (nSrcDamage / 100);
-		}
-	}
-
-	return nSrcDamage * (int64_t)nPercentage / 100;
+	int32_t nPercentage = STATLIST_UnitGetStatValue(pUnit, statId, 0);
+	return DATATBLS_ApplyRatio(nSrcDamage, nPercentage, 100);
 }
 
 //D2Common.0x6FDB2B00 (#11005)

--- a/source/D2Common/src/D2Skills.cpp
+++ b/source/D2Common/src/D2Skills.cpp
@@ -2659,46 +2659,56 @@ int __stdcall SKILLS_GetMinElemDamage(D2UnitStrc* pUnit, int nSkillId, int nSkil
 //D2Common.0x6FDB29D0
 int __fastcall SKILLS_CalculateMasteryBonus(D2UnitStrc* pUnit, int nElemType, int nSrcDamage)
 {
-	int nPercentage = 0;
+	int statId = 0;
 
 	switch (nElemType)
 	{
 	case ELEMTYPE_FIRE:
-		nPercentage = STATLIST_UnitGetStatValue(pUnit, STAT_PASSIVE_FIRE_MASTERY, 0);
-		if (!nPercentage)
-		{
-			return 0;
-		}
-
-		return nSrcDamage * nPercentage / 100;
+		statId = STAT_PASSIVE_FIRE_MASTERY;
+		break;
 	case ELEMTYPE_LTNG:
-		nPercentage = STATLIST_UnitGetStatValue(pUnit, STAT_PASSIVE_LTNG_MASTERY, 0);
-		if (!nPercentage)
-		{
-			return 0;
-		}
-
-		return nSrcDamage * nPercentage / 100;
+		statId = STAT_PASSIVE_LTNG_MASTERY;
+		break;
 	case ELEMTYPE_COLD:
 	case ELEMTYPE_FREEZE:
-		nPercentage = STATLIST_UnitGetStatValue(pUnit, STAT_PASSIVE_COLD_MASTERY, 0);
-		if (!nPercentage)
-		{
-			return 0;
-		}
-
-		return nSrcDamage * nPercentage / 100;
+		statId = STAT_PASSIVE_COLD_MASTERY;
+		break;
 	case ELEMTYPE_POIS:
-		nPercentage = STATLIST_UnitGetStatValue(pUnit, STAT_PASSIVE_POIS_MASTERY, 0);
-		if (!nPercentage)
-		{
-			return 0;
-		}
-		
-		return nSrcDamage * nPercentage / 100;
+		statId = STAT_PASSIVE_POIS_MASTERY;
+		break;
 	default:
 		return 0;
 	}
+
+	auto nPercentage = STATLIST_UnitGetStatValue(pUnit, statId, 0);
+
+	// NOTE: This is an exact copy of D2Game.0x6FC6AF70 (MONSTERUNIQUE_CalculatePercentage)
+	if (!nPercentage)
+	{
+		return 0;
+	}
+
+	if (nSrcDamage <= 0x100000)
+	{
+		if (nPercentage <= 0x10000)
+		{
+			return nSrcDamage * nPercentage / 100;
+		}
+
+		if ((nPercentage >> 4) >= 100)
+		{
+			return nSrcDamage * (nPercentage / 100);
+		}
+	}
+	else
+	{
+		if ((nSrcDamage >> 4) >= 100)
+		{
+			return nPercentage * (nSrcDamage / 100);
+		}
+	}
+
+	return nSrcDamage * (__int64)nPercentage / 100;
 }
 
 //D2Common.0x6FDB2B00 (#11005)

--- a/source/D2Common/src/D2Skills.cpp
+++ b/source/D2Common/src/D2Skills.cpp
@@ -2708,7 +2708,7 @@ int __fastcall SKILLS_CalculateMasteryBonus(D2UnitStrc* pUnit, int nElemType, in
 		}
 	}
 
-	return nSrcDamage * (__int64)nPercentage / 100;
+	return nSrcDamage * (int64_t)nPercentage / 100;
 }
 
 //D2Common.0x6FDB2B00 (#11005)

--- a/source/D2Common/src/Units/Missile.cpp
+++ b/source/D2Common/src/Units/Missile.cpp
@@ -889,50 +889,56 @@ void __fastcall MISSILE_CalculateFinalDamage(D2MissileDamageDataStrc* pMissileDa
 //D2Common.0x6FDBB1B0
 int __fastcall MISSILE_CalculateMasteryBonus(D2UnitStrc* pUnit, int nElemType, int nSrcDamage)
 {
-	int nPercentage = 0;
+	int statId = 0;
 
 	switch (nElemType)
 	{
 	case ELEMTYPE_FIRE:
-		nPercentage = STATLIST_UnitGetStatValue(pUnit, STAT_PASSIVE_FIRE_MASTERY, 0);
-		if (!nPercentage)
-		{
-			return 0;
-		}
-
-		return nSrcDamage * nPercentage / 100;
-
+		statId = STAT_PASSIVE_FIRE_MASTERY;
+		break;
 	case ELEMTYPE_LTNG:
-		nPercentage = STATLIST_UnitGetStatValue(pUnit, STAT_PASSIVE_LTNG_MASTERY, 0);
-		if (!nPercentage)
-		{
-			return 0;
-		}
-
-		return nSrcDamage * nPercentage / 100;
-
+		statId = STAT_PASSIVE_LTNG_MASTERY;
+		break;
 	case ELEMTYPE_COLD:
 	case ELEMTYPE_FREEZE:
-		nPercentage = STATLIST_UnitGetStatValue(pUnit, STAT_PASSIVE_COLD_MASTERY, 0);
-		if (!nPercentage)
-		{
-			return 0;
-		}
-
-		return nSrcDamage * nPercentage / 100;
-
+		statId = STAT_PASSIVE_COLD_MASTERY;
+		break;
 	case ELEMTYPE_POIS:
-		nPercentage = STATLIST_UnitGetStatValue(pUnit, STAT_PASSIVE_POIS_MASTERY, 0);
-		if (!nPercentage)
-		{
-			return 0;
-		}
-
-		return nSrcDamage * nPercentage / 100;
-
+		statId = STAT_PASSIVE_POIS_MASTERY;
+		break;
 	default:
 		return 0;
 	}
+
+	auto nPercentage = STATLIST_UnitGetStatValue(pUnit, statId, 0);
+
+	// NOTE: This is an exact copy of D2Game.0x6FC6AF70 (MONSTERUNIQUE_CalculatePercentage)
+	if (!nPercentage)
+	{
+		return 0;
+	}
+
+	if (nSrcDamage <= 0x100000)
+	{
+		if (nPercentage <= 0x10000)
+		{
+			return nSrcDamage * nPercentage / 100;
+		}
+
+		if ((nPercentage >> 4) >= 100)
+		{
+			return nSrcDamage * (nPercentage / 100);
+		}
+	}
+	else
+	{
+		if ((nSrcDamage >> 4) >= 100)
+		{
+			return nPercentage * (nSrcDamage / 100);
+		}
+	}
+
+	return nSrcDamage * (__int64)nPercentage / 100;
 }
 
 //D2Common.0x6FDBB2E0 (#11218)

--- a/source/D2Common/src/Units/Missile.cpp
+++ b/source/D2Common/src/Units/Missile.cpp
@@ -889,7 +889,7 @@ void __fastcall MISSILE_CalculateFinalDamage(D2MissileDamageDataStrc* pMissileDa
 //D2Common.0x6FDBB1B0
 int __fastcall MISSILE_CalculateMasteryBonus(D2UnitStrc* pUnit, int nElemType, int nSrcDamage)
 {
-	int statId = 0;
+	int32_t statId = 0;
 
 	switch (nElemType)
 	{
@@ -910,35 +910,8 @@ int __fastcall MISSILE_CalculateMasteryBonus(D2UnitStrc* pUnit, int nElemType, i
 		return 0;
 	}
 
-	auto nPercentage = STATLIST_UnitGetStatValue(pUnit, statId, 0);
-
-	// NOTE: This is an exact copy of D2Game.0x6FC6AF70 (MONSTERUNIQUE_CalculatePercentage)
-	if (!nPercentage)
-	{
-		return 0;
-	}
-
-	if (nSrcDamage <= 0x100000)
-	{
-		if (nPercentage <= 0x10000)
-		{
-			return nSrcDamage * nPercentage / 100;
-		}
-
-		if ((nPercentage >> 4) >= 100)
-		{
-			return nSrcDamage * (nPercentage / 100);
-		}
-	}
-	else
-	{
-		if ((nSrcDamage >> 4) >= 100)
-		{
-			return nPercentage * (nSrcDamage / 100);
-		}
-	}
-
-	return nSrcDamage * (int64_t)nPercentage / 100;
+	int32_t nPercentage = STATLIST_UnitGetStatValue(pUnit, statId, 0);
+	return DATATBLS_ApplyRatio(nSrcDamage, nPercentage, 100);
 }
 
 //D2Common.0x6FDBB2E0 (#11218)

--- a/source/D2Common/src/Units/Missile.cpp
+++ b/source/D2Common/src/Units/Missile.cpp
@@ -938,7 +938,7 @@ int __fastcall MISSILE_CalculateMasteryBonus(D2UnitStrc* pUnit, int nElemType, i
 		}
 	}
 
-	return nSrcDamage * (__int64)nPercentage / 100;
+	return nSrcDamage * (int64_t)nPercentage / 100;
 }
 
 //D2Common.0x6FDBB2E0 (#11218)


### PR DESCRIPTION
Fixed SKILLS_CalculateMasteryBonus so it matches the original code's multiplication and division ordering. It uses the "MONSTERUNIQUE_CalculatePercentage" logic inlined, but a dependency on Game from Common would look a bit weird so I just left it as is for now