### PR TITLE
fix SUNITDMG_ApplyResistancesAndAbsorb when dealing with negative damage values

### DIFF
--- a/source/D2Game/src/UNIT/SUnitDmg.cpp
+++ b/source/D2Game/src/UNIT/SUnitDmg.cpp
@@ -940,7 +940,11 @@ void __fastcall SUNITDMG_ApplyResistancesAndAbsorb(D2DamageInfoStrc* pDamageInfo
 	int32_t nValue = *pValue;
 	int32_t nPreviousValue = *pValue;
 
-	*pValue = std::max(*pValue, 0);
+	if (*pValue <= 0)
+	{
+		*pValue = 0;
+		return;
+	}
 
 	int32_t nResValue = 0;
 	if (pDamageStatTableRecord->nResStatId != -1)


### PR DESCRIPTION
In the original codebase SUNITDMG_ApplyResistancesAndAbsorb sets the damage value to 0 and returns early if pValue is <= 0;

This matters for weird cases where you have 0 damage and some additional absorbs/etc, pushing pValue negative when the original logic would not have done that