### PR TITLE
Fix incorrect field for book skill ID in sell item function

### DIFF
--- a/source/D2Game/src/UNIT/SUnitNpc.cpp
+++ b/source/D2Game/src/UNIT/SUnitNpc.cpp
@@ -796,9 +796,9 @@ int32_t __fastcall D2GAME_STORES_SellItem_6FCC7680(D2GameStrc* pGame, D2UnitStrc
             if (nQuantity >= 0)
             {
                 D2BooksTxt* pBooksTxtRecord = DATATBLS_GetBooksTxtRecord(ITEMS_GetSuffixId(pItem, 0));
-                if (pBooksTxtRecord->dwScrollSkillId >= 0)
+                if (pBooksTxtRecord->dwBookSkillId >= 0)
                 {
-                    D2SkillStrc* pSkill = SKILLS_GetHighestLevelSkillFromUnitAndId(pPlayer, pBooksTxtRecord->dwScrollSkillId);
+                    D2SkillStrc* pSkill = SKILLS_GetHighestLevelSkillFromUnitAndId(pPlayer, pBooksTxtRecord->dwBookSkillId);
                     if (pSkill)
                     {
                         int32_t nSkillQuantity = SKILLS_GetQuantity(pSkill) - nQuantity;


### PR DESCRIPTION
## Summary
- Fixes `D2GAME_STORES_SellItem_6FCC7680` using `dwScrollSkillId` instead of `dwBookSkillId` when handling book items

Fixes #205

> Note: This PR was produced using Claude Code based on the issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.