### PR TITLE
Fix incorrect range calculation in SUNITDMG_DrainItemDurability

### DIFF
--- a/source/D2Game/src/UNIT/SUnitDmg.cpp
+++ b/source/D2Game/src/UNIT/SUnitDmg.cpp
@@ -2303,7 +2303,7 @@ void __fastcall SUNITDMG_DrainItemDurability(D2GameStrc* pGame, D2UnitStrc* pAtt
 	D2DamageStrc damageCopy = {};
 	memcpy(&damageCopy, pDamage, sizeof(damageCopy));
 
-	if (!UNITS_IsInMeleeRange(pAttacker, pDefender, 2 * (pAttacker->dwUnitType == UNIT_PLAYER) + 1))
+	if (!UNITS_IsInMeleeRange(pAttacker, pDefender, 2 * (pAttacker->dwUnitType == UNIT_MONSTER) + 1))
 	{
 		SUNITDMG_FreeAttackerDefenderCombatList(pGame, pAttacker, pDefender);
 		return;


### PR DESCRIPTION
## Summary
- Fixes melee range calculation comparing against `UNIT_PLAYER` instead of `UNIT_MONSTER`, verified by Necrolis against original assembly (`CMP EDX,1`)

Fixes #165

> Note: This PR was produced using Claude Code based on the issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.