### PR TITLE
Fix and rename sub_6FCD09D0 to AITACTICS_WanderToTarget

### DIFF
--- a/source/D2Game/include/AI/AiTactics.h
+++ b/source/D2Game/include/AI/AiTactics.h
@@ -71,7 +71,7 @@ int32_t __fastcall sub_6FCD06D0(D2GameStrc* pGame, D2UnitStrc* pUnit, D2UnitStrc
 //D2Game.0x6FCD0840
 int32_t __fastcall AITACTICS_WalkCloseToUnit(D2GameStrc* pGame, D2UnitStrc* pUnit, int32_t nMaxDistance);
 //D2Game.0x6FCD09D0
-int32_t __fastcall sub_6FCD09D0(D2GameStrc* pGame, D2UnitStrc* pUnit, D2UnitStrc* pTarget, int32_t nMaxDistance);
+int32_t __fastcall AITACTICS_WanderToTarget(D2GameStrc* pGame, D2UnitStrc* pUnit, D2UnitStrc* pTarget, int32_t nMaxDistance);
 //D2Game.0x6FCD0B60
 int32_t __fastcall D2GAME_AICORE_WalkToOwner_6FCD0B60(D2GameStrc* pGame, D2UnitStrc* pUnit, D2UnitStrc* pOwner, int32_t nMaxDistance);
 //D2Game.0x6FCD0D00

--- a/source/D2Game/src/AI/AiTactics.cpp
+++ b/source/D2Game/src/AI/AiTactics.cpp
@@ -533,9 +533,36 @@ int32_t __fastcall AITACTICS_WalkCloseToUnit(D2GameStrc* pGame, D2UnitStrc* pUni
 }
 
 //D2Game.0x6FCD09D0
-int32_t __fastcall sub_6FCD09D0(D2GameStrc* pGame, D2UnitStrc* pUnit, D2UnitStrc* pTarget, int32_t nMaxDistance)
+int32_t __fastcall AITACTICS_WanderToTarget(D2GameStrc* pGame, D2UnitStrc* pUnit, D2UnitStrc* pTarget, int32_t nMaxDistance)
 {
-	return AITACTICS_WalkCloseToUnit(pGame, pUnit, nMaxDistance);
+	int32_t nOffsetX = 0;
+	int32_t nOffsetY = 0;
+
+	const int32_t nTargetX = CLIENTS_GetUnitX(pTarget);
+	const int32_t nTargetY = CLIENTS_GetUnitY(pTarget);
+
+	if (ITEMS_RollRandomNumber(&pUnit->pSeed) & 1)
+	{
+		nOffsetX = nMaxDistance;
+		nOffsetY = ITEMS_RollLimitedRandomNumber(&pUnit->pSeed, nMaxDistance);
+	}
+	else
+	{
+		nOffsetX = ITEMS_RollLimitedRandomNumber(&pUnit->pSeed, nMaxDistance);
+		nOffsetY = nMaxDistance;
+	}
+
+	if (ITEMS_RollRandomNumber(&pUnit->pSeed) & 1)
+	{
+		nOffsetX = -nOffsetX;
+	}
+
+	if (ITEMS_RollRandomNumber(&pUnit->pSeed) & 1)
+	{
+		nOffsetY = -nOffsetY;
+	}
+
+	return AITACTICS_MoveToTarget(pGame, pUnit, nullptr, MONMODE_WALK, nTargetX + nOffsetX, nTargetY + nOffsetY, 1u, 0);
 }
 
 //D2Game.0x6FCD0B60
@@ -546,7 +573,7 @@ int32_t __fastcall D2GAME_AICORE_WalkToOwner_6FCD0B60(D2GameStrc* pGame, D2UnitS
 		return AITACTICS_WalkCloseToUnit(pGame, pUnit, 2);
 	}
 
-	return sub_6FCD09D0(pGame, pUnit, pOwner, nMaxDistance);
+	return AITACTICS_WanderToTarget(pGame, pUnit, pOwner, nMaxDistance);
 }
 
 //D2Game.0x6FCD0D00

--- a/source/D2Game/src/AI/AiThink.cpp
+++ b/source/D2Game/src/AI/AiThink.cpp
@@ -8827,7 +8827,7 @@ void __fastcall AITHINK_Fn067_NecroPet(D2GameStrc* pGame, D2UnitStrc* pUnit, D2A
 
 	if (!pTarget || DUNGEON_IsRoomInTown(UNITS_GetRoom(pUnit)))
 	{
-		sub_6FCD09D0(pGame, pUnit, pOwner, 4u);
+		AITACTICS_WanderToTarget(pGame, pUnit, pOwner, 4u);
 		return;
 	}
 
@@ -8918,7 +8918,7 @@ int32_t __fastcall D2GAME_AI_PetMove_6FCE2BA0(D2GameStrc* pGame, D2UnitStrc* pOw
 
 		D2GAME_EVENTS_Delete_6FC34840(pGame, pUnit, EVENTTYPE_AITHINK, 0);
 
-		if (sub_6FCD09D0(pGame, pUnit, pOwner, 4u) || bRun && AITACTICS_RunToTargetCoordinatesDeleteAiEvent(pGame, pUnit, (nUnitX + nOwnerX) / 2, (nUnitY + nOwnerY) / 2) || AITACTICS_WalkToTargetCoordinatesDeleteAiEvent(pGame, pUnit, (nOwnerX + nUnitX) / 2, (nUnitY + nOwnerY) / 2))
+		if (AITACTICS_WanderToTarget(pGame, pUnit, pOwner, 4u) || bRun && AITACTICS_RunToTargetCoordinatesDeleteAiEvent(pGame, pUnit, (nUnitX + nOwnerX) / 2, (nUnitY + nOwnerY) / 2) || AITACTICS_WalkToTargetCoordinatesDeleteAiEvent(pGame, pUnit, (nOwnerX + nUnitX) / 2, (nUnitY + nOwnerY) / 2))
 		{
 			return 1;
 		}
@@ -9034,7 +9034,7 @@ int32_t __fastcall D2GAME_AI_PetMove_6FCE2BA0(D2GameStrc* pGame, D2UnitStrc* pOw
 
 		AITACTICS_SetVelocity(pUnit, 0, 15, 0);
 
-		if (sub_6FCD09D0(pGame, pUnit, pOwner, nDistance))
+		if (AITACTICS_WanderToTarget(pGame, pUnit, pOwner, nDistance))
 		{
 			return 1;
 		}
@@ -9049,7 +9049,7 @@ int32_t __fastcall D2GAME_AI_PetMove_6FCE2BA0(D2GameStrc* pGame, D2UnitStrc* pOw
 			return 1;
 		}
 
-		if (sub_6FCD09D0(pGame, pUnit, pOwner, ITEMS_RollRandomNumber(&pUnit->pSeed) % 3 + 3))
+		if (AITACTICS_WanderToTarget(pGame, pUnit, pOwner, ITEMS_RollRandomNumber(&pUnit->pSeed) % 3 + 3))
 		{
 			return 1;
 		}
@@ -9106,7 +9106,7 @@ int32_t __fastcall D2GAME_AI_PetMove_6FCE2BA0(D2GameStrc* pGame, D2UnitStrc* pOw
 		{
 			D2GAME_EVENTS_Delete_6FC34840(pGame, pUnit, EVENTTYPE_AITHINK, 0);
 
-			if (!sub_6FCD09D0(pGame, pUnit, pOwner, a7))
+			if (!AITACTICS_WanderToTarget(pGame, pUnit, pOwner, a7))
 			{
 				AITACTICS_IdleInNeutralMode(pGame, pUnit, 15);
 			}
@@ -9336,7 +9336,7 @@ void __fastcall sub_6FCE3740(D2GameStrc* pGame, D2UnitStrc* pUnit, D2AiTickParam
 
 	if (!pTarget || DUNGEON_IsRoomInTown(UNITS_GetRoom(pUnit)))
 	{
-		sub_6FCD09D0(pGame, pUnit, pOwner, 4u);
+		AITACTICS_WanderToTarget(pGame, pUnit, pOwner, 4u);
 		return;
 	}
 
@@ -9557,7 +9557,7 @@ int32_t __fastcall D2GAME_PETAI_PetMove_6FCE3EE0(D2GameStrc* pGame, D2UnitStrc* 
 		}
 
 		D2GAME_EVENTS_Delete_6FC34840(pGame, pUnit, EVENTTYPE_AITHINK, 0);
-		sub_6FCD09D0(pGame, pUnit, pOwner, 4u);
+		AITACTICS_WanderToTarget(pGame, pUnit, pOwner, 4u);
 		return 1;
 	}
 	case 1:
@@ -9657,7 +9657,7 @@ int32_t __fastcall D2GAME_PETAI_PetMove_6FCE3EE0(D2GameStrc* pGame, D2UnitStrc* 
 		}
 
 		AITACTICS_SetVelocity(pUnit, 0, 15, 0);
-		sub_6FCD09D0(pGame, pUnit, pOwner, nDistance);
+		AITACTICS_WanderToTarget(pGame, pUnit, pOwner, nDistance);
 		return 1;
 	}
 	case 2:
@@ -9668,7 +9668,7 @@ int32_t __fastcall D2GAME_PETAI_PetMove_6FCE3EE0(D2GameStrc* pGame, D2UnitStrc* 
 		}
 		else
 		{
-			if (!sub_6FCD09D0(pGame, pUnit, pOwner, ITEMS_RollRandomNumber(&pUnit->pSeed) % 3 + 3))
+			if (!AITACTICS_WanderToTarget(pGame, pUnit, pOwner, ITEMS_RollRandomNumber(&pUnit->pSeed) % 3 + 3))
 			{
 				D2GAME_EVENTS_Delete_6FC34840(pGame, pUnit, EVENTTYPE_AITHINK, 0);
 				AITACTICS_SetVelocity(pUnit, 0, 0, 40);
@@ -9718,7 +9718,7 @@ int32_t __fastcall D2GAME_PETAI_PetMove_6FCE3EE0(D2GameStrc* pGame, D2UnitStrc* 
 			if (!D2GAME_AICORE_Escape_6FCD0560(pGame, pUnit, pOwner, bSteps, 1))
 			{
 				D2GAME_EVENTS_Delete_6FC34840(pGame, pUnit, EVENTTYPE_AITHINK, 0);
-				sub_6FCD09D0(pGame, pUnit, pOwner, bSteps);
+				AITACTICS_WanderToTarget(pGame, pUnit, pOwner, bSteps);
 			}
 		}
 		return 1;


### PR DESCRIPTION
## Summary
- Fixes `sub_6FCD09D0` which incorrectly delegated to `AITACTICS_WalkCloseToUnit`, using the monster's own position instead of the target's
- The function now calculates random offsets around `pTarget`'s coordinates (via `CLIENTS_GetUnitX/Y`) and calls `AITACTICS_MoveToTarget`, matching the original assembly behavior
- Renames `sub_6FCD09D0` → `AITACTICS_WanderToTarget` across the codebase (3 files, 13 occurrences)

Fixes #193

> Note: This PR was produced using Claude Code based on the upstream issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.