### PR TITLE
fix: assign quest log flags instead of OR in ACT1Q1_Callback08_MonsterKilled

### DIFF
--- a/source/D2Game/src/QUESTS/ACT1/A1Q1.cpp
+++ b/source/D2Game/src/QUESTS/ACT1/A1Q1.cpp
@@ -1,4 +1,4 @@
-#include "QUESTS/ACT1/A1Q1.h"
+﻿#include "QUESTS/ACT1/A1Q1.h"
 
 #include <DataTbls/LevelsIds.h>
 #include <DataTbls/MonsterIds.h>
@@ -349,13 +349,13 @@ void __fastcall ACT1Q1_Callback08_MonsterKilled(D2QuestDataStrc* pQuestData, D2Q
 		{
 			if (pQuestData->fLastState == 4 && pQuestDataEx->nMonstersLeft > 5)
 			{
-				pQuestData->dwFlags |= 0x00000020;
+				pQuestData->dwFlags = 0x00000020;
 				QUESTS_UnitIterate(pQuestData, 4, 0, ACT1Q1_UnitIterate_StatusCyclerEx, 1);
 			}
 		}
 		else
 		{
-			pQuestData->dwFlags |= 0x00000020;
+			pQuestData->dwFlags = 0x00000020;
 			QUESTS_UnitIterate(pQuestData, 4, 0, ACT1Q1_UnitIterate_StatusCyclerEx, 1);
 			pQuestData->pfCallback[QUESTEVENT_NPCDEACTIVATE] = nullptr;
 		}


### PR DESCRIPTION
## Summary

fix: assign quest log flags instead of OR in ACT1Q1_Callback08_MonsterKilled

## Changes

- Vanilla 1.13c writes 0x20 into the quest flag byte (MOV), it does not OR.
- Replace dwFlags |= 0x00000020 with dwFlags = 0x00000020 at both sites in ACT1Q1_Callback08_MonsterKilled.
- Matches the disassembly cited in #226 (C647 14 20).

Fixes #226
