### PR TITLE
Fix incorrect logic in ACT1Q2_Callback03_ChangedLevel

### DIFF
--- a/source/D2Game/src/QUESTS/ACT1/A1Q2.cpp
+++ b/source/D2Game/src/QUESTS/ACT1/A1Q2.cpp
@@ -462,7 +462,11 @@ void __fastcall ACT1Q2_Callback03_ChangedLevel(D2QuestDataStrc* pQuestData, D2Qu
 {
 	if (pQuestArg->nNewLevel == LEVEL_BURIALGROUNDS && pQuestData->bNotIntro == 1)
 	{
-		if (pQuestData->fState < 3)
+		// In vanilla the result of the first fState check is kept in a stack
+		// boolean, because QUESTS_StateDebug overwrites fState with 3 and the
+		// second check would otherwise never trigger (D2Game.0x64EE9 in 1.13c)
+		const bool bStateUpdated = pQuestData->fState < 3;
+		if (bStateUpdated)
 		{
 			QUESTS_StateDebug(pQuestData, 3, __FILE__, __LINE__);
 			pQuestData->dwFlags &= 0xFFFFFF00;
@@ -475,7 +479,7 @@ void __fastcall ACT1Q2_Callback03_ChangedLevel(D2QuestDataStrc* pQuestData, D2Qu
 			return;
 		}
 
-		if (pQuestData->fState < 3)
+		if (bStateUpdated)
 		{
 			SUNIT_IterateUnitsOfType(pQuestData->pGame, 0, 0, ACT1Q2_UnitIterate_UpdateQuestStateFlags);
 			return;


### PR DESCRIPTION
## Summary

Fixes #227.

In `ACT1Q2_Callback03_ChangedLevel`, the second `pQuestData->fState < 3` check could never trigger: the first check calls `QUESTS_StateDebug(pQuestData, 3, ...)`, which assigns `fState = 3`, so by the time the second check runs the condition is always false.

As noted in the issue, vanilla handles this with a boolean stored on the stack that is set by the *first* check on `pQuestData->fState` (verified against the 1.13c assembly at `D2Game.0x64EE9`). This PR restores that behavior by capturing the comparison in a local `const bool bStateUpdated` before `QUESTS_StateDebug` mutates `fState`, and using it for both branches.

## Changes

- `source/D2Game/src/QUESTS/ACT1/A1Q2.cpp`: hoist the `fState < 3` comparison into a stack boolean and reuse it in the second branch, matching vanilla behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)