### PR TITLE
Fix MISSMODE_SrvDmg14_MoltenBoulder (case fallthrough to early return)

### DIFF
--- a/source/D2Game/src/MISSILES/MissMode.cpp
+++ b/source/D2Game/src/MISSILES/MissMode.cpp
@@ -4640,6 +4640,7 @@ void __fastcall MISSMODE_SrvDmg14_MoltenBoulder(D2GameStrc* pGame, D2UnitStrc* p
                 nChance = pMissilesTxtRecord->dwDmgParam[1];
             }
         }
+        break;
     }
     default:
     {


### PR DESCRIPTION
Added missing break to UNIT_MONSTER case of MISSMODE_SrvDmg14_MoltenBoulder. Without the break, the logic falls through to an early return and causes the entire UNIT_MONSTER case to does nothing