### PR TITLE
fix unsigned vs signed issues in D2DamageStrc

### DIFF
--- a/source/D2Game/include/UNIT/SUnitDmg.h
+++ b/source/D2Game/include/UNIT/SUnitDmg.h
@@ -68,25 +68,25 @@ struct D2DamageStrc
 	uint16_t wResultFlags;					//0x04
 	uint16_t wExtra;						//0x06
 	int32_t dwPhysDamage;					//0x08
-	uint32_t dwEnDmgPct;					//0x0C
+	int32_t dwEnDmgPct;						//0x0C
 	int32_t dwFireDamage;					//0x10
 	int32_t dwBurnDamage;					//0x14
-	uint32_t dwBurnLen;						//0x18
+	int32_t dwBurnLen;						//0x18
 	int32_t dwLtngDamage;					//0x1C
 	int32_t dwMagDamage;					//0x20
 	int32_t dwColdDamage;					//0x24
 	int32_t dwPoisDamage;					//0x28
-	uint32_t dwPoisLen;						//0x2C
-	uint32_t dwColdLen;						//0x30
-	uint32_t dwFrzLen;						//0x34
+	int32_t dwPoisLen;						//0x2C
+	int32_t dwColdLen;						//0x30
+	int32_t dwFrzLen;						//0x34
 	int32_t dwLifeLeech;					//0x38
 	int32_t dwManaLeech;					//0x3C
 	int32_t dwStamLeech;					//0x40
-	uint32_t dwStunLen;						//0x44
+	int32_t dwStunLen;						//0x44
 	int32_t dwAbsLife;						//0x48
-	uint32_t dwDmgTotal;					//0x4C
+	int32_t dwDmgTotal;						//0x4C
 	uint32_t unk0x50;						//0x50
-	uint32_t dwPiercePct;					//0x54
+	int32_t dwPiercePct;					//0x54
 	uint32_t dwDamageRate;					//0x58
 	uint32_t unk0x5C;						//0x5C
 	uint32_t dwHitClass;					//0x60

--- a/source/D2Game/include/UNIT/SUnitDmg.h
+++ b/source/D2Game/include/UNIT/SUnitDmg.h
@@ -87,7 +87,7 @@ struct D2DamageStrc
 	int32_t dwDmgTotal;						//0x4C
 	uint32_t unk0x50;						//0x50
 	int32_t dwPiercePct;					//0x54
-	uint32_t dwDamageRate;					//0x58
+	int32_t dwDamageRate;					//0x58
 	uint32_t unk0x5C;						//0x5C
 	uint32_t dwHitClass;					//0x60
 	uint8_t nHitClassActiveSet;				//0x64

--- a/source/D2Game/src/UNIT/SUnitDmg.cpp
+++ b/source/D2Game/src/UNIT/SUnitDmg.cpp
@@ -1290,7 +1290,7 @@ void __fastcall SUNITDMG_ExecuteEvents(D2GameStrc* pGame, D2UnitStrc* pAttacker,
 		STATLIST_SetUnitStat(pDefender, STAT_HITPOINTS, nNewHp, 0);
 	}
 
-	if ((int32_t)pDamage->dwDmgTotal > 0)
+	if (pDamage->dwDmgTotal > 0)
 	{
 		int32_t nNewHp = STATLIST_UnitGetStatValue(pDefender, STAT_HITPOINTS, 0) - pDamage->dwDmgTotal;
 		if (nNewHp < 256)

--- a/source/D2Game/src/UNIT/SUnitDmg.cpp
+++ b/source/D2Game/src/UNIT/SUnitDmg.cpp
@@ -1290,7 +1290,7 @@ void __fastcall SUNITDMG_ExecuteEvents(D2GameStrc* pGame, D2UnitStrc* pAttacker,
 		STATLIST_SetUnitStat(pDefender, STAT_HITPOINTS, nNewHp, 0);
 	}
 
-	if (pDamage->dwDmgTotal > 0)
+	if ((int32_t)pDamage->dwDmgTotal > 0)
 	{
 		int32_t nNewHp = STATLIST_UnitGetStatValue(pDefender, STAT_HITPOINTS, 0) - pDamage->dwDmgTotal;
 		if (nNewHp < 256)

--- a/source/D2Game/src/UNIT/SUnitDmg.cpp
+++ b/source/D2Game/src/UNIT/SUnitDmg.cpp
@@ -700,17 +700,17 @@ void __fastcall SUNITDMG_FillDamageValues(D2GameStrc* pGame, D2UnitStrc* pAttack
 
 		case ELEMTYPE_POIS:
 			pDamage->dwPoisDamage += nConvertedDamage / 8;
-			pDamage->dwPoisLen = std::max(pDamage->dwPoisLen, 50u);
+			pDamage->dwPoisLen = std::max(pDamage->dwPoisLen, 50);
 			break;
 
 		case ELEMTYPE_BURN:
 			pDamage->dwFireDamage += nConvertedDamage;
-			pDamage->dwBurnLen = std::max(pDamage->dwBurnLen, 50u);
+			pDamage->dwBurnLen = std::max(pDamage->dwBurnLen, 50);
 			break;
 
 		case ELEMTYPE_FREEZE:
 			pDamage->dwColdDamage += nConvertedDamage;
-			pDamage->dwFrzLen = std::max(pDamage->dwFrzLen, 50u);
+			pDamage->dwFrzLen = std::max(pDamage->dwFrzLen, 50);
 			break;
 
 		default:

--- a/source/D2Game/src/UNIT/SUnitDmg.cpp
+++ b/source/D2Game/src/UNIT/SUnitDmg.cpp
@@ -1320,13 +1320,13 @@ void __fastcall SUNITDMG_ExecuteEvents(D2GameStrc* pGame, D2UnitStrc* pAttacker,
 		STATLIST_SetUnitStat(pDefender, STAT_STAMINA, nNewStamina, 0);
 	}
 
-	uint32_t nStunLength = pDamage->dwStunLen;
+	int32_t nStunLength = pDamage->dwStunLen;
 	int32_t bApplyStun = 0;
 	if (nStunLength > 0)
 	{
 		if (!pDefender || pDefender->dwUnitType != UNIT_MONSTER)
 		{
-			nStunLength = std::min(nStunLength, 250u);
+			nStunLength = std::min(nStunLength, 250);
 			bApplyStun = 1;
 		}
 


### PR DESCRIPTION
the original codebase has dwDmgTotal being treated as a signed value (jle) on this comparison. This causes differences to the original client when dwDmgTotal is negative