### PR TITLE
Fix the ACT1Q3 status cycler callback

### DIFF
--- a/source/D2Game/src/QUESTS/ACT1/A1Q3.cpp
+++ b/source/D2Game/src/QUESTS/ACT1/A1Q3.cpp
@@ -553,7 +553,7 @@ void __fastcall ACT1Q3_Callback03_ChangedLevel(D2QuestDataStrc* pQuestData, D2Qu
 	if (pQuestData->fLastState != 1)
 	{
 		pQuestData->dwFlags &= 0xFFFFFF00;
-		QUESTS_UnitIterate(pQuestData, 1, 0, ACT1Q2_UnitIterate_StatusCyclerEx, 1);
+		QUESTS_UnitIterate(pQuestData, 1, 0, ACT1Q3_UnitIterate_StatusCyclerEx, 1);
 	}
 
 	QUESTS_StateDebug(pQuestData, 3, __FILE__, __LINE__);


### PR DESCRIPTION
## Summary

- I corrected `ACT1Q3_Callback03_ChangedLevel` to use `ACT1Q3_UnitIterate_StatusCyclerEx` instead of the Act 1 Quest 2 status cycler.
- This keeps the changed-level status update within the quest-specific callback identified in the issue.

## Validation

- Targeted source regression check: verified the callback invokes the Act 1 Quest 3 status cycler exactly once and no longer references the Act 1 Quest 2 status cycler.
- `git diff --check upstream/master...HEAD`

I could not run the repository's Windows/MSVC CMake build and test matrix in this Linux environment, so I left that full build to upstream CI.

Fixes #230
