### PR TITLE
Templatize D2GSPacketSrvStatAndGuid for correct packet sizes

### DIFF
--- a/source/D2CommonDefinitions/include/D2PacketDef.h
+++ b/source/D2CommonDefinitions/include/D2PacketDef.h
@@ -1948,19 +1948,20 @@ struct D2GSPacketSrv9D		//variable size
 //};
 
 
-struct D2GSPacketSrvStatAndGuid	//size of 0x08 (originally 0x07)
+template<typename T>
+struct D2GSPacketSrvStatAndGuid
 {
 	uint8_t nHeader;			//0x00
 	PacketStatId nStat;			//0x01
 	uint32_t dwGUID;			//0x03 (Originally 0x02)
-	uint8_t nValue;				//0x07 (Originally 0x06)
+	T nValue;				//0x07 (Originally 0x06)
 };
 
-using D2GSPacketSrv9E = D2GSPacketSrvStatAndGuid;
-using D2GSPacketSrv9F = D2GSPacketSrvStatAndGuid;
-using D2GSPacketSrvA0 = D2GSPacketSrvStatAndGuid;
-using D2GSPacketSrvA1 = D2GSPacketSrvStatAndGuid;
-using D2GSPacketSrvA2 = D2GSPacketSrvStatAndGuid;
+using D2GSPacketSrv9E = D2GSPacketSrvStatAndGuid<uint8_t>;
+using D2GSPacketSrv9F = D2GSPacketSrvStatAndGuid<uint16_t>;
+using D2GSPacketSrvA0 = D2GSPacketSrvStatAndGuid<uint32_t>;
+using D2GSPacketSrvA1 = D2GSPacketSrvStatAndGuid<uint8_t>;
+using D2GSPacketSrvA2 = D2GSPacketSrvStatAndGuid<uint16_t>;
 
 struct D2GSPacketSrvA3		//size of 0x18
 {

--- a/source/D2Net/src/Server.cpp
+++ b/source/D2Net/src/Server.cpp
@@ -195,16 +195,11 @@ int32_t __fastcall SERVER_GetServerPacketSize(D2PacketBufferStrc* pBuffer, uint3
 		sizeof(D2GSPacketSrv9B),
 		VARIABLE_PACKET_SIZE,
 		VARIABLE_PACKET_SIZE,
-		//sizeof(D2GSPacketSrv9E),
-		7, // 0x9E
-		//sizeof(D2GSPacketSrv9F),
-		8, // 0x9F
-		//sizeof(D2GSPacketSrvA0),
-		10, // 0xA0
-		//sizeof(D2GSPacketSrvA1),
-		7, // 0xA1
-		//sizeof(D2GSPacketSrvA2),
-		8, // 0xA2
+		sizeof(D2GSPacketSrv9E), // 0x9E
+		sizeof(D2GSPacketSrv9F), // 0x9F
+		sizeof(D2GSPacketSrvA0), // 0xA0
+		sizeof(D2GSPacketSrvA1), // 0xA1
+		sizeof(D2GSPacketSrvA2), // 0xA2
 		sizeof(D2GSPacketSrvA3),
 		sizeof(D2GSPacketSrvA4),
 		sizeof(D2GSPacketSrvA5),


### PR DESCRIPTION
## Summary
- Templatizes `D2GSPacketSrvStatAndGuid` so each packet variant has the correct value field width:
  - 9E, A1: `uint8_t` (7 bytes)
  - 9F, A2: `uint16_t` (8 bytes)
  - A0: `uint32_t` (10 bytes)
- Previously all 5 aliases pointed to the same struct with `uint8_t nValue`, causing value truncation for 16-bit and 32-bit packets
- Enables `sizeof()` for packet sizes in Server.cpp (previously hard-coded with sizeof commented out)

Fixes #172

> Note: This PR was produced using Claude Code based on the upstream issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.