### PR TITLE
Fix missing return in PLRINTRO_MaskNpcIntroFlag

### DIFF
--- a/source/D2Game/src/PLAYER/PlrIntro.cpp
+++ b/source/D2Game/src/PLAYER/PlrIntro.cpp
@@ -128,6 +128,7 @@ void __fastcall PLRINTRO_MaskNpcIntroFlag(D2GameStrc* pGame, D2UnitStrc* pPlayer
         if (npcIndexMap[i].nNpcClassId == nNpcId)
         {
             BITMANIP_MaskBitstate(pPlayerIntro->pNpcIntroFlags->pBuffer, npcIndexMap[i].nIndex);
+            return;
         }
     }
 


### PR DESCRIPTION
## Summary
- Adds missing `return` after clearing the NPC intro flag bit, matching original v1.10 behavior where the function exits immediately once an NPC index is matched

Fixes #202

> Note: This PR was produced using Claude Code based on the issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.