### PR TITLE
Fix health removal from incorrect unit in EventFunc26

### DIFF
--- a/source/D2Game/src/SKILLS/SkillNec.cpp
+++ b/source/D2Game/src/SKILLS/SkillNec.cpp
@@ -2305,7 +2305,7 @@ int32_t __fastcall D2GAME_EventFunc26_6FD0F5E0(D2GameStrc* pGame, int32_t nEvent
         nNewHp = 256;
     }
 
-    STATLIST_SetUnitStat(pAttacker, STAT_HITPOINTS, nNewHp, 0);
+    STATLIST_SetUnitStat(pOwner, STAT_HITPOINTS, nNewHp, 0);
 
     pDamage->dwDmgTotal -= nReducedDamage;
 


### PR DESCRIPTION
## Summary
- Fixes `D2GAME_EventFunc26_6FD0F5E0` removing HP from `pAttacker` instead of `pOwner`

Fixes #190

> Note: This PR was produced using Claude Code based on the issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.