### PR TITLE
Fix multiple issues in sub_6FC6A8C0

### DIFF
--- a/source/D2Game/include/MONSTER/MonsterSpawn.h
+++ b/source/D2Game/include/MONSTER/MonsterSpawn.h
@@ -74,6 +74,6 @@ int32_t __fastcall sub_6FC6A350(D2GameStrc* pGame, D2ActiveRoomStrc* pRoom, int3
 //D2Game.0x6FC6A810
 int32_t __fastcall sub_6FC6A810(D2GameStrc* pGame, D2ActiveRoomStrc* pRoom, int32_t a3, int32_t a4, D2UnitStrc* pTargetUnit, int32_t a6, int16_t a7);
 //D2Game.0x6FC6A8C0
-int32_t __fastcall sub_6FC6A8C0(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nMonsterId, int32_t nAnimMode, int32_t nCount, int32_t a6, int16_t nFlags);
+int32_t __fastcall sub_6FC6A8C0(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nMonsterId, int32_t nAnimMode, int32_t nCount, int32_t bNonWaterSpawn, int16_t nFlags);
 //D2Game.0x6FC6AA70
 int32_t __fastcall MONSTERSPAWN_SpawnRandomMonsterForLevel(D2GameStrc* pGame, D2ActiveRoomStrc* pRoom, int32_t nX, int32_t nY);

--- a/source/D2Game/src/MONSTER/MonsterSpawn.cpp
+++ b/source/D2Game/src/MONSTER/MonsterSpawn.cpp
@@ -1538,7 +1538,7 @@ int32_t __fastcall sub_6FC6A810(D2GameStrc* pGame, D2ActiveRoomStrc* pRoom, int3
 //D2Game.0x6FC6A8C0
 int32_t __fastcall sub_6FC6A8C0(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nMonsterId, int32_t nAnimMode, int32_t nCount, int32_t a6, int16_t nFlags)
 {
-    D2CoordStrc stru_6FD28B68[12] =
+    static const D2CoordStrc stru_6FD28B68[12] =
     {
         {-1,-4 },
         { 1, 4 },
@@ -1560,7 +1560,7 @@ int32_t __fastcall sub_6FC6A8C0(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nM
     }
 
     int32_t v9 = a6;
-    if (a6 < 0 || a6 > 2)
+    if (a6 < 0 || a6 > 1)
     {
         v9 = 0;
     }
@@ -1573,21 +1573,22 @@ int32_t __fastcall sub_6FC6A8C0(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nM
     int32_t nParam1 = ITEMS_RollRandomNumber(&pUnit->pSeed) % 6;
     const int32_t nParam2 = 6 * v9;
 
+    D2UnkMonCreateStrc monCreate = {};
+    monCreate.nUnitGUID = 0;
+    monCreate.pRoomCoordList = nullptr;
+    monCreate.field_20 = -1;
+    monCreate.nFlags = nFlags;
+    monCreate.nMonsterId = nMonsterId;
+    monCreate.nAnimMode = nAnimMode;
+    monCreate.pRoom = pRoom;
+    monCreate.pGame = pGame;
+
     for (int32_t i = 0; i < nCount; ++i)
     {
-        const int32_t nIndex = 2 * (nParam1 + nParam2);
+        const int32_t nIndex = nParam1 + nParam2;
 
-        D2UnkMonCreateStrc monCreate = {};
-        monCreate.nUnitGUID = 0;
-        monCreate.pRoomCoordList = nullptr;
-        monCreate.field_20 = -1;
         monCreate.nX = nX + stru_6FD28B68[nIndex].nX;
         monCreate.nY = nY + stru_6FD28B68[nIndex].nY;
-        monCreate.nFlags = nFlags;
-        monCreate.nMonsterId = nMonsterId;
-        monCreate.nAnimMode = nAnimMode;
-        monCreate.pRoom = pRoom;
-        monCreate.pGame = pGame;
 
         nParam1 = (nParam1 + 5) % 6;
 

--- a/source/D2Game/src/MONSTER/MonsterSpawn.cpp
+++ b/source/D2Game/src/MONSTER/MonsterSpawn.cpp
@@ -1536,7 +1536,7 @@ int32_t __fastcall sub_6FC6A810(D2GameStrc* pGame, D2ActiveRoomStrc* pRoom, int3
 }
 
 //D2Game.0x6FC6A8C0
-int32_t __fastcall sub_6FC6A8C0(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nMonsterId, int32_t nAnimMode, int32_t nCount, int32_t a6, int16_t nFlags)
+int32_t __fastcall sub_6FC6A8C0(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nMonsterId, int32_t nAnimMode, int32_t nCount, int32_t bNonWaterSpawn, int16_t nFlags)
 {
     static const D2CoordStrc stru_6FD28B68[12] =
     {
@@ -1559,8 +1559,13 @@ int32_t __fastcall sub_6FC6A8C0(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nM
         return 0;
     }
 
-    int32_t v9 = a6;
-    if (a6 < 0 || a6 > 1)
+    int32_t v9 = bNonWaterSpawn;
+#ifdef NO_BUG_FIX
+    // Original game accepts a value of 2 here, which then indexes past the end of stru_6FD28B68 (only 2 sets of 6 coordinates).
+    if (bNonWaterSpawn < 0 || bNonWaterSpawn > 2)
+#else
+    if (bNonWaterSpawn < 0 || bNonWaterSpawn > 1)
+#endif
     {
         v9 = 0;
     }


### PR DESCRIPTION
## Summary
1. Make coordinate array `static const` for immutability and performance
2. Fix incorrect index calculation `2 * (nParam1 + nParam2)` → `nParam1 + nParam2`, preventing OOB reads
3. Hoist `monCreate` initialization outside the loop (only X/Y change per iteration)
4. Fix bounds check `a6 > 2` → `a6 > 1` to prevent OOB reads when `a6 == 2` (vanilla bug)

Fixes #194

> Note: This PR was produced using Claude Code based on the upstream issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.