### PR TITLE
Fix incorrect quest ID for Wirt's body in QUESTS_ObjectEvents

### DIFF
--- a/source/D2Game/src/QUESTS/Quests.cpp
+++ b/source/D2Game/src/QUESTS/Quests.cpp
@@ -1709,7 +1709,7 @@ void __fastcall QUESTS_ObjectEvents(D2GameStrc* pGame, D2UnitStrc* pUnit)
 	}
 	case OBJECT_WIRTSBODY:
 	{
-		D2QuestDataStrc* pQuestData = QUESTS_GetQuestData(pGame, QUEST_A3Q2_KHALIMFLAIL);
+		D2QuestDataStrc* pQuestData = QUESTS_GetQuestData(pGame, QUEST_A1Q4_CAIN);
 		if (pQuestData)
 		{
 			D2Act1Quest4Strc* pAct1Quest4 = (D2Act1Quest4Strc*)pQuestData->pQuestDataEx;


### PR DESCRIPTION
## Summary
- Fixes `QUESTS_ObjectEvents` using `QUEST_A3Q2_KHALIMFLAIL` instead of `QUEST_A1Q4_CAIN` for Wirt's body (copy-paste error)

Fixes #206

> Note: This PR was produced using Claude Code based on the issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.