### PR TITLE
Fix use-after-free in monster AI interact handling

### DIFF
--- a/source/D2Game/src/MONSTER/MonsterAI.cpp
+++ b/source/D2Game/src/MONSTER/MonsterAI.cpp
@@ -458,12 +458,12 @@ void __fastcall sub_6FC61B70(D2GameStrc* pGame, D2UnitStrc* pPlayer, D2UnitStrc*
                 SUNIT_ResetInteractInfo(pPlayer);
             }
 
-            D2_FREE_POOL(pGame->pMemoryPool, pInteractInfo);
-
             if (pInteractInfo->nInteract >= 1 && !pMonInteract->pInteractInfo)
             {
                 SUNITPROXY_FreeNpcGamble(pGame, pNpc, pPlayer);
             }
+
+            D2_FREE_POOL(pGame->pMemoryPool, pInteractInfo);
             return;
         }
 


### PR DESCRIPTION
## Summary
- Moves `D2_FREE_POOL` call to after accessing `pInteractInfo->nInteract`, fixing a use-after-free where the struct was freed before its member was read

Fixes #201

> Note: This PR was produced using Claude Code based on the issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.