### PR TITLE
Clean up D2EventTimerQueueStrc and Event.cpp readability

### DIFF
--- a/source/D2Game/include/GAME/Event.h
+++ b/source/D2Game/include/GAME/Event.h
@@ -78,9 +78,10 @@ struct D2EventTimerSlabListStrc
 struct D2EventTimerQueueStrc
 {
 	int32_t nArrayIndex;
-	D2EventTimerStrc* unk0x04[10][64];
-	D2EventTimerStrc* unk0xA04[5];
-	D2EventTimerStrc* unk0xA18;
+	D2EventTimerStrc* pHead[5][64];			// first event per unit type per frame
+	D2EventTimerStrc* pTail[5][64];			// last event per unit type per frame
+	D2EventTimerStrc* pInfinite[5];			// events with no end frame
+	D2EventTimerStrc* pCurrent;
 	D2EventTimerSlabListStrc* pSlabListHead;
 };
 

--- a/source/D2Game/src/GAME/Event.cpp
+++ b/source/D2Game/src/GAME/Event.cpp
@@ -47,9 +47,9 @@ void __fastcall sub_6FC34890(D2GameStrc* pGame, D2EventTimerStrc* pTimer)
         return;
     }
 
-    if (pTimer == pGame->pTimerQueue->unk0xA18)
+    if (pTimer == pGame->pTimerQueue->pCurrent)
     {
-        pGame->pTimerQueue->unk0xA18 = pTimer->pNextFreeEventTimer;
+        pGame->pTimerQueue->pCurrent = pTimer->pNextFreeEventTimer;
     }
 
     if (pTimer->unk0x20)
@@ -68,7 +68,7 @@ void __fastcall sub_6FC34890(D2GameStrc* pGame, D2EventTimerStrc* pTimer)
     }
     else if (pTimer->nExpireFrame != -1)
     {
-        D2EventTimerStrc** ppEventTimer = &pGame->pTimerQueue->unk0x04[5][pTimer->nExpireFrame % 64 + (EVENT_MapUnitTypeToIndex(pTimer->nUnitType) << 6)];
+        D2EventTimerStrc** ppEventTimer = &pGame->pTimerQueue->pTail[EVENT_MapUnitTypeToIndex(pTimer->nUnitType)][pTimer->nExpireFrame % 64];
         if (ppEventTimer && *ppEventTimer == pTimer)
         {
             *ppEventTimer = pTimer->unk0x20;
@@ -183,24 +183,24 @@ void __fastcall EVENT_IterateEvents(D2GameStrc* pGame)
     pTimerQueue->nArrayIndex = pGame->dwGameFrame % 64;
 
     const int nMissileEventIdx = EVENT_MapUnitTypeToIndex(UNIT_MISSILE);
-    EVENT_ExecuteMissileEvents(pGame, pTimerQueue, pTimerQueue->unk0xA04[nMissileEventIdx], 0);
-    EVENT_ExecuteMissileEvents(pGame, pTimerQueue, pTimerQueue->unk0x04 [nMissileEventIdx][pTimerQueue->nArrayIndex], 1);
+    EVENT_ExecuteMissileEvents(pGame, pTimerQueue, pTimerQueue->pInfinite[nMissileEventIdx], 0);
+    EVENT_ExecuteMissileEvents(pGame, pTimerQueue, pTimerQueue->pHead[nMissileEventIdx][pTimerQueue->nArrayIndex], 1);
 
     const int nPlayerEventIdx = EVENT_MapUnitTypeToIndex(UNIT_PLAYER);
-    EVENT_ExecutePlayerEvents(pGame, pTimerQueue, pTimerQueue->unk0xA04[nPlayerEventIdx], 0);
-    EVENT_ExecutePlayerEvents(pGame, pTimerQueue, pTimerQueue->unk0x04 [nPlayerEventIdx][pTimerQueue->nArrayIndex], 1);
+    EVENT_ExecutePlayerEvents(pGame, pTimerQueue, pTimerQueue->pInfinite[nPlayerEventIdx], 0);
+    EVENT_ExecutePlayerEvents(pGame, pTimerQueue, pTimerQueue->pHead[nPlayerEventIdx][pTimerQueue->nArrayIndex], 1);
 
     const int nMonsterEventIdx = EVENT_MapUnitTypeToIndex(UNIT_MONSTER);
-    EVENT_ExecuteMonsterEvents(pGame, pTimerQueue, pTimerQueue->unk0xA04[nMonsterEventIdx], 0);
-    EVENT_ExecuteMonsterEvents(pGame, pTimerQueue, pTimerQueue->unk0x04 [nMonsterEventIdx][pTimerQueue->nArrayIndex], 1);
+    EVENT_ExecuteMonsterEvents(pGame, pTimerQueue, pTimerQueue->pInfinite[nMonsterEventIdx], 0);
+    EVENT_ExecuteMonsterEvents(pGame, pTimerQueue, pTimerQueue->pHead[nMonsterEventIdx][pTimerQueue->nArrayIndex], 1);
 
     const int nObjectEventIdx = EVENT_MapUnitTypeToIndex(UNIT_OBJECT);
-    EVENT_ExecuteObjectEvents(pGame, pTimerQueue, pTimerQueue->unk0xA04[nObjectEventIdx], 0);
-    EVENT_ExecuteObjectEvents(pGame, pTimerQueue, pTimerQueue->unk0x04 [nObjectEventIdx][pTimerQueue->nArrayIndex], 1);
+    EVENT_ExecuteObjectEvents(pGame, pTimerQueue, pTimerQueue->pInfinite[nObjectEventIdx], 0);
+    EVENT_ExecuteObjectEvents(pGame, pTimerQueue, pTimerQueue->pHead[nObjectEventIdx][pTimerQueue->nArrayIndex], 1);
 
     const int nItemEventIdx = EVENT_MapUnitTypeToIndex(UNIT_ITEM);
-    EVENT_ExecuteItemEvents(pGame, pTimerQueue, pTimerQueue->unk0xA04[nItemEventIdx], 0);
-    EVENT_ExecuteItemEvents(pGame, pTimerQueue, pTimerQueue->unk0x04 [nItemEventIdx][pTimerQueue->nArrayIndex], 1);
+    EVENT_ExecuteItemEvents(pGame, pTimerQueue, pTimerQueue->pInfinite[nItemEventIdx], 0);
+    EVENT_ExecuteItemEvents(pGame, pTimerQueue, pTimerQueue->pHead[nItemEventIdx][pTimerQueue->nArrayIndex], 1);
 }
 
 // Only differs from EventTimerCallback by return type
@@ -208,14 +208,14 @@ using ExecuteEventCallback = void(__fastcall*)(D2GameStrc*, D2UnitStrc*, D2C_Eve
 // Helper function
 static void __fastcall EVENT_ExecuteEventsImpl(ExecuteEventCallback pDefaultCallback, D2GameStrc* pGame, D2EventTimerQueueStrc* pTimerQueue, D2EventTimerStrc* pEventTimer, int32_t a4)
 {
-    pTimerQueue->unk0xA18 = nullptr;
+    pTimerQueue->pCurrent = nullptr;
 
     D2EventTimerStrc* pTimer = pEventTimer;
     if (a4)
     {
         while (pTimer)
         {
-            pTimerQueue->unk0xA18 = pTimer->pNextFreeEventTimer;
+            pTimerQueue->pCurrent = pTimer->pNextFreeEventTimer;
             if (pTimer->nExpireFrame == pGame->dwGameFrame)
             {
                 pTimer->nFlags |= EVENTFLAG_0x1;
@@ -232,14 +232,14 @@ static void __fastcall EVENT_ExecuteEventsImpl(ExecuteEventCallback pDefaultCall
                 sub_6FC34890(pGame, pTimer);
             }
 
-            pTimer = pTimerQueue->unk0xA18;
+            pTimer = pTimerQueue->pCurrent;
         }
     }
     else
     {
         while (pTimer)
         {
-            pTimerQueue->unk0xA18 = pTimer->pNextFreeEventTimer;
+            pTimerQueue->pCurrent = pTimer->pNextFreeEventTimer;
 
             pTimer->nFlags |= EVENTFLAG_0x1;
             if (pTimer->pCallback)
@@ -257,7 +257,7 @@ static void __fastcall EVENT_ExecuteEventsImpl(ExecuteEventCallback pDefaultCall
                 sub_6FC34890(pGame, pTimer);
             }
 
-            pTimer = pTimerQueue->unk0xA18;
+            pTimer = pTimerQueue->pCurrent;
         }
     }
 }
@@ -383,15 +383,15 @@ void __fastcall D2GAME_InitTimer_6FC351D0(D2GameStrc* pGame, D2UnitStrc* pUnit, 
     pEventTimer->nExpireFrame = nExpireFrame;
     pEventTimer->pCallback = pfCallBack;
 
-    D2EventTimerStrc** v19 = &pGame->pTimerQueue->unk0x04[5][nExpireFrame % 64 + (EVENT_MapUnitTypeToIndex(pEventTimer->nUnitType) << 6)];
+    D2EventTimerStrc** ppQueue = &pGame->pTimerQueue->pTail[EVENT_MapUnitTypeToIndex(pEventTimer->nUnitType)][nExpireFrame % 64];
 
     pEventTimer->pNextFreeEventTimer = nullptr;
-    pEventTimer->unk0x20 = *v19;
-    if (*v19)
+    pEventTimer->unk0x20 = *ppQueue;
+    if (*ppQueue)
     {
-        (*v19)->pNextFreeEventTimer = pEventTimer;
+        (*ppQueue)->pNextFreeEventTimer = pEventTimer;
     }
-    *v19 = pEventTimer;
+    *ppQueue = pEventTimer;
 
     ppEventTimer = sub_6FC353D0(pGame, pEventTimer->nUnitType, pEventTimer->nExpireFrame);
     if (!*ppEventTimer)
@@ -406,10 +406,10 @@ D2EventTimerStrc** __fastcall sub_6FC353D0(D2GameStrc* pGame, int32_t nUnitType,
     const int32_t nIndex = EVENT_MapUnitTypeToIndex(nUnitType);
     if (nExpireFrame == -1)
     {
-        return &pGame->pTimerQueue->unk0xA04[nIndex];
+        return &pGame->pTimerQueue->pInfinite[nIndex];
     }
 
-    return (D2EventTimerStrc**)((char*)pGame->pTimerQueue->unk0x04 + 4 * (nExpireFrame % 64 + (nIndex << 6)));
+    return &pGame->pTimerQueue->pHead[nIndex][nExpireFrame % 64];
 }
 
 //1.10f: D2Game.0x6FC35410


### PR DESCRIPTION
## Summary
- Restructures `D2EventTimerQueueStrc` to use named members instead of opaque `unk0x` fields:
  - `unk0x04[10][64]` → `pHead[5][64]` + `pTail[5][64]`
  - `unk0xA04[5]` → `pInfinite[5]`
  - `unk0xA18` → `pCurrent`
- Simplifies complex pointer arithmetic (bitshifts, manual offset calculations) into clean 2D array indexing
- Renames decompiler variable `v19` → `ppQueue`

Fixes #191

> Note: This PR was produced using Claude Code based on the upstream issue description. The change has not been compiled or tested, as the project requires a Windows build environment which was not available. Please review carefully before merging.