### PR TITLE
Fix missing break statements in SKILLITEM_EventFunc19_Slow

### DIFF
--- a/source/D2Game/src/SKILLS/SkillItem.cpp
+++ b/source/D2Game/src/SKILLS/SkillItem.cpp
@@ -1569,6 +1569,7 @@ int32_t __fastcall SKILLITEM_EventFunc19_Slow(D2GameStrc* pGame, int32_t nEvent,
         {
             nSlowValue = 50;
         }
+        break;
     }
     case UNIT_MONSTER:
     {
@@ -1593,6 +1594,7 @@ int32_t __fastcall SKILLITEM_EventFunc19_Slow(D2GameStrc* pGame, int32_t nEvent,
                 nSlowValue = 90;
             }
         }
+        break;
     }
     default:
         return 0;


### PR DESCRIPTION
## Summary
- Adds missing `break` statements to UNIT_PLAYER and UNIT_MONSTER cases in the switch statement, preventing unintended fall-through

Fixes #188

> Note: This PR was produced using Claude Code based on the issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.