### PR TITLE
ci: fix the clang-tidy lookup broken by the VS 2026 runner image

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -39,14 +39,14 @@
       "name": "clang-tidy",
       "inherits": "ninja",
       "cacheVariables": {
-        "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--extra-arg=-D_CRT_USE_BUILTIN_OFFSETOF;--extra-arg=-Wno-microsoft-cast;--extra-arg=-Wno-multichar;--header-filter=.*"
+        "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--extra-arg=--target=i686-pc-windows-msvc;--extra-arg=-D_CRT_USE_BUILTIN_OFFSETOF;--extra-arg=-Wno-microsoft-cast;--extra-arg=-Wno-multichar;--header-filter=.*"
       }
     },
     {
       "name": "clang-tidy-fix",
       "inherits": "clang-tidy",
       "cacheVariables": {
-        "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--extra-arg=-D_CRT_USE_BUILTIN_OFFSETOF;--extra-arg=-Wno-microsoft-cast;--extra-arg=-Wno-multichar;--header-filter=.*;--fix"
+        "CMAKE_CXX_CLANG_TIDY": "clang-tidy;--extra-arg=--target=i686-pc-windows-msvc;--extra-arg=-D_CRT_USE_BUILTIN_OFFSETOF;--extra-arg=-Wno-microsoft-cast;--extra-arg=-Wno-multichar;--header-filter=.*;--fix"
       }
     }
   ],

--- a/cmake/D2MOO.ModHelpers.cmake
+++ b/cmake/D2MOO.ModHelpers.cmake
@@ -22,6 +22,16 @@ function(D2MOO_register_detours_patch_if_exists DLLTargetName)
   
   target_sources(${DLLTargetName} PRIVATE "${PatchCppFile}")
   source_group(patch FILES "${PatchCppFile}")
+  # The patch sources sit outside source/, so source/.clang-tidy does not apply to
+  # them and they end up with an empty check set. clang-tidy 19 turned that from a
+  # warning into a hard error, which fails the clang-tidy build on files that have
+  # never actually been linted. Say so explicitly instead.
+  if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.27.0") # SKIP_LINTING requires 3.27
+    set_source_files_properties("${PatchCppFile}"
+      TARGET_DIRECTORY ${DLLTargetName}
+      PROPERTIES SKIP_LINTING ON
+    )
+  endif()
   if(EXISTS "${PatchRcFile}")
     target_sources(${DLLTargetName} PRIVATE "${PatchRcFile}")
     source_group(patch FILES "${PatchRcFile}")

--- a/source/.clang-tidy
+++ b/source/.clang-tidy
@@ -2,6 +2,6 @@
 Checks:          '-*,readability-inconsistent-declaration-parameter-name,bugprone-*,-bugprone-easily-swappable-parameters,-bugprone-narrowing-conversions,-clang-diagnostic-multichar,-clang-diagnostic-microsoft-cast'
 CheckOptions:
   - { key: bugprone-signed-char-misuse.CharTypdefsToIgnore, value: "int8_t" }
-WarningsAsErrors: '*,-clang-diagnostic-microsoft-cast,-clang-diagnostic-multichar'
+WarningsAsErrors: '*,-clang-diagnostic-microsoft-cast,-clang-diagnostic-multichar,-bugprone-multi-level-implicit-pointer-conversion,-bugprone-return-const-ref-from-parameter,-bugprone-signed-char-misuse,-bugprone-unchecked-string-to-number-conversion,-bugprone-undefined-memory-manipulation,-bugprone-too-small-loop-variable,-bugprone-switch-missing-default-case,-bugprone-invalid-enum-default-initialization,-bugprone-bitwise-pointer-cast'
 HeaderFilterRegex: 'doctest.*'
 FormatStyle:     none

--- a/source/.clang-tidy
+++ b/source/.clang-tidy
@@ -4,5 +4,4 @@ CheckOptions:
   - { key: bugprone-signed-char-misuse.CharTypdefsToIgnore, value: "int8_t" }
 WarningsAsErrors: '*,-clang-diagnostic-microsoft-cast,-clang-diagnostic-multichar'
 HeaderFilterRegex: 'doctest.*'
-AnalyzeTemporaryDtors: false
 FormatStyle:     none


### PR DESCRIPTION
## Summary

CI has been red on `master` since 6 July. #235 fixed the first failure — the `vswhere` lookup, which the VS 2026 runner image broke — but `master` is still red, because the failure only moves one step later each time. This PR is the rest of that chain, rebased onto `master` so #235 is in.

Where `master` stands today ([run 33217317192](https://github.com/ThePhrozenKeep/D2MOO/actions/runs/33217317192)): clang-tidy is found, then

```
source/.clang-tidy:7:1: error: unknown key 'AnalyzeTemporaryDtors'
Error parsing source/.clang-tidy: invalid argument
Error: no checks enabled.
```

Last green run on `master`: [26 April](https://github.com/ThePhrozenKeep/D2MOO/actions/runs/24950360230).

## Changes

Four commits, each independently reviewable, and each one the next failure the CI run actually hit.

1. **`ci: drop AnalyzeTemporaryDtors from .clang-tidy`** — the failure `master` has right now. The option drove the static analyzer's temporary-destructor modelling, was deprecated in clang-tidy 16 and removed in 18, and the parser now rejects the whole config on an unknown key, so every translation unit fails before a check runs. The value was already `false`, which is what the analyzer does now that the option is gone.

2. **`ci: pin clang-tidy's analysis target to x86`** — `--extra-arg=--target=i686-pc-windows-msvc`. The build is x86, but clang-tidy inferred its target from its own host, which was only ever right while the copy on PATH was the x86-hosted one. With the x64-hosted copy the analysis runs 64-bit type widths against a 32-bit build, and `source/D2Hell/src/Archive.cpp:166` fails with `no matching function for call to 'ARCHIVE_GetFileSize'` — `uint32_t*` against `size_t*`, the same type in what is actually compiled and different only under the mismatched target.

3. **`ci: stop linting the D2.Detours patch sources`** — `SKIP_LINTING` in `D2MOO_register_detours_patch_if_exists`. The patch sources live outside `source/`, so no `.clang-tidy` applies to them and they have always been compiled with an empty check set; clang-tidy 19 turned that from a warning into a hard error. The property keeps exactly the previous behaviour and keeps it visible, rather than passing `--allow-no-checks` in the preset, which would also mask a source that is genuinely misconfigured. Guarded on CMake 3.27, the way the `COPY_FILE` call above it is guarded on 3.21.

4. **`ci: keep the checks new to clang-tidy 18 out of WarningsAsErrors`** — the image also moves clang-tidy 17 → 18. `Checks` enables `bugprone-*` as a wildcard and `WarningsAsErrors` is `'*'`, so every check added since this config was last exercised arrives at once as a build error. A survey run with `WarningsAsErrors` cleared builds all 323 objects and reports 708 findings across nine checks ([log](https://github.com/devtejasx/D2MOO/actions/runs/33633565961)); 624 of them are one pattern, the `void*` `pLinkField` in the .txt table descriptors. The nine are excluded from `WarningsAsErrors` and left in `Checks`, so they all keep running and every finding still appears in the build log. Per-check reasoning is in the commit message.

Two findings look like real defects rather than idiom, and are worth their own issues rather than a drive-by fix here:

- `DataTbls.cpp:57` passes `ARRAY_SIZE` (element count, 16) to `memset`, which wants bytes (32 for `Unicode[16]`), so it clears half the array. Separate from the TriviallyCopyable complaint on the same line.
- `Objects.cpp:1962` and `:1983` iterate a `uint16_t` against a `uint32_t` bound.

## Verification

All four jobs green: [run 33642805455](https://github.com/ThePhrozenKeep/D2MOO/actions/runs/33642805455) — `Debug 1.10f`, `RelWithDebInfo 1.00`, `1.10f`, `1.14d`.

This also unblocks every other open PR, which all inherit the same red X for a reason that has nothing to do with their contents.
