### PR TITLE
Fix ACT1Q4_SetMonolithOrder skipping a monolith on a collision

### DIFF
--- a/source/D2Game/src/QUESTS/ACT1/A1Q4.cpp
+++ b/source/D2Game/src/QUESTS/ACT1/A1Q4.cpp
@@ -247,7 +247,10 @@ void __fastcall ACT1Q4_SetMonolithOrder(D2QuestDataStrc* pQuestData)
 	pQuestDataEx->nCurrentMonolithNo = 0;
 
 	D2SeedStrc* pSeed = QUESTS_GetGlobalSeed(pQuestData->pGame);
-	for (int32_t i = 0; i < 5; ++i)
+	// The counter only advances once a stone has actually been placed, so the
+	// loop keeps rolling until all five monoliths have a class. Advancing it on
+	// every roll would leave the slots that lost a collision set to zero.
+	for (int32_t i = 0; i < 5;)
 	{
 		const uint32_t nRand = ITEMS_RollRandomNumber(pSeed) % 5;
 		if (!pQuestDataEx->nStoneOrder[nRand])
@@ -256,6 +259,7 @@ void __fastcall ACT1Q4_SetMonolithOrder(D2QuestDataStrc* pQuestData)
 			sprintf(szMessage, "stone %d is class %d", nRand, nMonolithClassIds[i]);
 			QUESTS_DebugOutput(pQuestData->pGame, szMessage, __FILE__, __LINE__);
 			pQuestDataEx->nStoneOrder[nRand] = nMonolithClassIds[i];
+			++i;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #224.

`ACT1Q4_SetMonolithOrder` advances `i` on every roll. In 1.10 the counter only moves once a stone is placed: the occupied-slot branch at `6FC99F3A` jumps to `6FC99F78`, past the `INC EBP` at `6FC99F73`, and the loop is bottom-tested against 5. So the original keeps rolling until all five monoliths have a class, while this one rolls exactly five times.

Any collision leaves a slot at 0 and drops a class id. With the rolls 2, 2, 0, 4, 1:

```
current  [19, 21, 17,  0, 20]
fixed    [18, 20, 17, 21, 19]
```

The fix moves `++i` into the placement branch. One file, +5/-1.
