### PR TITLE
Fix incorrect unit type check in EventFunc04

### DIFF
--- a/source/D2Game/src/SKILLS/SkillNec.cpp
+++ b/source/D2Game/src/SKILLS/SkillNec.cpp
@@ -1898,7 +1898,7 @@ int32_t __fastcall D2GAME_EventFunc04_6FD0E840(D2GameStrc* pGame, int32_t nEvent
 
     D2UnitStrc* pStatListOwner = SUNIT_GetServerUnit(pGame, STATLIST_GetOwnerType(pStatList), STATLIST_GetOwnerGUID(pStatList));
     int32_t nDamagePercent = 0;
-    if (pAttacker->dwUnitType == UNIT_MONSTER || MONSTERS_GetHirelingTypeId(pAttacker))
+    if (pAttacker->dwUnitType == UNIT_PLAYER || MONSTERS_GetHirelingTypeId(pAttacker))
     {
         if (pUnit->dwUnitType == UNIT_MONSTER)
         {


### PR DESCRIPTION
## Summary
- Fixes `D2GAME_EventFunc04_6FD0E840` checking for `UNIT_MONSTER` instead of `UNIT_PLAYER`, verified against v1.10 and v1.13c assembly

Fixes #187

> Note: This PR was produced using Claude Code based on the issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.